### PR TITLE
chore(kaizen): configure kaizen plugin for langsmith-cli

### DIFF
--- a/.agents/kaizen/local/policies-local.md
+++ b/.agents/kaizen/local/policies-local.md
@@ -1,0 +1,9 @@
+# Host-Specific Kaizen Policies
+
+These policies extend the generic kaizen policies for this project.
+Add project-specific enforcement rules here.
+
+<!-- Example:
+10. **Never install system packages on the host.** System deps go in Dockerfiles.
+11. **All dev work must be in a case with its own worktree.**
+-->

--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,8 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 .kaizen/
+# kaizen session-local state (not committed)
+.claude/review-fix/
+.claude/audit/
+.agents/kaizen/local/audit/
+.claude/worktrees/

--- a/.kaizen-hooks/pre-push
+++ b/.kaizen-hooks/pre-push
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Kaizen host-project pre-push entry (installed by /kaizen-setup, epic #1059).
+#
+# This script is written to the host project at .kaizen-hooks/pre-push
+# and invoked by whichever hook framework the host uses (pre-commit, husky,
+# lefthook, raw .git/hooks/pre-push, or kaizen's standalone .githooks/).
+#
+# At install time, ${CLAUDE_PLUGIN_ROOT} is substituted for the captured
+# plugin path. If that path becomes invalid (kaizen updated or removed),
+# the fallback searches the Claude plugin cache.
+
+set -eu
+
+# ── Agent-env gate ─────────────────────────────────────────────────────
+# Exit silently for human-driven git operations. Only AI-agent sessions
+# invoke kaizen's review gate. See epic #1059 "agent-only gating".
+if [ -z "${CLAUDECODE:-}" ] && [ -z "${CLAUDE_PROJECT_DIR:-}" ] \
+   && [ -z "${CODEX_SESSION:-}" ] && [ -z "${KAIZEN_SESSION:-}" ]; then
+  exit 0
+fi
+
+# ── Resolve kaizen plugin root ─────────────────────────────────────────
+# Primary: env var at invocation time (Claude Code sets this).
+KAIZEN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+
+# Secondary: baked-in path from install time.
+# kaizen-setup.ts substitutes /home/aviadr1/.claude/plugins/cache/kaizen/kaizen/1.0.99 with the absolute path.
+if [ ! -d "$KAIZEN_ROOT" ]; then
+  KAIZEN_ROOT="/home/aviadr1/.claude/plugins/cache/kaizen/kaizen/1.0.99"
+fi
+
+# Fallback 2: search the Claude plugin cache for kaizen.
+if [ ! -d "$KAIZEN_ROOT" ]; then
+  CACHE_ROOT="${HOME}/.claude/plugins/cache"
+  if [ -d "$CACHE_ROOT" ]; then
+    CANDIDATE=$(find "$CACHE_ROOT" -maxdepth 5 -name "plugin.json" -path "*kaizen*" 2>/dev/null | head -1 || true)
+    if [ -n "$CANDIDATE" ]; then
+      KAIZEN_ROOT=$(dirname "$(dirname "$CANDIDATE")")
+    fi
+  fi
+fi
+
+# If still not found, fail-open (do not block the push).
+if [ ! -d "$KAIZEN_ROOT" ]; then
+  echo "kaizen: plugin root not found; pre-push gate skipped" >&2
+  exit 0
+fi
+
+HOOK_TS="$KAIZEN_ROOT/src/hooks/pre-push.ts"
+if [ ! -f "$HOOK_TS" ]; then
+  echo "kaizen: hook source missing at $HOOK_TS; pre-push gate skipped" >&2
+  exit 0
+fi
+
+# ── Dispatch ───────────────────────────────────────────────────────────
+if [ -x "$KAIZEN_ROOT/node_modules/.bin/tsx" ]; then
+  exec "$KAIZEN_ROOT/node_modules/.bin/tsx" "$HOOK_TS" "$@"
+fi
+
+if command -v npx >/dev/null 2>&1; then
+  exec npx --no-install tsx "$HOOK_TS" "$@"
+fi
+
+# No tsx available — fail-open.
+echo "kaizen: tsx not found; pre-push gate skipped" >&2
+exit 0

--- a/.kaizen-hooks/pre-push
+++ b/.kaizen-hooks/pre-push
@@ -1,66 +1,29 @@
 #!/usr/bin/env bash
-# Kaizen host-project pre-push entry (installed by /kaizen-setup, epic #1059).
+# Kaizen pre-push dispatcher — thin wrapper around the kaizen plugin's entry.
 #
-# This script is written to the host project at .kaizen-hooks/pre-push
-# and invoked by whichever hook framework the host uses (pre-commit, husky,
-# lefthook, raw .git/hooks/pre-push, or kaizen's standalone .githooks/).
+# Intentionally minimal: hook logic lives in the plugin at
+#   $CLAUDE_PLUGIN_ROOT/src/hooks/kaizen-host-entry.sh
+# so bug fixes and feature updates apply on every plugin update without
+# re-running /kaizen-setup. This file only resolves the plugin root and
+# delegates — it should almost never need to change.
 #
-# At install time, ${CLAUDE_PLUGIN_ROOT} is substituted for the captured
-# plugin path. If that path becomes invalid (kaizen updated or removed),
-# the fallback searches the Claude plugin cache.
+# Discussion: https://github.com/Garsson-io/kaizen/issues/1086
 
 set -eu
 
-# ── Agent-env gate ─────────────────────────────────────────────────────
-# Exit silently for human-driven git operations. Only AI-agent sessions
-# invoke kaizen's review gate. See epic #1059 "agent-only gating".
-if [ -z "${CLAUDECODE:-}" ] && [ -z "${CLAUDE_PROJECT_DIR:-}" ] \
-   && [ -z "${CODEX_SESSION:-}" ] && [ -z "${KAIZEN_SESSION:-}" ]; then
-  exit 0
-fi
-
-# ── Resolve kaizen plugin root ─────────────────────────────────────────
-# Primary: env var at invocation time (Claude Code sets this).
+# Resolve the kaizen plugin root.
+# Primary: env var set by Claude Code at hook invocation.
+# Fallback: search the plugin cache for any installed kaizen version.
 KAIZEN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
-
-# Secondary: baked-in path from install time.
-# kaizen-setup.ts substitutes /home/aviadr1/.claude/plugins/cache/kaizen/kaizen/1.0.99 with the absolute path.
 if [ ! -d "$KAIZEN_ROOT" ]; then
-  KAIZEN_ROOT="/home/aviadr1/.claude/plugins/cache/kaizen/kaizen/1.0.99"
+  CANDIDATE=$(find "${HOME}/.claude/plugins/cache" -maxdepth 5 -name plugin.json -path '*kaizen*' 2>/dev/null | head -1 || true)
+  [ -n "$CANDIDATE" ] && KAIZEN_ROOT=$(dirname "$(dirname "$CANDIDATE")")
 fi
 
-# Fallback 2: search the Claude plugin cache for kaizen.
-if [ ! -d "$KAIZEN_ROOT" ]; then
-  CACHE_ROOT="${HOME}/.claude/plugins/cache"
-  if [ -d "$CACHE_ROOT" ]; then
-    CANDIDATE=$(find "$CACHE_ROOT" -maxdepth 5 -name "plugin.json" -path "*kaizen*" 2>/dev/null | head -1 || true)
-    if [ -n "$CANDIDATE" ]; then
-      KAIZEN_ROOT=$(dirname "$(dirname "$CANDIDATE")")
-    fi
-  fi
-fi
+# No kaizen installed — fail-open so unrelated pushes still work.
+[ -d "$KAIZEN_ROOT" ] || exit 0
 
-# If still not found, fail-open (do not block the push).
-if [ ! -d "$KAIZEN_ROOT" ]; then
-  echo "kaizen: plugin root not found; pre-push gate skipped" >&2
-  exit 0
-fi
+ENTRY="$KAIZEN_ROOT/src/hooks/kaizen-host-entry.sh"
+[ -f "$ENTRY" ] || exit 0
 
-HOOK_TS="$KAIZEN_ROOT/src/hooks/pre-push.ts"
-if [ ! -f "$HOOK_TS" ]; then
-  echo "kaizen: hook source missing at $HOOK_TS; pre-push gate skipped" >&2
-  exit 0
-fi
-
-# ── Dispatch ───────────────────────────────────────────────────────────
-if [ -x "$KAIZEN_ROOT/node_modules/.bin/tsx" ]; then
-  exec "$KAIZEN_ROOT/node_modules/.bin/tsx" "$HOOK_TS" "$@"
-fi
-
-if command -v npx >/dev/null 2>&1; then
-  exec npx --no-install tsx "$HOOK_TS" "$@"
-fi
-
-# No tsx available — fail-open.
-echo "kaizen: tsx not found; pre-push gate skipped" >&2
-exit 0
+exec bash "$ENTRY" "$@"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,10 +6,21 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.1
     hooks:
       - id: ruff
-        args: [ --fix ]
+        args:
+          - --fix
       - id: ruff-format
+  - repo: local
+    hooks:
+      - id: kaizen-pre-push
+        name: Kaizen pre-push gate
+        entry: .kaizen-hooks/pre-push
+        language: script
+        stages:
+          - pre-push
+        always_run: true
+        pass_filenames: false
+        verbose: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1005,3 +1005,51 @@ Per docs/dev/SESSION_DIRECTIVES.md:
 - Ensure `git status` is clean before commits
 - Run pre-commit hooks before committing
 - Never use `git commit --amend` or force push (per user's global CLAUDE.md)
+
+<!-- BEGIN KAIZEN PLUGIN — managed by /kaizen-setup. Do not edit this section manually. -->
+
+## Kaizen — Continuous Improvement
+
+Kaizen is installed at `$CLAUDE_PLUGIN_ROOT` (resolved per-session from the kaizen plugin cache). It provides enforcement hooks, reflection workflows, and dev workflow skills. Configuration in `kaizen.config.json`.
+
+### Kaizen Skills
+
+| Skill | When to Use |
+|-------|-------------|
+| `/kaizen-reflect` | Post-work reflection — classify impediments, file issues (Level 1→2→3) |
+| `/kaizen-pick` | Select next kaizen issue — filters claimed, balances epic momentum vs diversity |
+| `/kaizen-gaps` | Strategic analysis — tooling/testing gaps, horizon concentration, unnamed dimensions |
+| `/kaizen-deep-dive` | Autonomous deep-dive — fix root cause category behind repeated issues |
+| `/kaizen-audit-issues` | Periodic issue taxonomy audit — label coverage, epic health, incidents |
+
+### Dev work skill chain — MUST follow this workflow
+
+**Full workflow docs:** `$CLAUDE_PLUGIN_ROOT/.agents/kaizen/workflow.md`
+
+Key triggers — activate the right skill for the user's intent:
+
+- "gap analysis", "analyze gaps", "tooling gaps" → `/kaizen-gaps`
+- "make a dent", "hero mode", "deep dive" → `/kaizen-deep-dive`
+- "what's next", "pick work", "pick a kaizen" → `/kaizen-pick`
+- "look at issue #N", "evaluate this" → `/kaizen-evaluate`
+- "lets do it", "go ahead", "build it", "ship it" → `/kaizen-implement`
+
+### The Zen of Kaizen
+
+Run `/kaizen-zen` to see the full commentary (`$CLAUDE_PLUGIN_ROOT/.agents/kaizen/zen.md`).
+
+### Kaizen Policies
+
+**Generic policies:** `$CLAUDE_PLUGIN_ROOT/.agents/kaizen/policies.md` — recursive kaizen, hooks infrastructure, worktree isolation, co-commit tests, smoke tests ship with feature.
+
+**Host-specific policies:** [`.agents/kaizen/local/policies-local.md`](.agents/kaizen/local/policies-local.md) — project-specific enforcement rules.
+
+### Verification Discipline
+
+**Read `$CLAUDE_PLUGIN_ROOT/.agents/kaizen/verification.md`** before writing fixes or tests. Covers: path tracing, invariant statements, runtime artifact verification, smoke tests.
+
+### Kaizen Backlog
+
+Future work tracked as GitHub Issues. Issue taxonomy in `$CLAUDE_PLUGIN_ROOT/docs/issue-taxonomy.md`. Every issue MUST have: `kaizen` + level (`level-1`/`level-2`/`level-3`) + area label.
+
+<!-- END KAIZEN PLUGIN -->

--- a/kaizen.config.json
+++ b/kaizen.config.json
@@ -1,0 +1,29 @@
+{
+  "host": {
+    "name": "langsmith-cli",
+    "repo": "gigaverse-app/langsmith-cli",
+    "description": "Context-efficient CLI for LangSmith; also a Claude Code plugin"
+  },
+  "kaizen": {
+    "repo": "Garsson-io/kaizen",
+    "issueLabel": "kaizen"
+  },
+  "taxonomy": {
+    "levels": [
+      "level-1",
+      "level-2",
+      "level-3"
+    ],
+    "areas": [],
+    "areaPrefix": "area/",
+    "epicPrefix": "epic/",
+    "horizonPrefix": "horizon/"
+  },
+  "issues": {
+    "repo": "gigaverse-app/langsmith-cli",
+    "label": "kaizen"
+  },
+  "notifications": {
+    "channel": "none"
+  }
+}


### PR DESCRIPTION
Closes #108

## Summary

Completes Steps 1–5 of `/kaizen-setup` for this repo. Kaizen is already enabled at project scope via `.claude/settings.json` (committed in 4a97f10); this PR adds the host-project config, policies scaffold, CLAUDE.md section, and git-hook dispatcher that kaizen expects. Plan stored on the issue.

## Changes

- **`kaizen.config.json`** — host metadata (name, repo, description) + pointer to `Garsson-io/kaizen`
- **`.agents/kaizen/local/policies-local.md`** — scaffold for project-specific policies (empty, ready to fill)
- **`CLAUDE.md`** — appended kaizen plugin section. Uses `$CLAUDE_PLUGIN_ROOT` so doc links stay portable across users and kaizen updates
- **`.gitignore`** — ignore kaizen session-local state (`.claude/review-fix/`, `.claude/audit/`, `.agents/kaizen/local/audit/`, `.claude/worktrees/`)
- **`.pre-commit-config.yaml`** — add local `kaizen-pre-push` hook stage
- **`.kaizen-hooks/pre-push`** — kaizen's pre-push dispatcher script

## Activation after merge

Each collaborator activates the pre-push hook once locally:
```
uv run pre-commit install --hook-type pre-push
```

## Test Plan

- [x] `npx kaizen-setup --step verify` — 63/63 checks pass
- [x] Pre-push hook activates and runs (saw "Kaizen pre-push gate ... Passed" on this branch's push)
- [ ] After merge, pull on a second clone and confirm `/kaizen-setup --step verify` reports all green
- [ ] Open a trivial PR and confirm kaizen's PR-review loop fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)