### PR TITLE
fix: Improve project resolution UX for AI agents

### DIFF
--- a/skills/langsmith/references/troubleshooting.md
+++ b/skills/langsmith/references/troubleshooting.md
@@ -80,8 +80,14 @@ langsmith-cli <command> [options]
 **Solution:** Run `langsmith-cli auth login` or set `LANGSMITH_API_KEY` env var
 
 ### "Project not found"
-**Cause:** Project name doesn't exist
-**Solution:** Run `langsmith-cli projects list` to see available projects
+**Cause:** Project name doesn't exist or has a path prefix (e.g., `prd/my-project`)
+**Solution:**
+1. The error message will suggest similar project names if available
+2. List projects: `langsmith-cli --json projects list --fields name`
+3. Use substring matching: `langsmith-cli --json runs list --project-name my-project`
+4. Use wildcards: `langsmith-cli --json runs list --project-name-pattern "*my-project*"`
+5. If you have a UUID, pass it to `--project-id` or `--project` (UUIDs are auto-detected)
+6. In JSON mode, the error includes structured `suggestions` and `failed_sources` fields
 
 ### "Dataset not found"
 **Cause:** Dataset name doesn't match exactly


### PR DESCRIPTION
## Summary

- **UUID auto-detection**: Passing a UUID to `--project` now auto-redirects to `--project-id` lookup, so `--project 8dc9fb82-...` just works
- **Project name suggestions**: When a project isn't found, the CLI suggests similar names using substring and token matching (e.g., `promotion_service` → `prd/promotion_service`)
- **Structured JSON errors**: New `CLIFetchError` exception produces structured JSON with `failed_sources` and `suggestions` fields, so agents parsing stdout get actionable data instead of "check the error messages above"

### Before
```json
{"error": "ClickException", "message": "Failed to fetch runs from all 1 source(s). Check the error messages above."}
```

### After
```json
{
  "error": "FetchError",
  "message": "Failed to fetch runs from all 1 source(s).\n  promotion_service: Project not found\nDid you mean: 'prd/promotion_service'?",
  "failed_sources": [{"name": "promotion_service", "error": "Project not found"}],
  "suggestions": ["prd/promotion_service", "stg/promotion_service"]
}
```

## Test plan

- [x] 37 new tests across test_utils.py, test_main.py, test_runs_list.py
- [x] Full suite: 668 tests passing
- [x] Pyright: 0 errors
- [x] Ruff: all checks passed
- [ ] Manual test: `langsmith-cli --json runs list --project <wrong-name>` shows suggestions
- [ ] Manual test: `langsmith-cli --json runs list --project <uuid>` works without `--project-id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)