### PR TITLE
refactor: remove unnecessary hasattr() on guaranteed Run fields

### DIFF
--- a/src/langsmith_cli/commands/runs/analyze_cmd.py
+++ b/src/langsmith_cli/commands/runs/analyze_cmd.py
@@ -263,11 +263,7 @@ def compute_metrics(
 
     # Cost metrics (if available in SDK)
     if "avg_cost" in requested_metrics:
-        costs = [
-            r.total_cost
-            for r in runs
-            if hasattr(r, "total_cost") and r.total_cost is not None
-        ]
+        costs = [r.total_cost for r in runs if r.total_cost is not None]
         result["avg_cost"] = float(statistics.mean(costs)) if costs else 0.0
 
     return result

--- a/src/langsmith_cli/commands/runs/list_cmd.py
+++ b/src/langsmith_cli/commands/runs/list_cmd.py
@@ -432,9 +432,7 @@ def list_runs(
             "name": lambda r: (r.name or "").lower(),
             "status": lambda r: r.status or "",
             "latency": lambda r: r.latency if r.latency is not None else 0,
-            "start_time": lambda r: (
-                r.start_time if hasattr(r, "start_time") else datetime.datetime.min
-            ),
+            "start_time": lambda r: r.start_time,
         }
         runs = sort_items(runs, sort_by, sort_key_map, console)
 


### PR DESCRIPTION
## Summary

- Remove `hasattr(r, "total_cost")` guard in `analyze_cmd.py` — `total_cost` is a defined field on `Run`
- Remove `hasattr(r, "start_time")` fallback in `list_cmd.py` — `start_time` is a required field on `Run`
- Both fields verified present via `Run.model_fields` and pyright (0 errors)

Also closed two issues that were already fixed:
- **#62** (grep+limit API 400): Already handled by `_make_fetch_runs()` pagination in `_group.py`
- **#61** (since+last combining): Already implemented in `time_parsing.py`

## Test plan

- [x] `pytest tests/test_runs_analyze.py tests/test_runs_list.py` — 87 tests pass
- [x] `pyright` — 0 errors on changed files
- [x] `ruff check` + `ruff format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)