### PR TITLE
fix(#87,#88,#89): datetime tz normalization, follow-children 422, --trace alias, sort crash fixes

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith-cli",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "A context-efficient interface for LangSmith observability and evaluations.",
   "author": {
     "name": "Aviad Rozenhek",
@@ -9,6 +9,13 @@
   "homepage": "https://github.com/gigaverse-app/langsmith-cli",
   "repository": "https://github.com/gigaverse-app/langsmith-cli",
   "license": "MIT",
-  "keywords": ["langsmith", "observability", "evaluations", "tracing"],
-  "skills": ["./skills/"]
+  "keywords": [
+    "langsmith",
+    "observability",
+    "evaluations",
+    "tracing"
+  ],
+  "skills": [
+    "./skills/"
+  ]
 }

--- a/src/langsmith_cli/cache.py
+++ b/src/langsmith_cli/cache.py
@@ -13,8 +13,9 @@ from typing import Any, overload
 
 from langsmith.schemas import Run
 from platformdirs import user_cache_dir
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
+from langsmith_cli.time_parsing import ensure_aware_datetime
 from langsmith_cli.utils import FetchResult
 
 
@@ -106,6 +107,19 @@ class CacheMetadata(BaseModel):
     last_updated: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     filters_used: str | None = None
 
+    @model_validator(mode="after")
+    def _normalize_datetimes(self) -> "CacheMetadata":
+        """Normalize naive datetimes to UTC-aware on load.
+
+        Old cache files may contain naive datetime strings (no timezone offset).
+        Without normalization, comparing them against newly-fetched UTC-aware
+        datetimes raises TypeError. This validator fixes all such values at
+        deserialization time, making the model safe to use regardless of cache age.
+        """
+        self.oldest_run_start_time = ensure_aware_datetime(self.oldest_run_start_time)
+        self.newest_run_start_time = ensure_aware_datetime(self.newest_run_start_time)
+        return self
+
 
 def get_cache_dir() -> Path:
     """Get the cache directory for langsmith-cli runs."""
@@ -173,9 +187,7 @@ def read_cached_runs(
         except Exception as e:
             logger.warning("Skipping corrupt cache line in %s: %s", cache_path, e)
             continue
-        start = run.start_time
-        if start.tzinfo is None:
-            start = start.replace(tzinfo=timezone.utc)
+        start = ensure_aware_datetime(run.start_time)
         if since and start < since:
             continue
         if until and start > until:
@@ -205,8 +217,7 @@ def get_existing_run_ids(project_name: str) -> set[str]:
 
 def _update_meta_times(meta: CacheMetadata, t: datetime) -> None:
     """Update oldest/newest run time bounds in metadata in-place."""
-    if t.tzinfo is None:
-        t = t.replace(tzinfo=timezone.utc)
+    t = ensure_aware_datetime(t) or t
     if meta.oldest_run_start_time is None or t < meta.oldest_run_start_time:
         meta.oldest_run_start_time = t
     if meta.newest_run_start_time is None or t > meta.newest_run_start_time:

--- a/src/langsmith_cli/cache.py
+++ b/src/langsmith_cli/cache.py
@@ -217,7 +217,7 @@ def get_existing_run_ids(project_name: str) -> set[str]:
 
 def _update_meta_times(meta: CacheMetadata, t: datetime) -> None:
     """Update oldest/newest run time bounds in metadata in-place."""
-    t = ensure_aware_datetime(t) or t
+    t = ensure_aware_datetime(t)
     if meta.oldest_run_start_time is None or t < meta.oldest_run_start_time:
         meta.oldest_run_start_time = t
     if meta.newest_run_start_time is None or t > meta.newest_run_start_time:

--- a/src/langsmith_cli/commands/projects.py
+++ b/src/langsmith_cli/commands/projects.py
@@ -199,6 +199,7 @@ def list_projects(
     # Define table builder function
     def build_projects_table(projects):
         from datetime import datetime, timezone
+        from langsmith_cli.time_parsing import ensure_aware_datetime
 
         table = Table(title="Projects")
         table.add_column("Name", style="cyan")
@@ -214,11 +215,7 @@ def list_projects(
             # Last run time (human-readable relative time)
             if p.last_run_start_time:
                 now = datetime.now(timezone.utc)
-                # Handle timezone-aware and timezone-naive datetimes
-                last_run = p.last_run_start_time
-                if last_run.tzinfo is None:
-                    # Make naive datetime timezone-aware (assume UTC)
-                    last_run = last_run.replace(tzinfo=timezone.utc)
+                last_run = ensure_aware_datetime(p.last_run_start_time)
                 delta = now - last_run
                 if delta.days > 0:
                     last_run_str = f"{delta.days}d ago"

--- a/src/langsmith_cli/commands/runs/get_cmd.py
+++ b/src/langsmith_cli/commands/runs/get_cmd.py
@@ -1,5 +1,6 @@
 """Runs get, get-latest, and view-file commands."""
 
+from datetime import datetime as _datetime, timezone as _timezone
 from typing import Any
 import json
 
@@ -60,7 +61,8 @@ def get_run(ctx, run_id, fields, output, follow_children):
         children = [
             c for c in client.list_runs(trace_id=str(trace_id)) if str(c.id) != run_id
         ]
-        children.sort(key=lambda r: r.start_time or "")
+        _epoch = _datetime.min.replace(tzinfo=_timezone.utc)
+        children.sort(key=lambda r: r.start_time or _epoch)
         child_data = [filter_fields(c, fields) for c in children]
         data = filter_fields(run, fields)
         data["_children"] = child_data

--- a/src/langsmith_cli/commands/runs/get_cmd.py
+++ b/src/langsmith_cli/commands/runs/get_cmd.py
@@ -54,13 +54,13 @@ def get_run(ctx, run_id, fields, output, follow_children):
 
     if follow_children:
         trace_id = run.trace_id or run.id
-        children = list(
-            client.list_runs(
-                trace_id=str(trace_id),
-                execution_order=[2, None],  # skip root (order=1)
-            )
-        )
-        children.sort(key=lambda r: (r.execution_order or 0, r.start_time or ""))
+        # Fetch all runs in the trace then exclude the root run by ID.
+        # Do NOT pass execution_order as a kwarg — the API requires an integer,
+        # not a list, and rejects the request with 422.
+        children = [
+            c for c in client.list_runs(trace_id=str(trace_id)) if str(c.id) != run_id
+        ]
+        children.sort(key=lambda r: r.start_time or "")
         child_data = [filter_fields(c, fields) for c in children]
         data = filter_fields(run, fields)
         data["_children"] = child_data

--- a/src/langsmith_cli/commands/runs/get_cmd.py
+++ b/src/langsmith_cli/commands/runs/get_cmd.py
@@ -108,6 +108,9 @@ def get_run(ctx, run_id, fields, output, follow_children):
 )
 @click.option("--last", help="Show runs from last duration (e.g., '24h', '7d', '30m').")
 @click.option("--filter", "filter_", help="Custom FQL filter string.")
+@click.option(
+    "--run-type", help="Filter by run type (llm, chain, tool, retriever, etc)."
+)
 @fields_option(
     "Comma-separated field names (e.g., 'id,name,inputs,outputs'). Reduces context."
 )
@@ -136,6 +139,7 @@ def get_latest_run(
     before,
     last,
     filter_,
+    run_type,
     fields,
     output,
 ):
@@ -204,6 +208,7 @@ def get_latest_run(
         error=error_filter,
         filter=combined_filter,
         is_root=roots,
+        run_type=run_type,
     )
 
     if pq.use_id:

--- a/src/langsmith_cli/commands/runs/list_cmd.py
+++ b/src/langsmith_cli/commands/runs/list_cmd.py
@@ -44,7 +44,7 @@ from langsmith_cli.utils import (
     "filter_",
     help='LangSmith FQL filter. Examples: eq(name, "extractor"), gt(latency, "5s"), has(tags, "prod"). See --help for full examples.',
 )
-@click.option("--trace-id", help="Get all runs in a specific trace.")
+@click.option("--trace-id", "--trace", help="Get all runs in a specific trace.")
 @click.option(
     "--run-type", help="Filter by run type (llm, chain, tool, retriever, etc)."
 )

--- a/src/langsmith_cli/commands/runs/usage_cmd.py
+++ b/src/langsmith_cli/commands/runs/usage_cmd.py
@@ -286,7 +286,7 @@ def _truncate_hour(dt: Any) -> str:
 
     if isinstance(dt, str):
         dt = datetime.fromisoformat(dt)
-    dt = ensure_aware_datetime(dt) or dt
+    dt = ensure_aware_datetime(dt)
     return dt.strftime("%Y-%m-%dT%H:00Z")
 
 
@@ -657,7 +657,7 @@ def usage_runs(
     # Build bucket key function
     def _bucket_key(run: Run) -> str:
         if interval == "day":
-            dt = ensure_aware_datetime(run.start_time) or run.start_time
+            dt = ensure_aware_datetime(run.start_time)
             return dt.strftime("%Y-%m-%d")
         return _truncate_hour(run.start_time)
 

--- a/src/langsmith_cli/commands/runs/usage_cmd.py
+++ b/src/langsmith_cli/commands/runs/usage_cmd.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from rich.table import Table
 
 from langsmith_cli.commands.runs._group import console, runs
+from langsmith_cli.time_parsing import ensure_aware_datetime
 from langsmith_cli.output import json_dumps
 from langsmith_cli.utils import (
     add_grep_options,
@@ -281,12 +282,11 @@ def _metadata_value_matches(candidate: str | None, pattern: str) -> bool:
 
 def _truncate_hour(dt: Any) -> str:
     """Truncate a datetime to the hour, return as ISO string."""
-    from datetime import datetime, timezone
+    from datetime import datetime
 
     if isinstance(dt, str):
         dt = datetime.fromisoformat(dt)
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
+    dt = ensure_aware_datetime(dt) or dt
     return dt.strftime("%Y-%m-%dT%H:00Z")
 
 
@@ -417,7 +417,6 @@ def usage_runs(
           --last 7d --active-only
     """
     from collections import defaultdict
-    from datetime import timezone
 
     from langsmith_cli.commands.runs import extract_group_value, parse_grouping_field
 
@@ -658,9 +657,7 @@ def usage_runs(
     # Build bucket key function
     def _bucket_key(run: Run) -> str:
         if interval == "day":
-            dt = run.start_time
-            if dt.tzinfo is None:
-                dt = dt.replace(tzinfo=timezone.utc)
+            dt = ensure_aware_datetime(run.start_time) or run.start_time
             return dt.strftime("%Y-%m-%d")
         return _truncate_hour(run.start_time)
 

--- a/src/langsmith_cli/commands/runs/usage_cmd.py
+++ b/src/langsmith_cli/commands/runs/usage_cmd.py
@@ -24,7 +24,9 @@ from langsmith_cli.utils import (
     filter_runs_by_tags,
     get_or_create_client,
     output_formatted_data,
+    output_option,
     resolve_project_filters,
+    write_output_to_file,
 )
 
 
@@ -350,6 +352,7 @@ def _truncate_hour(dt: Any) -> str:
     type=click.Choice(["table", "json", "csv", "yaml"]),
     help="Output format (default: table, or json if --json flag used).",
 )
+@output_option()
 @click.pass_context
 def usage_runs(
     ctx: click.Context,
@@ -377,6 +380,7 @@ def usage_runs(
     from_cache: bool,
     apply_pricing: str | None,
     output_format: str | None,
+    output: str | None,
 ) -> None:
     """Analyze token usage over time with flexible grouping and breakdowns.
 
@@ -772,6 +776,11 @@ def usage_runs(
 
     # Determine output format
     format_type = determine_output_format(output_format, ctx.obj.get("json"))
+
+    # Handle file output — write results to file and return
+    if output:
+        write_output_to_file(results, output, console, format_type="jsonl")
+        return
 
     if format_type != "table":
         # CSV/YAML need a flat list; JSON gets the full nested structure

--- a/src/langsmith_cli/commands/runs/usage_cmd.py
+++ b/src/langsmith_cli/commands/runs/usage_cmd.py
@@ -1,5 +1,6 @@
 """Usage analysis command for runs."""
 
+from datetime import datetime as _datetime
 from typing import Any
 
 import click
@@ -282,14 +283,12 @@ def _metadata_value_matches(candidate: str | None, pattern: str) -> bool:
     return candidate == pattern
 
 
-def _truncate_hour(dt: Any) -> str:
+def _truncate_hour(dt: _datetime | str) -> str:
     """Truncate a datetime to the hour, return as ISO string."""
-    from datetime import datetime
-
     if isinstance(dt, str):
-        dt = datetime.fromisoformat(dt)
-    dt = ensure_aware_datetime(dt)
-    return dt.strftime("%Y-%m-%dT%H:00Z")
+        dt = _datetime.fromisoformat(dt)
+    aware = ensure_aware_datetime(dt)
+    return aware.strftime("%Y-%m-%dT%H:00Z")
 
 
 @runs.command("usage")
@@ -662,7 +661,11 @@ def usage_runs(
     def _bucket_key(run: Run) -> str:
         if interval == "day":
             dt = ensure_aware_datetime(run.start_time)
+            if dt is None:
+                return "unknown"
             return dt.strftime("%Y-%m-%d")
+        if run.start_time is None:
+            return "unknown"
         return _truncate_hour(run.start_time)
 
     # Aggregate into buckets

--- a/src/langsmith_cli/commands/runs/watch_cmd.py
+++ b/src/langsmith_cli/commands/runs/watch_cmd.py
@@ -1,5 +1,7 @@
 """Open and watch commands for runs."""
 
+from datetime import datetime as _datetime, timezone as _timezone
+
 import click
 from rich.table import Table
 from langsmith.schemas import Run
@@ -130,7 +132,8 @@ def watch_runs(
                     failed_count += 1
 
         # Sort by start time (most recent first) and limit to 10
-        all_runs.sort(key=lambda item: item[1].start_time or "", reverse=True)
+        _epoch = _datetime.min.replace(tzinfo=_timezone.utc)
+        all_runs.sort(key=lambda item: item[1].start_time or _epoch, reverse=True)
         all_runs = all_runs[:10]
 
         # Add failure count to title if any projects failed

--- a/src/langsmith_cli/time_parsing.py
+++ b/src/langsmith_cli/time_parsing.py
@@ -3,9 +3,34 @@
 import datetime
 import re
 from datetime import datetime as datetime_type
-from typing import Any, Callable
+from typing import Any, Callable, overload
 
 import click
+
+
+@overload
+def ensure_aware_datetime(dt: datetime_type) -> datetime_type: ...
+
+
+@overload
+def ensure_aware_datetime(dt: None) -> None: ...
+
+
+@overload
+def ensure_aware_datetime(dt: datetime_type | None) -> datetime_type | None: ...
+
+
+def ensure_aware_datetime(dt: datetime_type | None) -> datetime_type | None:
+    """Return dt with UTC tzinfo attached if naive, unchanged if already aware or None.
+
+    Use this whenever comparing datetimes that may come from external sources
+    (SDK, cached JSON) where timezone info is not guaranteed.
+    """
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=datetime.timezone.utc)
+    return dt
 
 
 def parse_duration_to_seconds(duration_str: str) -> str:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -100,6 +100,73 @@ class TestCacheMetadata:
         monkeypatch.setattr("langsmith_cli.cache.get_cache_dir", lambda: tmp_path)
         assert read_cache_metadata("nonexistent") is None
 
+    def test_model_validator_normalizes_naive_datetimes(self):
+        """INVARIANT: CacheMetadata loaded from JSON with naive datetimes produces aware fields."""
+        raw_json = json.dumps(
+            {
+                "project_name": "legacy-project",
+                "oldest_run_start_time": "2026-01-01T10:00:00",  # naive — no offset
+                "newest_run_start_time": "2026-03-09T16:00:00",  # naive — no offset
+                "run_count": 5,
+                "last_updated": "2026-03-09T16:05:00+00:00",
+            }
+        )
+        meta = CacheMetadata.model_validate_json(raw_json)
+        assert meta.oldest_run_start_time is not None
+        assert meta.oldest_run_start_time.tzinfo is not None
+        assert meta.newest_run_start_time is not None
+        assert meta.newest_run_start_time.tzinfo is not None
+
+    def test_model_validator_preserves_aware_times(self):
+        """INVARIANT: already-aware datetimes are not changed by the validator."""
+        raw_json = json.dumps(
+            {
+                "project_name": "aware-project",
+                "oldest_run_start_time": "2026-01-01T10:00:00+00:00",
+                "newest_run_start_time": "2026-03-09T16:00:00+00:00",
+                "run_count": 3,
+                "last_updated": "2026-03-09T16:05:00+00:00",
+            }
+        )
+        meta = CacheMetadata.model_validate_json(raw_json)
+        assert meta.oldest_run_start_time is not None
+        assert meta.oldest_run_start_time.tzinfo is not None
+        assert meta.newest_run_start_time is not None
+        assert meta.newest_run_start_time.tzinfo is not None
+
+    def test_appending_to_legacy_cache_with_naive_metadata_does_not_crash(
+        self, tmp_path, monkeypatch
+    ):
+        """INVARIANT: appending runs to a legacy cache (naive metadata on disk) must not raise TypeError.
+
+        Regression test for: 'can't compare offset-naive and offset-aware datetimes'
+        This crash happened when _update_meta_times compared a newly normalized
+        UTC-aware datetime against a naive datetime loaded from old cached metadata.
+        """
+        monkeypatch.setattr("langsmith_cli.cache.get_cache_dir", lambda: tmp_path)
+
+        # Simulate old cache: metadata written with naive datetimes (no UTC offset)
+        meta_path = tmp_path / "legacy-project.meta.json"
+        meta_path.write_text(
+            json.dumps(
+                {
+                    "project_name": "legacy-project",
+                    "oldest_run_start_time": "2026-01-01T10:00:00",  # naive
+                    "newest_run_start_time": "2026-03-09T16:00:00",  # naive
+                    "run_count": 2,
+                    "last_updated": "2026-03-09T16:00:00+00:00",
+                }
+            )
+        )
+        (tmp_path / "legacy-project.jsonl").touch()
+
+        # Appending a new run must not raise TypeError on datetime comparison
+        meta = append_runs_to_cache("legacy-project", [_make_run(99)])
+        assert meta.oldest_run_start_time is not None
+        assert meta.oldest_run_start_time.tzinfo is not None
+        assert meta.newest_run_start_time is not None
+        assert meta.newest_run_start_time.tzinfo is not None
+
 
 class TestCacheReadWrite:
     def test_append_and_read(self, tmp_path, monkeypatch):

--- a/tests/test_runs_get.py
+++ b/tests/test_runs_get.py
@@ -768,3 +768,101 @@ class TestRunsWatch:
         assert result.exit_code == 0
         output = strip_ansi(result.output)
         assert "failed" in output.lower()
+
+
+PARENT_RUN_ID = "aaaaaaaa-0000-0000-0000-000000000001"
+TRACE_ID_FC = "bbbbbbbb-0000-0000-0000-000000000001"
+CHILD_RUN_ID_1 = "cccccccc-0000-0000-0000-000000000001"
+CHILD_RUN_ID_2 = "dddddddd-0000-0000-0000-000000000001"
+
+
+class TestFollowChildren:
+    """Tests for runs get --follow-children flag."""
+
+    def test_follow_children_does_not_pass_execution_order_to_api(
+        self, runner, mock_client
+    ):
+        """INVARIANT: execution_order must NOT be forwarded to client.list_runs — API rejects it with 422."""
+        parent = create_run(id_str=PARENT_RUN_ID, trace_id=TRACE_ID_FC)
+        child = create_run(
+            id_str=CHILD_RUN_ID_1,
+            trace_id=TRACE_ID_FC,
+            parent_run_id=PARENT_RUN_ID,
+            name="child-llm",
+        )
+        mock_client.read_run.return_value = parent
+        mock_client.list_runs.return_value = iter([parent, child])
+
+        result = runner.invoke(
+            cli, ["--json", "runs", "get", PARENT_RUN_ID, "--follow-children"]
+        )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_client.list_runs.call_args[1]
+        assert "execution_order" not in call_kwargs, (
+            "execution_order must not be passed to list_runs — LangSmith API rejects it with 422"
+        )
+
+    def test_follow_children_excludes_root_run_from_children(self, runner, mock_client):
+        """INVARIANT: the root run itself must not appear in _children."""
+        parent = create_run(id_str=PARENT_RUN_ID, trace_id=TRACE_ID_FC)
+        child = create_run(
+            id_str=CHILD_RUN_ID_1,
+            trace_id=TRACE_ID_FC,
+            parent_run_id=PARENT_RUN_ID,
+            name="llm-child",
+        )
+        mock_client.read_run.return_value = parent
+        mock_client.list_runs.return_value = iter([parent, child])
+
+        result = runner.invoke(
+            cli, ["--json", "runs", "get", PARENT_RUN_ID, "--follow-children"]
+        )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        child_ids = [c["id"] for c in data["_children"]]
+        assert PARENT_RUN_ID not in child_ids
+        assert CHILD_RUN_ID_1 in child_ids
+
+    def test_follow_children_fetches_by_trace_id(self, runner, mock_client):
+        """INVARIANT: list_runs is called with the run's trace_id."""
+        parent = create_run(id_str=PARENT_RUN_ID, trace_id=TRACE_ID_FC)
+        mock_client.read_run.return_value = parent
+        mock_client.list_runs.return_value = iter([])
+
+        runner.invoke(
+            cli, ["--json", "runs", "get", PARENT_RUN_ID, "--follow-children"]
+        )
+
+        call_kwargs = mock_client.list_runs.call_args[1]
+        assert call_kwargs["trace_id"] == TRACE_ID_FC
+
+    def test_follow_children_json_output_has_children_list(self, runner, mock_client):
+        """INVARIANT: JSON output with --follow-children always has a _children list with correct count."""
+        parent = create_run(id_str=PARENT_RUN_ID, trace_id=TRACE_ID_FC)
+        child1 = create_run(
+            id_str=CHILD_RUN_ID_1,
+            trace_id=TRACE_ID_FC,
+            parent_run_id=PARENT_RUN_ID,
+            name="llm-child",
+        )
+        child2 = create_run(
+            id_str=CHILD_RUN_ID_2,
+            trace_id=TRACE_ID_FC,
+            parent_run_id=PARENT_RUN_ID,
+            name="tool-child",
+        )
+        mock_client.read_run.return_value = parent
+        # SDK returns all 3 runs in trace (including root)
+        mock_client.list_runs.return_value = iter([parent, child1, child2])
+
+        result = runner.invoke(
+            cli, ["--json", "runs", "get", PARENT_RUN_ID, "--follow-children"]
+        )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "_children" in data
+        assert isinstance(data["_children"], list)
+        assert len(data["_children"]) == 2  # parent excluded, 2 children remain

--- a/tests/test_runs_get.py
+++ b/tests/test_runs_get.py
@@ -431,6 +431,21 @@ class TestRunsGetLatest:
         assert 'has(tags, "prod")' in call_kwargs["filter"]
         assert 'has(tags, "critical")' in call_kwargs["filter"]
 
+    def test_get_latest_run_type_accepted_and_forwarded(self, runner, mock_client):
+        """INVARIANT: --run-type is a valid option on get-latest and is forwarded to client.list_runs."""
+        mock_client.list_runs.return_value = iter([create_run(name="LLM Run")])
+
+        result = runner.invoke(
+            cli,
+            ["--json", "runs", "get-latest", "--project", "test", "--run-type", "llm"],
+        )
+
+        assert result.exit_code == 0, (
+            f"--run-type should be accepted. Got exit_code={result.exit_code}, output={result.output!r}"
+        )
+        call_kwargs = mock_client.list_runs.call_args[1]
+        assert call_kwargs.get("run_type") == "llm"
+
 
 class TestRunsStats:
     """Tests for runs stats command."""

--- a/tests/test_runs_get.py
+++ b/tests/test_runs_get.py
@@ -769,6 +769,33 @@ class TestRunsWatch:
         output = strip_ansi(result.output)
         assert "failed" in output.lower()
 
+    def test_watch_does_not_crash_when_run_start_time_is_none(
+        self, runner, mock_client
+    ):
+        """INVARIANT: sorting runs by start_time in watch must not crash when start_time is None.
+
+        Regression guard: the sort key previously used `item[1].start_time or ""` which
+        returns "" (a string) for None, then comparing str and datetime raises TypeError.
+        """
+        run_with_time = create_run(id_str="aaaaaaaa-0000-0000-0000-000000000010")
+        run_no_time = create_run(
+            id_str="aaaaaaaa-0000-0000-0000-000000000011"
+        ).model_copy(update={"start_time": None})
+
+        mock_client.list_projects.return_value = [create_project(name="test-proj")]
+        mock_client.list_runs.return_value = [run_with_time, run_no_time]
+
+        with patch("time.sleep") as mock_sleep:
+            mock_sleep.side_effect = KeyboardInterrupt()
+            result = runner.invoke(
+                cli,
+                ["runs", "watch", "--project", "test-proj"],
+            )
+
+        assert result.exit_code == 0, (
+            f"Watch crashed on None start_time: {result.output}"
+        )
+
 
 PARENT_RUN_ID = "aaaaaaaa-0000-0000-0000-000000000001"
 TRACE_ID_FC = "bbbbbbbb-0000-0000-0000-000000000001"
@@ -866,3 +893,36 @@ class TestFollowChildren:
         assert "_children" in data
         assert isinstance(data["_children"], list)
         assert len(data["_children"]) == 2  # parent excluded, 2 children remain
+
+    def test_follow_children_does_not_crash_when_start_time_is_none(
+        self, runner, mock_client
+    ):
+        """INVARIANT: sorting children by start_time must not crash when start_time is None.
+
+        Regression guard: the sort key previously used `r.start_time or ""` which returns ""
+        (a string) for None start_times, then mixing str and datetime in sort raises TypeError.
+        The fix uses a datetime sentinel so all keys are comparable datetime objects.
+        """
+        parent = create_run(id_str=PARENT_RUN_ID, trace_id=TRACE_ID_FC)
+        child_with_time = create_run(
+            id_str=CHILD_RUN_ID_1,
+            trace_id=TRACE_ID_FC,
+            parent_run_id=PARENT_RUN_ID,
+        )
+        child_no_time = create_run(
+            id_str=CHILD_RUN_ID_2,
+            trace_id=TRACE_ID_FC,
+            parent_run_id=PARENT_RUN_ID,
+        ).model_copy(update={"start_time": None})
+        mock_client.read_run.return_value = parent
+        mock_client.list_runs.return_value = iter(
+            [parent, child_with_time, child_no_time]
+        )
+
+        result = runner.invoke(
+            cli, ["--json", "runs", "get", PARENT_RUN_ID, "--follow-children"]
+        )
+
+        assert result.exit_code == 0, f"Command crashed: {result.output}"
+        data = json.loads(result.output)
+        assert len(data["_children"]) == 2

--- a/tests/test_runs_list.py
+++ b/tests/test_runs_list.py
@@ -716,3 +716,40 @@ class TestRunsListMetadataFilter:
         fql = call_kwargs.get("filter") or ""
         assert "env" in fql
         assert "team" in fql
+
+
+SOME_TRACE = "11111111-2222-3333-4444-555555555555"
+
+
+class TestTraceAlias:
+    """Tests for --trace as alias for --trace-id on runs list."""
+
+    def test_trace_alias_accepted_without_error(self, runner, mock_client):
+        """INVARIANT: --trace is a valid alias for --trace-id; must not produce NoSuchOption."""
+        mock_client.list_runs.return_value = iter([])
+
+        result = runner.invoke(cli, ["runs", "list", "--trace", SOME_TRACE])
+
+        assert result.exit_code == 0, (
+            f"--trace should be accepted as alias for --trace-id. "
+            f"Got exit_code={result.exit_code}, output={result.output!r}"
+        )
+
+    def test_trace_alias_passes_trace_id_to_api(self, runner, mock_client):
+        """INVARIANT: --trace value is forwarded as trace_id to client.list_runs."""
+        mock_client.list_runs.return_value = iter([create_run(name="Traced Run")])
+
+        runner.invoke(cli, ["runs", "list", "--trace", SOME_TRACE])
+
+        call_kwargs = mock_client.list_runs.call_args[1]
+        assert call_kwargs.get("trace_id") == SOME_TRACE
+
+    def test_trace_id_flag_still_works_after_alias(self, runner, mock_client):
+        """INVARIANT: --trace-id continues to work after --trace alias is added."""
+        mock_client.list_runs.return_value = iter([])
+
+        result = runner.invoke(cli, ["runs", "list", "--trace-id", SOME_TRACE])
+
+        assert result.exit_code == 0
+        call_kwargs = mock_client.list_runs.call_args[1]
+        assert call_kwargs.get("trace_id") == SOME_TRACE

--- a/tests/test_runs_usage.py
+++ b/tests/test_runs_usage.py
@@ -1744,3 +1744,60 @@ class TestUsageApplyPricingWithTiers:
         # flex pricing: 700 * 0.55/1M = 0.000385; 300 * 2.20/1M = 0.00066
         assert bucket["prompt_cost"] == pytest.approx(0.000385, rel=0.01)
         assert bucket["completion_cost"] == pytest.approx(0.00066, rel=0.01)
+
+
+class TestUsageOutputOption:
+    """Tests for runs usage --output file writing."""
+
+    def test_usage_output_writes_jsonl_to_file(self, runner, mock_client, tmp_path):
+        """INVARIANT: --output writes usage bucket results as JSONL to the specified file."""
+        runs = [_create_llm_run(1, model="gpt-4", total_tokens=500)]
+        mock_client.list_runs.return_value = runs
+        output_file = tmp_path / "usage.jsonl"
+
+        result = runner.invoke(
+            cli,
+            [
+                "--json",
+                "runs",
+                "usage",
+                "--project",
+                "test-proj",
+                "--last",
+                "24h",
+                "--output",
+                str(output_file),
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert output_file.exists(), "--output file was not created"
+        lines = [ln for ln in output_file.read_text().splitlines() if ln.strip()]
+        assert len(lines) >= 1
+        bucket = json.loads(lines[0])
+        assert "total_tokens" in bucket
+
+    def test_usage_output_option_accepted_without_error(
+        self, runner, mock_client, tmp_path
+    ):
+        """INVARIANT: --output is a recognized option for runs usage (no NoSuchOption error)."""
+        mock_client.list_runs.return_value = []
+        output_file = tmp_path / "out.jsonl"
+
+        result = runner.invoke(
+            cli,
+            [
+                "runs",
+                "usage",
+                "--project",
+                "test",
+                "--last",
+                "1h",
+                "--output",
+                str(output_file),
+            ],
+        )
+
+        assert result.exit_code == 0, (
+            f"--output should be accepted. Got exit_code={result.exit_code}, output={result.output!r}"
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,6 +42,7 @@ from langsmith_cli.utils import (
     parse_time_range,
     write_output_to_file,
 )
+from langsmith_cli.time_parsing import ensure_aware_datetime
 
 
 @dataclass
@@ -2031,3 +2032,33 @@ class TestApplyMetadataFilter:
 
         result = list(apply_metadata_filter([r1, r2], ("channel_id=Gigaverse*",)))
         assert result == [r2]
+
+
+class TestEnsureAwareDatetime:
+    """INVARIANT: ensure_aware_datetime always returns None or a timezone-aware datetime."""
+
+    def test_none_returns_none(self):
+        assert ensure_aware_datetime(None) is None
+
+    def test_aware_datetime_unchanged(self):
+        dt = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        result = ensure_aware_datetime(dt)
+        assert result == dt
+        assert result is not None and result.tzinfo is not None
+
+    def test_naive_datetime_gets_utc(self):
+        dt = datetime(2026, 1, 1, 12, 0, 0)  # no tzinfo
+        result = ensure_aware_datetime(dt)
+        assert result is not None
+        assert result.tzinfo == timezone.utc
+        assert result.year == 2026
+        assert result.hour == 12
+
+    def test_naive_and_aware_are_now_comparable(self):
+        """INVARIANT: after normalization, naive and aware datetimes must be comparable."""
+        naive = datetime(2026, 3, 9, 10, 0, 0)
+        aware = datetime(2026, 3, 9, 12, 0, 0, tzinfo=timezone.utc)
+        a = ensure_aware_datetime(naive)
+        b = ensure_aware_datetime(aware)
+        assert a is not None and b is not None
+        assert a < b  # must not raise TypeError


### PR DESCRIPTION
## Summary

### Bug fixes
- **#87 — `runs cache download --last` crash**: `CacheMetadata` had no timezone normalization on load. Added `model_validator(mode="after")` to `CacheMetadata` that normalizes both time bounds to UTC-aware at deserialization — prevents the error class-wide.
- **#88 — `runs get --follow-children` 422**: Removed `execution_order=[2, None]` kwarg forwarded to API (LangSmith rejects it with 422). Replaced with client-side ID filter: fetch all trace runs, exclude root by ID.
- **#89 — `--trace` not recognized**: Added `"--trace"` as alias for `"--trace-id"` in `runs list`.
- **Sort crash (`start_time or ""`)**:  `r.start_time or ""` crashes with `TypeError` when `start_time` is `None` because `datetime < str` is invalid. Fixed in `get_cmd.py` (follow-children sort) and `watch_cmd.py` (watch loop sort) using `datetime.min.replace(tzinfo=utc)` as sentinel.

### DRY consolidation
- Extracted `ensure_aware_datetime()` utility with `@overload` signatures to `time_parsing.py` — pyright tracks `(datetime)→datetime` overload precisely. Applied to `cache.py`, `projects.py`, `usage_cmd.py`. Removed all inline `if dt.tzinfo is None` patterns and redundant `or dt` fallbacks.

### Parameter consistency (task #7)
- `runs get-latest --run-type`: was missing from `get-latest` while present in `list` and `usage`. Now forwarded as `run_type=` to `list_runs`.
- `runs usage --output`: `list` had file-writing support but `usage` did not. Now writes bucket results as JSONL via `write_output_to_file`.

## Test plan

- [ ] `TestEnsureAwareDatetime` — None→None, aware unchanged, naive gets UTC, comparisons work
- [ ] `TestCacheMetadata` — model_validator normalizes naive, preserves aware, legacy-cache regression
- [ ] `TestFollowChildren` — no `execution_order` kwarg, root excluded, trace_id used, `_children` correct count, None start_time doesn't crash sort
- [ ] `TestTraceAlias` — `--trace` accepted, correct trace_id, `--trace-id` still works
- [ ] `TestRunsWatch` — None start_time doesn't crash sort in watch loop
- [ ] `TestUsageOutputOption` — `--output` accepted, writes JSONL to file
- [ ] `TestGetLatestRun::test_get_latest_run_type_accepted_and_forwarded` — `--run-type` accepted, forwarded as `run_type=` to API
- [ ] `uv run pytest -x -q` → 1104 passed
- [ ] `uv run pyright` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)