### PR TITLE
docs: Update documentation for recent features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,10 +111,18 @@ main.py (entry point)
 ├── runs (group)
 │   ├── list
 │   ├── get
+│   ├── get-latest
 │   ├── stats
 │   ├── open
 │   ├── watch
-│   └── search
+│   ├── search
+│   ├── sample
+│   ├── analyze
+│   ├── tags
+│   ├── metadata-keys
+│   ├── fields
+│   ├── describe
+│   └── view-file
 ├── datasets (group)
 │   ├── list
 │   ├── get
@@ -124,10 +132,13 @@ main.py (entry point)
 │   ├── list
 │   ├── get
 │   └── create
-└── prompts (group)
-    ├── list
-    ├── get
-    └── push
+├── prompts (group)
+│   ├── list
+│   ├── get
+│   └── push
+└── self (group)
+    ├── detect
+    └── update
 ```
 
 ### Key Design Patterns
@@ -217,23 +228,37 @@ def list_runs(ctx, output_format, count, output, ...):
 ```
 src/langsmith_cli/
 ├── __init__.py
-├── main.py              # Entry point, CLI group registration
-├── logging.py           # CLILogger for verbosity control and stream separation
+├── main.py              # Entry point, CLI group registration, global error handler
+├── cli_logging.py       # CLILogger for verbosity control and stream separation
+├── config.py            # Credentials file management
+├── field_analysis.py    # Field discovery and statistics (runs fields/describe)
+├── filters.py           # FQL filter builders and time parsing
+├── utils.py             # Shared helpers (output formatting, project resolution, etc.)
 └── commands/            # Modular command implementations
     ├── auth.py          # Authentication (login)
     ├── projects.py      # Project management
     ├── runs.py          # Runs/traces (largest module)
     ├── datasets.py      # Dataset operations
     ├── examples.py      # Dataset examples
-    └── prompts.py       # Prompt management
+    ├── prompts.py       # Prompt management
+    └── self_cmd.py      # Self-inspection (detect, update)
 
 tests/
-├── conftest.py          # Pytest fixtures (CliRunner)
-├── test_main.py         # Root CLI tests
+├── conftest.py          # Pytest fixtures (CliRunner, model factories)
+├── test_main.py         # Root CLI + global error handler tests
 ├── test_logging.py      # CLILogger tests
 ├── test_auth.py         # Auth command tests
 ├── test_projects.py     # Projects command tests
-├── test_runs.py         # Runs command tests (largest)
+├── test_runs.py         # Runs command tests
+├── test_runs_list.py    # Runs list command tests (filters, JSON, formats)
+├── test_runs_get.py     # Runs get/get-latest/open tests
+├── test_runs_roots.py   # Runs --roots flag tests
+├── test_runs_sample.py  # Runs sample command tests
+├── test_datasets.py     # Datasets command tests
+├── test_examples.py     # Examples command tests
+├── test_prompts.py      # Prompts command tests
+├── test_self.py         # Self detect/update command tests
+├── test_utils.py        # Utility function tests
 ├── test_smoke.py        # Smoke tests (requires API key)
 └── test_e2e.py          # End-to-end tests (requires API key)
 

--- a/README.md
+++ b/README.md
@@ -108,10 +108,11 @@ langsmith-cli runs watch
 ### 📦 **Complete Coverage**
 Every LangSmith resource at your fingertips:
 - ✅ **Projects** - List, create, inspect
-- ✅ **Runs** - Search, stats, watch, open in browser
+- ✅ **Runs** - Search, stats, watch, sample, analyze, field discovery
 - ✅ **Datasets** - CRUD + bulk JSONL uploads
 - ✅ **Examples** - Full lifecycle management
 - ✅ **Prompts** - Version control your prompts
+- ✅ **Self** - Installation detection + auto-update
 
 ---
 
@@ -260,8 +261,8 @@ langsmith-cli runs watch --project production
 ### 💾 Bulk Dataset Uploads
 
 ```bash
-# Export examples to JSONL
-langsmith-cli --json examples list --dataset my-dataset > examples.jsonl
+# Export examples to JSONL (using --output for reliable file writing)
+langsmith-cli examples list --dataset my-dataset --output examples.jsonl
 
 # Upload to new dataset
 langsmith-cli datasets push examples.jsonl --dataset production-eval
@@ -374,9 +375,18 @@ auth login              # Authenticate with LangSmith
 projects list           # List all projects
 runs list              # Search and filter runs
 runs get <id>          # Inspect a specific run
+runs get-latest        # Get most recent run matching filters
 runs stats             # Aggregate statistics
 runs watch             # Live run dashboard
 runs open <id>         # Open trace in browser
+runs search            # Full-text search across runs
+runs sample            # Stratified sampling by tags/metadata
+runs analyze           # Group runs and compute metrics
+runs tags              # Discover tag patterns
+runs metadata-keys     # Discover metadata keys
+runs fields            # Discover field paths and types
+runs describe          # Detailed field statistics
+runs view-file         # View runs from JSONL files
 datasets list          # List datasets
 datasets create        # Create new dataset
 datasets push          # Bulk upload from JSONL
@@ -385,6 +395,8 @@ examples create        # Add example to dataset
 prompts list           # List prompt repositories
 prompts get            # Pull a prompt template
 prompts push           # Push local prompt to LangSmith
+self detect            # Show installation details
+self update            # Update to latest version
 ```
 
 ### Global Flags
@@ -400,7 +412,8 @@ prompts push           # Push local prompt to LangSmith
 
 | Option | Description | Example |
 |--------|-------------|---------|
-| `--project` | Filter by project | `--project production` |
+| `--project` | Filter by project name | `--project production` |
+| `--project-id` | Filter by project UUID | `--project-id abc-123...` |
 | `--status` | Filter by status | `--status error` |
 | `--failed` | Only failed runs | `--failed` |
 | `--succeeded` | Only successful runs | `--succeeded` |
@@ -492,8 +505,7 @@ uv run pyright
 ```
 
 ### Project Stats
-- **79% Test Coverage** (116 tests)
-- **100% Utils Coverage** (47 tests for helpers)
+- **92% Test Coverage** (589 tests)
 - **Zero Type Errors** (Pyright clean)
 - **100% MCP Parity** (13/13 tools)
 

--- a/skills/langsmith/SKILL.md
+++ b/skills/langsmith/SKILL.md
@@ -48,8 +48,8 @@ langsmith-cli runs list --project my-project --fields id,name,status --output ru
 ```bash
 # ❌ WRONG - Never use shell redirection for data extraction
 langsmith-cli --json runs list --project my-project > runs.json
-# If API fails: you get empty [], no error message, exit code 0
-# You won't know anything went wrong!
+# If API fails: errors go to stderr (invisible with redirection)
+# You may get a JSON error object instead of data, and won't know what happened
 ```
 
 ```bash
@@ -107,7 +107,8 @@ langsmith-cli --json runs list --project my-project --limit 5 2>&1
 
 ### Runs (Traces)
 - `langsmith-cli --json runs list [OPTIONS]`: List recent runs.
-  - `--project <name>`: Filter by project.
+  - `--project <name>`: Filter by project name (default: "default").
+  - `--project-id <uuid>`: Filter by project UUID (bypasses name resolution, faster).
   - `--limit <n>`: Max results (default 10, keep it small).
   - `--status <success|error>`: Filter by status.
   - `--filter <string>`: Advanced FQL query string (see FQL examples below).
@@ -210,6 +211,13 @@ langsmith-cli --json runs list --project my-project --limit 5 2>&1
   - `--output <file>`: Write to file instead of stdout
 - `langsmith-cli --json prompts get <name> [--commit <hash>]`: Fetch a prompt template.
 - `langsmith-cli --json prompts push <name> <file_path>`: Push a local file as a prompt.
+
+### Self (Installation Management)
+- `langsmith-cli self detect`: Show installation details (version, install method, paths).
+  - Reports: version, install method (uv tool, pipx, pip, editable), install path, executable path, Python version.
+- `langsmith-cli self update`: Update langsmith-cli to the latest version.
+  - Auto-detects install method and runs the appropriate upgrade command.
+  - Checks PyPI for latest version before updating.
 
 ## Common Patterns (No Piping Needed)
 


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: Update command structure tree with all 14 runs subcommands and self group. Update file organization to reflect `cli_logging.py` rename, new modules (`field_analysis.py`, `filters.py`, `config.py`, `self_cmd.py`), and all 17 test files.
- **SKILL.md**: Add `self detect`/`self update` commands, add `--project-id` option to runs, update error handling description to reflect PR #15 improvements.
- **README.md**: Add `self` commands to Complete Coverage and Command Reference (now 27 commands listed). Add `--project-id` to Runs Filtering table. Update project stats from "79% coverage, 116 tests" to "92% coverage, 589 tests". Fix dataset export example to use `--output` instead of shell redirection.

## Test plan
- [x] Documentation-only changes, no code modifications
- [x] Verified all listed commands match actual `--help` output
- [x] Verified test counts and coverage match actual `pytest --cov` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)