### PR TITLE
feat(runs): Add --project-id to all project-scoped commands

### DIFF
--- a/tests/test_runs_get.py
+++ b/tests/test_runs_get.py
@@ -176,6 +176,26 @@ class TestRunsGetLatest:
         assert result.exit_code == 0
         assert "Latest Run" in result.output
 
+    def test_get_latest_with_project_id(self, runner, mock_client):
+        """INVARIANT: --project-id passes project_id directly to SDK."""
+        mock_client.list_runs.return_value = iter([create_run(name="ID Run")])
+
+        result = runner.invoke(
+            cli,
+            [
+                "--json",
+                "runs",
+                "get-latest",
+                "--project-id",
+                "8dc9fb82-ee48-4815-a0b0-c0fbabaa1887",
+            ],
+        )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_client.list_runs.call_args[1]
+        assert call_kwargs["project_id"] == "8dc9fb82-ee48-4815-a0b0-c0fbabaa1887"
+        assert "project_name" not in call_kwargs
+
     def test_get_latest_json_output(self, runner, mock_client):
         """INVARIANT: runs get-latest --json returns a single dict (not a list)."""
         mock_client.list_runs.return_value = iter([create_run(name="Latest Run")])

--- a/tests/test_runs_list.py
+++ b/tests/test_runs_list.py
@@ -185,6 +185,26 @@ class TestRunsListFilters:
             reference_example_id=None,
         )
 
+    def test_project_id_filter(self, runner, mock_client):
+        """INVARIANT: --project-id passes project_id directly to SDK, not project_name."""
+        mock_client.list_runs.return_value = []
+
+        runner.invoke(
+            cli,
+            [
+                "runs",
+                "list",
+                "--project-id",
+                "8dc9fb82-ee48-4815-a0b0-c0fbabaa1887",
+                "--limit",
+                "5",
+            ],
+        )
+
+        call_kwargs = mock_client.list_runs.call_args[1]
+        assert call_kwargs["project_id"] == "8dc9fb82-ee48-4815-a0b0-c0fbabaa1887"
+        assert "project_name" not in call_kwargs
+
     def test_tag_filter(self, runner, mock_client):
         """--tag filter builds correct FQL."""
         mock_client.list_runs.return_value = []


### PR DESCRIPTION
## Summary
- Adds `--project-id` option to all 11 project-scoped run commands, enabling direct UUID-based lookup that bypasses name resolution for faster queries
- Introduces `ProjectQuery` dataclass and `resolve_project_filters()` helper in utils.py to encapsulate the name-vs-ID resolution logic
- Updates `fetch_from_projects()` to accept `project_query` parameter for direct ID-based fetching
- Removes unused `get_matching_projects` import from runs.py

## Commands updated
`list`, `get-latest`, `stats`, `watch`, `search`, `sample`, `analyze`, `tags`, `metadata-keys`, `fields`, `describe`

## Test plan
- [x] TDD tests for `--project-id` on `runs list` (verifies `project_id` kwarg passed to SDK, `project_name` absent)
- [x] TDD tests for `--project-id` on `runs get-latest` (verifies direct SDK call with `project_id`)
- [x] 584 tests pass
- [x] pyright: 0 errors
- [x] ruff: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)