### PR TITLE
feat: Add `self update` command

### DIFF
--- a/src/langsmith_cli/commands/self_cmd.py
+++ b/src/langsmith_cli/commands/self_cmd.py
@@ -81,6 +81,38 @@ def detect_installation() -> dict[str, str]:
     return result
 
 
+_UPDATE_COMMANDS: dict[str, str] = {
+    "uv tool": "uv tool upgrade langsmith-cli",
+    "pipx": "pipx upgrade langsmith-cli",
+    "pip (virtualenv)": "pip install --upgrade langsmith-cli",
+    "pip (system)": "pip install --upgrade langsmith-cli",
+}
+
+
+def get_update_command(install_method: str) -> str | None:
+    """Return the shell command to update langsmith-cli for the given install method.
+
+    Returns None for install methods that can't be auto-updated (editable, unknown).
+    """
+    return _UPDATE_COMMANDS.get(install_method)
+
+
+def check_latest_version() -> str | None:
+    """Check PyPI for the latest version of langsmith-cli.
+
+    Returns the version string, or None if the check fails.
+    """
+    import urllib.request
+
+    try:
+        url = "https://pypi.org/pypi/langsmith-cli/json"
+        with urllib.request.urlopen(url, timeout=5) as resp:  # noqa: S310
+            data = json_mod.loads(resp.read())
+            return data["info"]["version"]
+    except Exception:
+        return None
+
+
 @click.group("self")
 def self_group():
     """Inspect and manage the langsmith-cli installation."""
@@ -118,3 +150,109 @@ def detect(ctx: click.Context) -> None:
         table.add_row(label, data.get(key, "unknown"))
 
     console.print(table)
+
+
+@self_group.command("update")
+@click.pass_context
+def update(ctx: click.Context) -> None:
+    """Update langsmith-cli to the latest version."""
+    import subprocess
+
+    info = detect_installation()
+    current = info["version"]
+    method = info["install_method"]
+    json_mode = ctx.obj.get("json")
+
+    # Check latest version on PyPI
+    latest = check_latest_version()
+
+    # Already up to date?
+    if latest and current == latest:
+        if json_mode:
+            click.echo(
+                json_dumps(
+                    {
+                        "status": "up_to_date",
+                        "current_version": current,
+                        "latest_version": latest,
+                    }
+                )
+            )
+        else:
+            click.echo(f"Already up to date (v{current}).")
+        return
+
+    # Get the update command for this install method
+    cmd = get_update_command(method)
+
+    if cmd is None:
+        # Can't auto-update (editable or unknown)
+        if json_mode:
+            click.echo(
+                json_dumps(
+                    {
+                        "status": "manual_update_required",
+                        "current_version": current,
+                        "latest_version": latest,
+                        "install_method": method,
+                        "hint": "Run 'git pull && uv sync' to update manually.",
+                    }
+                )
+            )
+        else:
+            version_info = f"v{current}"
+            if latest:
+                version_info += f" -> v{latest}"
+            click.echo(f"Current: {version_info}")
+            click.echo(f"Install method: {method}")
+            click.echo(
+                "This install cannot be auto-updated. "
+                "Run 'git pull && uv sync' to update manually."
+            )
+        return
+
+    # Run the update command
+    version_info = f"v{current}"
+    if latest:
+        version_info += f" -> v{latest}"
+
+    if not json_mode:
+        click.echo(f"Updating langsmith-cli ({version_info})...")
+        click.echo(f"Running: {cmd}")
+
+    result = subprocess.run(cmd.split(), capture_output=True, text=True)
+
+    if result.returncode == 0:
+        if json_mode:
+            click.echo(
+                json_dumps(
+                    {
+                        "status": "updated",
+                        "current_version": current,
+                        "latest_version": latest,
+                        "command": cmd,
+                    }
+                )
+            )
+        else:
+            if result.stdout.strip():
+                click.echo(result.stdout.strip())
+            click.echo("Update complete.")
+    else:
+        if json_mode:
+            click.echo(
+                json_dumps(
+                    {
+                        "status": "error",
+                        "current_version": current,
+                        "latest_version": latest,
+                        "command": cmd,
+                        "error": result.stderr.strip(),
+                    }
+                )
+            )
+        else:
+            click.echo(f"Update failed (exit code {result.returncode}).")
+            if result.stderr.strip():
+                click.echo(result.stderr.strip())
+        ctx.exit(1)

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1,4 +1,4 @@
-"""Tests for self detect command."""
+"""Tests for self detect and self update commands."""
 
 import json
 import sys
@@ -270,3 +270,198 @@ class TestSelfDetectCLI:
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["install_method"] == "development (editable)"
+
+
+class TestGetUpdateCommand:
+    """Unit tests for get_update_command() pure function."""
+
+    def test_uv_tool_returns_uv_upgrade(self):
+        """INVARIANT: uv tool installs use 'uv tool upgrade langsmith-cli'."""
+        from langsmith_cli.commands.self_cmd import get_update_command
+
+        assert get_update_command("uv tool") == "uv tool upgrade langsmith-cli"
+
+    def test_pipx_returns_pipx_upgrade(self):
+        """INVARIANT: pipx installs use 'pipx upgrade langsmith-cli'."""
+        from langsmith_cli.commands.self_cmd import get_update_command
+
+        assert get_update_command("pipx") == "pipx upgrade langsmith-cli"
+
+    def test_pip_virtualenv_returns_pip_install(self):
+        """INVARIANT: pip virtualenv installs use 'pip install --upgrade langsmith-cli'."""
+        from langsmith_cli.commands.self_cmd import get_update_command
+
+        assert (
+            get_update_command("pip (virtualenv)")
+            == "pip install --upgrade langsmith-cli"
+        )
+
+    def test_pip_system_returns_pip_install(self):
+        """INVARIANT: pip system installs use 'pip install --upgrade langsmith-cli'."""
+        from langsmith_cli.commands.self_cmd import get_update_command
+
+        assert (
+            get_update_command("pip (system)") == "pip install --upgrade langsmith-cli"
+        )
+
+    def test_editable_returns_none(self):
+        """INVARIANT: Editable installs return None (user should update manually)."""
+        from langsmith_cli.commands.self_cmd import get_update_command
+
+        assert get_update_command("development (editable)") is None
+
+    def test_unknown_returns_none(self):
+        """INVARIANT: Unknown install methods return None."""
+        from langsmith_cli.commands.self_cmd import get_update_command
+
+        assert get_update_command("source (not installed)") is None
+
+
+class TestCheckLatestVersion:
+    """Unit tests for check_latest_version()."""
+
+    def test_returns_latest_from_pypi(self):
+        """INVARIANT: Returns the latest version string from PyPI JSON API."""
+        from langsmith_cli.commands.self_cmd import check_latest_version
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.read.return_value = json.dumps(
+            {"info": {"version": "1.2.3"}}
+        ).encode()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_response):
+            assert check_latest_version() == "1.2.3"
+
+    def test_returns_none_on_network_error(self):
+        """INVARIANT: Returns None when PyPI is unreachable."""
+        from langsmith_cli.commands.self_cmd import check_latest_version
+
+        with patch("urllib.request.urlopen", side_effect=Exception("timeout")):
+            assert check_latest_version() is None
+
+
+class TestSelfUpdateCLI:
+    """CLI integration tests for self update command."""
+
+    def test_update_shows_in_help(self, runner):
+        """INVARIANT: 'self --help' lists the update subcommand."""
+        result = runner.invoke(cli, ["self", "--help"])
+
+        assert result.exit_code == 0
+        assert "update" in result.output
+
+    def test_update_editable_shows_manual_instructions(self, runner):
+        """INVARIANT: In dev/editable mode, update tells user to update manually."""
+        # We're in an editable install in the test env
+        with patch(
+            "langsmith_cli.commands.self_cmd.check_latest_version",
+            return_value="99.0.0",
+        ):
+            result = runner.invoke(cli, ["self", "update"])
+
+        assert result.exit_code == 0
+        assert (
+            "development" in result.output.lower()
+            or "editable" in result.output.lower()
+        )
+        assert "git pull" in result.output or "manually" in result.output.lower()
+
+    def test_update_already_up_to_date(self, runner):
+        """INVARIANT: When current version matches latest, reports up to date."""
+        from langsmith_cli.commands.self_cmd import detect_installation
+
+        current = detect_installation()["version"]
+
+        with patch(
+            "langsmith_cli.commands.self_cmd.check_latest_version",
+            return_value=current,
+        ):
+            result = runner.invoke(cli, ["self", "update"])
+
+        assert result.exit_code == 0
+        assert "up to date" in result.output.lower()
+
+    def test_update_uv_tool_runs_upgrade(self, runner):
+        """INVARIANT: For uv tool installs, runs 'uv tool upgrade langsmith-cli'."""
+        mock_info = {
+            "version": "0.1.0",
+            "install_method": "uv tool",
+            "install_path": "/some/path",
+            "executable_path": "/some/bin/langsmith-cli",
+            "python_path": sys.executable,
+            "python_version": "3.12.0",
+        }
+
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = "Updated langsmith-cli to 0.3.1"
+        mock_proc.stderr = ""
+
+        with (
+            patch(
+                "langsmith_cli.commands.self_cmd.detect_installation",
+                return_value=mock_info,
+            ),
+            patch(
+                "langsmith_cli.commands.self_cmd.check_latest_version",
+                return_value="0.3.1",
+            ),
+            patch("subprocess.run", return_value=mock_proc) as mock_run,
+        ):
+            result = runner.invoke(cli, ["self", "update"])
+
+        assert result.exit_code == 0
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["uv", "tool", "upgrade", "langsmith-cli"]
+
+    def test_update_json_output(self, runner):
+        """INVARIANT: --json self update returns structured JSON with status."""
+        from langsmith_cli.commands.self_cmd import detect_installation
+
+        current = detect_installation()["version"]
+
+        with patch(
+            "langsmith_cli.commands.self_cmd.check_latest_version",
+            return_value=current,
+        ):
+            result = runner.invoke(cli, ["--json", "self", "update"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "status" in data
+        assert "current_version" in data
+
+    def test_update_pypi_unreachable(self, runner):
+        """INVARIANT: When PyPI check fails, still attempts update."""
+        mock_info = {
+            "version": "0.1.0",
+            "install_method": "uv tool",
+            "install_path": "/some/path",
+            "executable_path": "/some/bin/langsmith-cli",
+            "python_path": sys.executable,
+            "python_version": "3.12.0",
+        }
+
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = "Updated"
+        mock_proc.stderr = ""
+
+        with (
+            patch(
+                "langsmith_cli.commands.self_cmd.detect_installation",
+                return_value=mock_info,
+            ),
+            patch(
+                "langsmith_cli.commands.self_cmd.check_latest_version",
+                return_value=None,
+            ),
+            patch("subprocess.run", return_value=mock_proc),
+        ):
+            result = runner.invoke(cli, ["self", "update"])
+
+        assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- Adds `self update` subcommand that auto-detects install method and runs the appropriate upgrade
- Checks PyPI for latest version; skips if already up to date
- Supports `--json` for structured output

| Install method | Update command |
|---|---|
| uv tool | `uv tool upgrade langsmith-cli` |
| pipx | `pipx upgrade langsmith-cli` |
| pip (virtualenv/system) | `pip install --upgrade langsmith-cli` |
| development (editable) | Shows manual instructions (`git pull && uv sync`) |

## Test plan
- [x] 29 tests (14 new for update), all passing
- [x] pyright: 0 errors
- [x] ruff: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)