### PR TITLE
fix(self-update): verify post-upgrade version + force fresh uv index (#119)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith-cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "A context-efficient interface for LangSmith observability and evaluations.",
   "author": {
     "name": "Aviad Rozenhek",

--- a/src/langsmith_cli/commands/self_cmd.py
+++ b/src/langsmith_cli/commands/self_cmd.py
@@ -155,11 +155,27 @@ def detect_installation() -> dict[str, str]:
     return result
 
 
+# `--refresh` is the answer to issue #119's root cause: `uv tool upgrade` reads
+# the package's available-version list from ~/.cache/uv/simple-v*/pypi/<name>.rkyv,
+# which is invalidated using HTTP cache semantics from PyPI's simple index. For
+# minutes after a new release ships, uv can resolve against a stale view and
+# silently no-op exit 0. `--refresh` forces a fresh index fetch every time, so
+# `self update` never relies on a cache that hasn't seen the new version yet.
+# Verification (`_verify_installed_version`) still guards the post-condition for
+# any *other* reason the installer might no-op.
 _UPDATE_COMMANDS: dict[str, str] = {
-    "uv tool": "uv tool upgrade langsmith-cli",
+    "uv tool": "uv tool upgrade --refresh langsmith-cli",
     "pipx": "pipx upgrade langsmith-cli",
     "pip (virtualenv)": "pip install --upgrade langsmith-cli",
     "pip (system)": "pip install --upgrade langsmith-cli",
+}
+
+
+_REMEDIATION_COMMANDS: dict[str, str] = {
+    "uv tool": "uv tool install --force langsmith-cli && hash -r",
+    "pipx": "pipx install --force langsmith-cli && hash -r",
+    "pip (virtualenv)": "pip install --upgrade --force-reinstall langsmith-cli",
+    "pip (system)": "pip install --upgrade --force-reinstall langsmith-cli",
 }
 
 
@@ -171,6 +187,45 @@ def get_update_command(install_method: str) -> str | None:
     if install_method in _UPDATE_COMMANDS:
         return _UPDATE_COMMANDS[install_method]
     return None
+
+
+def get_remediation_command(install_method: str) -> str:
+    """Return a force-reinstall fallback for when an upgrade subprocess no-ops."""
+    return _REMEDIATION_COMMANDS.get(
+        install_method, "Reinstall langsmith-cli manually."
+    )
+
+
+def _verify_installed_version() -> str | None:
+    """Read the installed CLI version by invoking the executable as a fresh subprocess.
+
+    The running Python process has the *old* install's metadata pinned on sys.path,
+    so importlib.metadata cannot see the upgraded version. A fresh subprocess loads
+    whatever is currently at the resolved executable path on disk.
+
+    Returns the parsed version string, or None if verification cannot be performed.
+    """
+    import re
+    import subprocess
+
+    exe = shutil.which("langsmith-cli")
+    if exe is None:
+        return None
+    try:
+        result = subprocess.run(
+            [exe, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    # Click's default --version output: "<prog>, version X.Y.Z" — require a
+    # digit-led token so garbage output doesn't masquerade as a version.
+    match = re.search(r"version\s+(\d\S*)", result.stdout)
+    return match.group(1) if match else None
 
 
 def check_latest_version() -> str | None:
@@ -377,23 +432,7 @@ def update(ctx: click.Context) -> None:
 
     result = subprocess.run(shlex.split(cmd), capture_output=True, text=True)
 
-    if result.returncode == 0:
-        if json_mode:
-            click.echo(
-                json_dumps(
-                    {
-                        "status": "updated",
-                        "current_version": current,
-                        "latest_version": latest,
-                        "command": cmd,
-                    }
-                )
-            )
-        else:
-            if result.stdout.strip():
-                click.echo(result.stdout.strip())
-            click.echo("Update complete.")
-    else:
+    if result.returncode != 0:
         if json_mode:
             click.echo(
                 json_dumps(
@@ -410,4 +449,67 @@ def update(ctx: click.Context) -> None:
             click.echo(f"Update failed (exit code {result.returncode}).")
             if result.stderr.strip():
                 click.echo(result.stderr.strip())
-        ctx.exit(1)
+        # See note below: sys.exit avoids the root JSON-error handler double-emitting.
+        sys.exit(1)
+
+    # Upgrade subprocess exited 0 — verify the installed version actually moved.
+    # The running process still has the *old* install pinned on sys.path, so we
+    # spawn the installed executable as a fresh subprocess to read the new version.
+    new_version = _verify_installed_version()
+    verified = new_version is not None and (
+        (latest is not None and new_version == latest)
+        or (latest is None and new_version != current)
+    )
+
+    if verified:
+        if json_mode:
+            click.echo(
+                json_dumps(
+                    {
+                        "status": "updated",
+                        "previous_version": current,
+                        "current_version": new_version,
+                        "latest_version": latest,
+                        "command": cmd,
+                    }
+                )
+            )
+        else:
+            if result.stdout.strip():
+                click.echo(result.stdout.strip())
+            click.echo(f"Update complete (v{current} -> v{new_version}).")
+        return
+
+    # Verification failed: subprocess succeeded but the installed version did
+    # not move to the expected target. This is the #119 false-success case.
+    exe_path = info["executable_path"]
+    remediation = get_remediation_command(method)
+    if json_mode:
+        click.echo(
+            json_dumps(
+                {
+                    "status": "verification_failed",
+                    "previous_version": current,
+                    "current_version": new_version,
+                    "expected_version": latest,
+                    "executable_path": exe_path,
+                    "install_method": method,
+                    "command": cmd,
+                    "remediation": remediation,
+                }
+            )
+        )
+    else:
+        observed = new_version if new_version is not None else "unknown"
+        expected = f"v{latest}" if latest else "a newer version"
+        click.echo(
+            f"Warning: '{cmd}' exited successfully but the installed CLI "
+            f"is still at v{observed} (expected {expected})."
+        )
+        click.echo(f"  Executable: {exe_path}")
+        click.echo(f"  Install method: {method}")
+        click.echo("Try the following to force a clean reinstall:")
+        click.echo(f"  {remediation}")
+    # sys.exit (SystemExit) bypasses the root group's JSON-error handler, which
+    # otherwise would append a second {"error":"Exit"...} line after our payload.
+    sys.exit(1)

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -277,10 +277,17 @@ class TestGetUpdateCommand:
     """Unit tests for get_update_command() pure function."""
 
     def test_uv_tool_returns_uv_upgrade(self):
-        """INVARIANT: uv tool installs use 'uv tool upgrade langsmith-cli'."""
+        """INVARIANT: uv tool installs use 'uv tool upgrade --refresh langsmith-cli'.
+
+        `--refresh` is required to bypass uv's simple-index cache, which was the
+        root cause behind #119: without it, uv can resolve against a stale view
+        of PyPI for minutes after a new release and silently no-op exit 0.
+        """
         from langsmith_cli.commands.self_cmd import get_update_command
 
-        assert get_update_command("uv tool") == "uv tool upgrade langsmith-cli"
+        assert (
+            get_update_command("uv tool") == "uv tool upgrade --refresh langsmith-cli"
+        )
 
     def test_pipx_returns_pipx_upgrade(self):
         """INVARIANT: pipx installs use 'pipx upgrade langsmith-cli'."""
@@ -412,6 +419,10 @@ class TestSelfUpdateCLI:
                 "langsmith_cli.commands.self_cmd.check_latest_version",
                 return_value="0.3.1",
             ),
+            patch(
+                "langsmith_cli.commands.self_cmd._verify_installed_version",
+                return_value="0.3.1",
+            ),
             patch("subprocess.run", return_value=mock_proc) as mock_run,
         ):
             result = runner.invoke(cli, ["self", "update"])
@@ -419,7 +430,10 @@ class TestSelfUpdateCLI:
         assert result.exit_code == 0
         mock_run.assert_called_once()
         cmd = mock_run.call_args[0][0]
-        assert cmd == ["uv", "tool", "upgrade", "langsmith-cli"]
+        assert cmd == ["uv", "tool", "upgrade", "--refresh", "langsmith-cli"]
+        # Lock in the #119 root-cause defense: --refresh must be present.
+        # Without it, uv's simple-index cache can silently no-op exit 0.
+        assert "--refresh" in cmd
 
     def test_update_json_output(self, runner):
         """INVARIANT: --json self update returns structured JSON with status."""
@@ -439,7 +453,8 @@ class TestSelfUpdateCLI:
         assert "current_version" in data
 
     def test_update_pypi_unreachable(self, runner):
-        """INVARIANT: When PyPI check fails, still attempts update."""
+        """INVARIANT: When PyPI is unreachable, still attempts update and treats a
+        version change as success."""
         mock_info = {
             "version": "0.1.0",
             "install_method": "uv tool",
@@ -463,11 +478,372 @@ class TestSelfUpdateCLI:
                 "langsmith_cli.commands.self_cmd.check_latest_version",
                 return_value=None,
             ),
+            patch(
+                "langsmith_cli.commands.self_cmd._verify_installed_version",
+                return_value="0.1.1",
+            ),
             patch("subprocess.run", return_value=mock_proc),
         ):
             result = runner.invoke(cli, ["self", "update"])
 
         assert result.exit_code == 0
+
+
+class TestVerifyInstalledVersion:
+    """Unit tests for _verify_installed_version()."""
+
+    def test_returns_parsed_version_from_subprocess(self):
+        """INVARIANT: Parses 'langsmith-cli, version X.Y.Z' from a fresh subprocess."""
+        from langsmith_cli.commands import self_cmd
+
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = "langsmith-cli, version 0.10.0\n"
+
+        with (
+            patch.object(
+                self_cmd.shutil,
+                "which",
+                return_value="/home/u/.local/bin/langsmith-cli",
+            ),
+            patch("subprocess.run", return_value=mock_proc) as mock_run,
+        ):
+            assert self_cmd._verify_installed_version() == "0.10.0"
+            # Must spawn the resolved executable, not the running interpreter.
+            assert mock_run.call_args[0][0] == [
+                "/home/u/.local/bin/langsmith-cli",
+                "--version",
+            ]
+
+    def test_returns_none_when_executable_not_found(self):
+        """INVARIANT: When shutil.which returns None, verification yields None."""
+        from langsmith_cli.commands import self_cmd
+
+        with patch.object(self_cmd.shutil, "which", return_value=None):
+            assert self_cmd._verify_installed_version() is None
+
+    def test_returns_none_when_subprocess_returncode_nonzero(self):
+        """INVARIANT: A non-zero exit from the version probe yields None."""
+        from langsmith_cli.commands import self_cmd
+
+        mock_proc = MagicMock()
+        mock_proc.returncode = 2
+        mock_proc.stdout = ""
+
+        with (
+            patch.object(self_cmd.shutil, "which", return_value="/bin/langsmith-cli"),
+            patch("subprocess.run", return_value=mock_proc),
+        ):
+            assert self_cmd._verify_installed_version() is None
+
+    def test_returns_none_when_subprocess_raises(self):
+        """INVARIANT: A crashing or timing-out probe yields None, not an exception."""
+        import subprocess
+
+        from langsmith_cli.commands import self_cmd
+
+        with (
+            patch.object(self_cmd.shutil, "which", return_value="/bin/langsmith-cli"),
+            patch(
+                "subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd="langsmith-cli", timeout=10),
+            ),
+        ):
+            assert self_cmd._verify_installed_version() is None
+
+    def test_returns_none_when_stdout_has_no_version(self):
+        """INVARIANT: Malformed --version stdout yields None instead of crashing."""
+        from langsmith_cli.commands import self_cmd
+
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = "no version here\n"
+
+        with (
+            patch.object(self_cmd.shutil, "which", return_value="/bin/langsmith-cli"),
+            patch("subprocess.run", return_value=mock_proc),
+        ):
+            assert self_cmd._verify_installed_version() is None
+
+
+class TestRemediationCommand:
+    """Unit tests for get_remediation_command()."""
+
+    def test_uv_tool_remediation_uses_force_install(self):
+        """INVARIANT: uv tool failure suggests 'uv tool install --force'."""
+        from langsmith_cli.commands.self_cmd import get_remediation_command
+
+        assert (
+            get_remediation_command("uv tool")
+            == "uv tool install --force langsmith-cli && hash -r"
+        )
+
+    def test_pipx_remediation_uses_force_install(self):
+        """INVARIANT: pipx failure suggests 'pipx install --force'."""
+        from langsmith_cli.commands.self_cmd import get_remediation_command
+
+        assert (
+            get_remediation_command("pipx")
+            == "pipx install --force langsmith-cli && hash -r"
+        )
+
+    def test_pip_remediation_uses_force_reinstall(self):
+        """INVARIANT: pip failure suggests '--force-reinstall'."""
+        from langsmith_cli.commands.self_cmd import get_remediation_command
+
+        assert (
+            get_remediation_command("pip (virtualenv)")
+            == "pip install --upgrade --force-reinstall langsmith-cli"
+        )
+        assert (
+            get_remediation_command("pip (system)")
+            == "pip install --upgrade --force-reinstall langsmith-cli"
+        )
+
+    def test_unknown_install_method_returns_manual_hint(self):
+        """INVARIANT: Unknown install methods return a manual-reinstall hint."""
+        from langsmith_cli.commands.self_cmd import get_remediation_command
+
+        assert "manually" in get_remediation_command("source (not installed)")
+
+
+def _mk_info(version: str = "0.9.1", method: str = "uv tool") -> dict[str, str]:
+    """Minimal detect_installation() stub for self update CliRunner tests."""
+    return {
+        "version": version,
+        "install_method": method,
+        "install_path": "/some/path",
+        "executable_path": "/home/u/.local/bin/langsmith-cli",
+        "python_path": sys.executable,
+        "python_version": "3.12.0",
+    }
+
+
+def _mk_proc(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.stdout = stdout
+    proc.stderr = stderr
+    return proc
+
+
+class TestSelfUpdateVerification:
+    """CLI integration tests for the post-upgrade verification gate (#119)."""
+
+    def test_success_when_version_moves_to_latest(self, runner):
+        """INVARIANT: Upgrade exit 0 + verify==latest → text success, exit 0."""
+        with (
+            patch(
+                "langsmith_cli.commands.self_cmd.detect_installation",
+                return_value=_mk_info("0.9.1"),
+            ),
+            patch(
+                "langsmith_cli.commands.self_cmd.check_latest_version",
+                return_value="0.10.0",
+            ),
+            patch(
+                "langsmith_cli.commands.self_cmd._verify_installed_version",
+                return_value="0.10.0",
+            ),
+            patch("subprocess.run", return_value=_mk_proc(0)),
+        ):
+            result = runner.invoke(cli, ["self", "update"])
+
+        assert result.exit_code == 0
+        assert "Update complete" in result.output
+        assert "0.9.1" in result.output and "0.10.0" in result.output
+
+    def test_success_json_includes_previous_and_current(self, runner):
+        """INVARIANT: JSON success carries previous_version + current_version."""
+        with (
+            patch(
+                "langsmith_cli.commands.self_cmd.detect_installation",
+                return_value=_mk_info("0.9.1"),
+            ),
+            patch(
+                "langsmith_cli.commands.self_cmd.check_latest_version",
+                return_value="0.10.0",
+            ),
+            patch(
+                "langsmith_cli.commands.self_cmd._verify_installed_version",
+                return_value="0.10.0",
+            ),
+            patch("subprocess.run", return_value=_mk_proc(0)),
+        ):
+            result = runner.invoke(cli, ["--json", "self", "update"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["status"] == "updated"
+        assert data["previous_version"] == "0.9.1"
+        assert data["current_version"] == "0.10.0"
+        assert data["latest_version"] == "0.10.0"
+
+    def test_failure_when_version_unchanged_text_mode(self, runner):
+        """INVARIANT: The exact #119 scenario — upgrade exit 0 but verify==previous
+        → exit 1, output names the executable, install method, and remediation."""
+        with (
+            patch(
+                "langsmith_cli.commands.self_cmd.detect_installation",
+                return_value=_mk_info("0.9.1"),
+            ),
+            patch(
+                "langsmith_cli.commands.self_cmd.check_latest_version",
+                return_value="0.10.0",
+            ),
+            patch(
+                "langsmith_cli.commands.self_cmd._verify_installed_version",
+                return_value="0.9.1",
+            ),
+            patch("subprocess.run", return_value=_mk_proc(0)),
+        ):
+            result = runner.invoke(cli, ["self", "update"])
+
+        assert result.exit_code != 0
+        assert "Update complete" not in result.output
+        assert "0.9.1" in result.output  # observed
+        assert "0.10.0" in result.output  # expected
+        assert "/home/u/.local/bin/langsmith-cli" in result.output  # exe path
+        assert "uv tool" in result.output  # install method
+        assert "uv tool install --force langsmith-cli" in result.output  # remediation
+        assert "hash -r" in result.output
+
+    def test_failure_when_version_unchanged_json_mode(self, runner):
+        """INVARIANT: JSON failure has a distinct verification_failed status with
+        the full structured payload required by the issue."""
+        with (
+            patch(
+                "langsmith_cli.commands.self_cmd.detect_installation",
+                return_value=_mk_info("0.9.1"),
+            ),
+            patch(
+                "langsmith_cli.commands.self_cmd.check_latest_version",
+                return_value="0.10.0",
+            ),
+            patch(
+                "langsmith_cli.commands.self_cmd._verify_installed_version",
+                return_value="0.9.1",
+            ),
+            patch("subprocess.run", return_value=_mk_proc(0)),
+        ):
+            result = runner.invoke(cli, ["--json", "self", "update"])
+
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["status"] == "verification_failed"
+        assert data["previous_version"] == "0.9.1"
+        assert data["current_version"] == "0.9.1"
+        assert data["expected_version"] == "0.10.0"
+        assert data["executable_path"] == "/home/u/.local/bin/langsmith-cli"
+        assert data["install_method"] == "uv tool"
+        assert data["command"] == "uv tool upgrade --refresh langsmith-cli"
+        assert data["remediation"] == (
+            "uv tool install --force langsmith-cli && hash -r"
+        )
+
+    def test_failure_when_version_cannot_be_read(self, runner):
+        """INVARIANT: If the post-upgrade executable cannot be probed at all,
+        treat as verification_failed with current_version=null."""
+        with (
+            patch(
+                "langsmith_cli.commands.self_cmd.detect_installation",
+                return_value=_mk_info("0.9.1"),
+            ),
+            patch(
+                "langsmith_cli.commands.self_cmd.check_latest_version",
+                return_value="0.10.0",
+            ),
+            patch(
+                "langsmith_cli.commands.self_cmd._verify_installed_version",
+                return_value=None,
+            ),
+            patch("subprocess.run", return_value=_mk_proc(0)),
+        ):
+            result = runner.invoke(cli, ["--json", "self", "update"])
+
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["status"] == "verification_failed"
+        assert data["current_version"] is None
+
+    def test_pypi_unreachable_with_version_change_is_success(self, runner):
+        """INVARIANT: latest=None + new_version != current → success."""
+        with (
+            patch(
+                "langsmith_cli.commands.self_cmd.detect_installation",
+                return_value=_mk_info("0.1.0"),
+            ),
+            patch(
+                "langsmith_cli.commands.self_cmd.check_latest_version",
+                return_value=None,
+            ),
+            patch(
+                "langsmith_cli.commands.self_cmd._verify_installed_version",
+                return_value="0.1.1",
+            ),
+            patch("subprocess.run", return_value=_mk_proc(0)),
+        ):
+            result = runner.invoke(cli, ["--json", "self", "update"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["status"] == "updated"
+        assert data["current_version"] == "0.1.1"
+        assert data["latest_version"] is None
+
+    def test_pypi_unreachable_with_no_version_change_is_failure(self, runner):
+        """INVARIANT: latest=None + new_version == current → verification_failed.
+        Without PyPI data we must still refuse to print success when nothing moved."""
+        with (
+            patch(
+                "langsmith_cli.commands.self_cmd.detect_installation",
+                return_value=_mk_info("0.1.0"),
+            ),
+            patch(
+                "langsmith_cli.commands.self_cmd.check_latest_version",
+                return_value=None,
+            ),
+            patch(
+                "langsmith_cli.commands.self_cmd._verify_installed_version",
+                return_value="0.1.0",
+            ),
+            patch("subprocess.run", return_value=_mk_proc(0)),
+        ):
+            result = runner.invoke(cli, ["--json", "self", "update"])
+
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["status"] == "verification_failed"
+        assert data["previous_version"] == "0.1.0"
+        assert data["current_version"] == "0.1.0"
+
+    def test_upgrade_subprocess_failure_path_unchanged(self, runner):
+        """INVARIANT: Subprocess non-zero exit still reports status=error (not
+        verification_failed). Verification is only attempted on subprocess success."""
+        with (
+            patch(
+                "langsmith_cli.commands.self_cmd.detect_installation",
+                return_value=_mk_info("0.9.1"),
+            ),
+            patch(
+                "langsmith_cli.commands.self_cmd.check_latest_version",
+                return_value="0.10.0",
+            ),
+            patch(
+                "langsmith_cli.commands.self_cmd._verify_installed_version",
+                return_value="0.10.0",  # should NOT be consulted
+            ) as mock_verify,
+            patch(
+                "subprocess.run",
+                return_value=_mk_proc(1, stderr="network error"),
+            ),
+        ):
+            result = runner.invoke(cli, ["--json", "self", "update"])
+
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["status"] == "error"
+        mock_verify.assert_not_called()
 
 
 class TestSkillCommand:


### PR DESCRIPTION
Closes #119.

## Summary

- Adds a post-condition gate to `langsmith-cli self update`. After the upgrade subprocess exits 0, the installed `langsmith-cli` executable is invoked as a fresh subprocess to read the *real* post-upgrade version. Mismatch with the expected target → exit non-zero with a structured payload.
- Passes `--refresh` to `uv tool upgrade` so uv's simple-index cache is bypassed on every self-update — eliminating the most common cause of false success.

## Root cause analysis

`uv tool upgrade` reads the available-version list from `~/.cache/uv/simple-v*/pypi/<name>.rkyv`, invalidated via HTTP cache semantics from PyPI's simple index. For minutes after a release ships, uv can resolve against a stale view, conclude "already at latest", and exit 0 — without performing the upgrade and without printing the "Updated …" line. The reproducer in #119 shows exactly that.

Verified experimentally on the bug reporter's machine:
- Running `uv tool upgrade langsmith-cli` shortly after `v0.10.0` shipped: exit 0, no upgrade.
- Running it again later: `Updated langsmith-cli v0.9.1 -> v0.10.0`, and the cached `.rkyv` file's mtime was the same instant — i.e., uv refreshed the simple-index entry on that run.

## Defense in depth

1. **Frequency reducer (`--refresh`).** Kills the cache-no-op variant before it can fire.
2. **Post-condition gate (`_verify_installed_version`).** Catches whatever the frequency reducer misses — works for any installer no-op variant, not just uv cache. The current process can't observe the upgrade via `importlib.metadata` because the old install is pinned on `sys.path`, so we spawn a fresh subprocess of the installed binary.
3. **Honest failure surface.** On verification failure, text mode prints executable path, install method, and a concrete `uv tool install --force langsmith-cli && hash -r` remediation. JSON mode emits `status: "verification_failed"` with `previous_version`, `current_version`, `expected_version`, `executable_path`, `install_method`, `command`, `remediation`. Version regex requires a digit-led token so garbage output can't masquerade as a version. The error path uses `sys.exit` (`SystemExit`) instead of `ctx.exit` (`click.Exit`) to bypass the root group's JSON-error handler — otherwise it appends a second `{"error":"Exit"}` line after the verification_failed payload.

## Acceptance criteria from #119

- [x] `self update` does not print "Update complete" unless the installed version actually changes to the expected latest version.
- [x] JSON mode includes a distinct status (`verification_failed`) for post-update verification failure.
- [x] Tests cover the case where the update subprocess succeeds but the detected version remains unchanged.
- [x] Error output includes the resolved executable path and install method.
- [x] Suggests a concrete `--force` remediation per install method.

## Test plan

- [x] `uv run pytest` — 1268/1268 pass.
- [x] `uv run pyright src/langsmith_cli/commands/self_cmd.py tests/test_self.py` — 0 errors / 0 warnings.
- [x] `uv run ruff check && uv run ruff format --check` — clean.
- [x] New tests: `TestVerifyInstalledVersion` (5 cases), `TestRemediationCommand` (4 cases), `TestSelfUpdateVerification` (8 CLI cases).
- [x] In-process CliRunner reproduction of the exact #119 scenario — exit 1 + remediation text + structured JSON.
- [ ] Post-merge: cut a patch release, install the prior version via `uv tool`, run `langsmith-cli self update`, observe honest success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)