### PR TITLE
fix(self-update): use --reinstall (uv 0.9.x rejects --refresh) (#119)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith-cli",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "A context-efficient interface for LangSmith observability and evaluations.",
   "author": {
     "name": "Aviad Rozenhek",

--- a/src/langsmith_cli/commands/self_cmd.py
+++ b/src/langsmith_cli/commands/self_cmd.py
@@ -155,16 +155,19 @@ def detect_installation() -> dict[str, str]:
     return result
 
 
-# `--refresh` is the answer to issue #119's root cause: `uv tool upgrade` reads
-# the package's available-version list from ~/.cache/uv/simple-v*/pypi/<name>.rkyv,
-# which is invalidated using HTTP cache semantics from PyPI's simple index. For
-# minutes after a new release ships, uv can resolve against a stale view and
-# silently no-op exit 0. `--refresh` forces a fresh index fetch every time, so
-# `self update` never relies on a cache that hasn't seen the new version yet.
-# Verification (`_verify_installed_version`) still guards the post-condition for
-# any *other* reason the installer might no-op.
+# `--reinstall` is the answer to issue #119's root cause: `uv tool upgrade`
+# reads the package's available-version list from
+# ~/.cache/uv/simple-v*/pypi/<name>.rkyv, invalidated via HTTP cache semantics
+# from PyPI's simple index. For minutes after a release ships, uv can resolve
+# against a stale view and silently no-op exit 0. `uv tool upgrade --reinstall`
+# implies `--refresh` (per `uv tool upgrade --help`), so the simple-index cache
+# is bypassed every time `self update` runs. The `uv tool upgrade --refresh`
+# flag does NOT exist on `uv tool upgrade` itself in uv 0.9.x — only on
+# `uv pip install` / `uv sync` — so we must use `--reinstall` here.
+# Verification (`_verify_installed_version`) still guards the post-condition
+# for any *other* reason the installer might no-op.
 _UPDATE_COMMANDS: dict[str, str] = {
-    "uv tool": "uv tool upgrade --refresh langsmith-cli",
+    "uv tool": "uv tool upgrade --reinstall langsmith-cli",
     "pipx": "pipx upgrade langsmith-cli",
     "pip (virtualenv)": "pip install --upgrade langsmith-cli",
     "pip (system)": "pip install --upgrade langsmith-cli",

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -277,16 +277,45 @@ class TestGetUpdateCommand:
     """Unit tests for get_update_command() pure function."""
 
     def test_uv_tool_returns_uv_upgrade(self):
-        """INVARIANT: uv tool installs use 'uv tool upgrade --refresh langsmith-cli'.
+        """INVARIANT: uv tool installs use 'uv tool upgrade --reinstall langsmith-cli'.
 
-        `--refresh` is required to bypass uv's simple-index cache, which was the
-        root cause behind #119: without it, uv can resolve against a stale view
-        of PyPI for minutes after a new release and silently no-op exit 0.
+        `--reinstall` is required to bypass uv's simple-index cache, which was
+        the root cause behind #119: without it, uv can resolve against a stale
+        view of PyPI for minutes after a new release and silently no-op exit 0.
+        `--reinstall` implies `--refresh` (per `uv tool upgrade --help`). The
+        bare `--refresh` flag is not a valid argument to `uv tool upgrade` in
+        uv 0.9.x — using it causes uv to error with 'unexpected argument'.
         """
         from langsmith_cli.commands.self_cmd import get_update_command
 
         assert (
-            get_update_command("uv tool") == "uv tool upgrade --refresh langsmith-cli"
+            get_update_command("uv tool") == "uv tool upgrade --reinstall langsmith-cli"
+        )
+
+    def test_uv_tool_upgrade_actually_accepts_the_flag(self):
+        """REGRESSION FROM v0.10.1: the previously-shipped `--refresh` flag is
+        rejected by `uv tool upgrade` ("unexpected argument"). This test invokes
+        the real `uv` binary with `--help` and asserts that the flag we use
+        appears in the supported-flags list. Skips silently if uv isn't installed."""
+        import shutil
+        import subprocess
+
+        uv = shutil.which("uv")
+        if uv is None:
+            import pytest
+
+            pytest.skip("uv not on PATH")
+
+        help_output = subprocess.run(
+            [uv, "tool", "upgrade", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert help_output.returncode == 0
+        assert "--reinstall" in help_output.stdout, (
+            "uv tool upgrade no longer supports --reinstall; revisit "
+            "_UPDATE_COMMANDS['uv tool'] in self_cmd.py"
         )
 
     def test_pipx_returns_pipx_upgrade(self):
@@ -430,10 +459,12 @@ class TestSelfUpdateCLI:
         assert result.exit_code == 0
         mock_run.assert_called_once()
         cmd = mock_run.call_args[0][0]
-        assert cmd == ["uv", "tool", "upgrade", "--refresh", "langsmith-cli"]
-        # Lock in the #119 root-cause defense: --refresh must be present.
+        assert cmd == ["uv", "tool", "upgrade", "--reinstall", "langsmith-cli"]
+        # Lock in the #119 root-cause defense: --reinstall must be present.
         # Without it, uv's simple-index cache can silently no-op exit 0.
-        assert "--refresh" in cmd
+        # (`--reinstall` implies `--refresh`; the bare `--refresh` flag is
+        # rejected by `uv tool upgrade` in uv 0.9.x.)
+        assert "--reinstall" in cmd
 
     def test_update_json_output(self, runner):
         """INVARIANT: --json self update returns structured JSON with status."""
@@ -736,7 +767,7 @@ class TestSelfUpdateVerification:
         assert data["expected_version"] == "0.10.0"
         assert data["executable_path"] == "/home/u/.local/bin/langsmith-cli"
         assert data["install_method"] == "uv tool"
-        assert data["command"] == "uv tool upgrade --refresh langsmith-cli"
+        assert data["command"] == "uv tool upgrade --reinstall langsmith-cli"
         assert data["remediation"] == (
             "uv tool install --force langsmith-cli && hash -r"
         )


### PR DESCRIPTION
Follow-up to #120 / refs #119.

v0.10.1 shipped `_UPDATE_COMMANDS[\"uv tool\"]` as \`uv tool upgrade --refresh langsmith-cli\`, but uv 0.9.x rejects \`--refresh\` on \`uv tool upgrade\`:

\`\`\`console
$ uv tool upgrade --refresh langsmith-cli
error: unexpected argument '--refresh' found
  tip: a similar argument exists: '--prerelease'
\`\`\`

The previous PR misread the help text — those \"--refresh\" mentions were only describing what \`--reinstall\` *implies*. Only \`--reinstall\` is accepted on \`uv tool upgrade\`, and it implies \`--refresh\` (per the official help), so it correctly bypasses the simple-index cache.

## What changes
- \`_UPDATE_COMMANDS[\"uv tool\"]\` → \`uv tool upgrade --reinstall langsmith-cli\`.
- Existing \`--refresh\` test invariants updated to \`--reinstall\`.
- New regression test \`test_uv_tool_upgrade_actually_accepts_the_flag\` shells out to the real \`uv tool upgrade --help\` and asserts the flag appears in the supported-flag list. If a future uv release renames or removes the flag, CI fails immediately.

## Behavior on v0.10.1 (the bug being fixed here)
Without this hotfix, on any environment with a stale uv simple-index cache (i.e. the exact #119 condition), \`self update\` exits non-zero with stderr \"unexpected argument '--refresh'\". The verification gate from #120 still prevents *false success*, but the user experience regresses to \"every update appears broken\" until the cache TTL expires.

## Test plan
- [x] uv run pytest — 1269/1269 pass (one more than v0.10.1: the new regression test).
- [x] pyright clean. ruff clean.
- [x] Hand-verified on the host that triggered #119: \`uv tool upgrade --reinstall langsmith-cli\` upgrades 0.10.0 → 0.10.1 with exit 0.
- [ ] Post-merge: cut v0.10.2 and verify \`self update\` from 0.10.1 → 0.10.2 prints honest \`Update complete\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)