### PR TITLE
Add organization-managed S3 trace archival and DuckDB queries

### DIFF
--- a/docs/TRACE_ARCHIVE_DESIGN.md
+++ b/docs/TRACE_ARCHIVE_DESIGN.md
@@ -1,0 +1,167 @@
+# LangSmith Trace Archive Design
+
+## Purpose
+
+`langsmith-cli` provides an organization-operated mechanism for retaining LangSmith
+traces in private object storage and querying them after LangSmith retention expires.
+The organization owns the scheduler, LangSmith credentials, AWS identity, buckets,
+encryption, lifecycle rules, and retention policy. The CLI owns only the protocol:
+export, reconcile, verify, canonicalize, publish manifests, and query Parquet.
+
+## Lifecycle
+
+For a UTC trace date `D` and 14-day LangSmith retention:
+
+```text
+D+2   primary snapshot of [D, D+1)
+D+12  reconciliation snapshot of the same window
+D+14  LangSmith retention expires the source traces
+```
+
+The second snapshot deliberately overlaps the first. Late children and updated runs
+make a delta-only export unsafe without a reliable modification watermark.
+
+An organization-owned daily job invokes:
+
+```bash
+LANGSMITH_ARCHIVE_URI=s3://gigaverse-langsmith-traces-prd/langsmith \
+  langsmith-cli --json archive sync --project prd/my-agent --retention-days 14
+```
+
+Each invocation calculates both due windows. Completed phases are skipped, known
+in-flight jobs are resumed, and failures are safe to retry.
+
+## Project routing
+
+Archive destinations are selected by ordered, named project routes:
+
+```yaml
+routes:
+  - name: dev
+    project_pattern: "dev/**"
+    archive_uri: s3://gigaverse-langsmith-traces-dev/langsmith
+  - name: staging
+    project_pattern: "stg/**"
+    archive_uri: s3://gigaverse-langsmith-traces-stg/langsmith
+  - name: production
+    project_pattern: "prd/**"
+    archive_uri: s3://gigaverse-langsmith-traces-prd/langsmith
+```
+
+One config may describe every environment. The safer deployment uses one CronJob per
+route (`archive sync --route dev`) and gives that workload access only to its bucket.
+An explicitly authorized central job may use `--all-routes`, resolving the project
+catalog once and dispatching each project to its route.
+
+A project must match exactly one route. Multiple matches are a configuration error;
+unmatched projects are reported and never fall back to another bucket. Route names
+are configuration identifiers represented internally by typed models; archive phase
+and state decisions use Enums.
+
+## Storage model
+
+```text
+<archive-uri>/
+  raw/project_id=<uuid>/date=YYYY-MM-DD/phase=primary/generation=<uuid>/runs.parquet
+  raw/project_id=<uuid>/date=YYYY-MM-DD/phase=reconciliation/generation=<uuid>/runs.parquet
+  canonical/project_id=<uuid>/date=YYYY-MM-DD/generation=<uuid>/runs.parquet
+  manifests/project_id=<uuid>/date=YYYY-MM-DD.json
+```
+
+Raw generations are immutable. A canonical generation is also immutable; the
+manifest is the publication pointer and is written last. Readers never glob all
+canonical generations. They resolve manifests and read only their referenced keys.
+
+Arbitrary SDK `bytes` values are preserved as tagged base64 objects with
+`__langsmith_archive_encoding__ = "base64"`. Lazy SDK serialization iterators are
+materialized at the JSON-to-Parquet boundary. This keeps non-UTF-8 media payloads
+without weakening UTF-8 validation for the surrounding trace document.
+
+The bucket owner may expire `raw/` after a repair/audit window. Canonical objects and
+manifests are retained according to the organization's policy.
+
+## Deduplication
+
+Canonicalization unions the primary and reconciliation snapshots using DuckDB and
+selects one row per stable `run.id`. Reconciliation has higher precedence. A run
+missing from reconciliation is retained from primary; a new late run is added; an
+updated run is replaced by its reconciliation representation.
+
+```sql
+SELECT * EXCLUDE (snapshot_rank, archive_row_number)
+FROM (
+  SELECT *, row_number() OVER (
+    PARTITION BY id ORDER BY snapshot_rank DESC
+  ) AS archive_row_number
+  FROM (
+    SELECT *, 1 AS snapshot_rank FROM read_parquet(primary)
+    UNION ALL BY NAME
+    SELECT *, 2 AS snapshot_rank FROM read_parquet(reconciliation)
+  ) snapshots
+)
+WHERE archive_row_number = 1
+```
+
+Each snapshot must independently satisfy `count(*) = count(DISTINCT id)`. A
+duplicate within one provider snapshot is a verification failure, not something to
+hide during compaction.
+
+## Idempotency and crash recovery
+
+The logical operation key is `(archive, project_id, UTC date, phase, schema_version)`.
+A phase transitions through `pending`, `exporting`, `exported`, and `verified`.
+The manifest records provider job/generation identifiers, object keys, counts, and
+errors. A verified phase is never exported again unless an operator explicitly asks
+for repair.
+
+Cross-service exactly-once behavior is impossible if a process dies after creating a
+remote export but before persisting its ID. The design therefore guarantees
+at-least-once raw attempts and exactly-once canonical rows. Orphan raw attempts can be
+adopted or removed by lifecycle policy.
+
+## Query architecture
+
+Read-only run commands create a typed query and select one backend:
+
+```text
+command options -> RunQuery -> LangSmith backend | DuckDB archive backend
+                              -> shared result/view layer
+```
+
+`--archive` is a boolean source selector. A single `LANGSMITH_ARCHIVE_URI` or a route
+configuration supplies the archive location. For a configured project path, the
+reader resolves exactly one destination; cross-route project patterns query each
+matching archive and merge results. Archive readers need AWS read permissions but no
+LangSmith key.
+Unsupported live-only filters fail explicitly rather than silently changing meaning.
+
+The initial parity surface is `runs list`, `runs search`, `runs get`, and
+`runs get-latest`; run-derived discovery and analysis commands follow the same
+backend contract. `runs watch`, `runs open`, and mutations remain live-only.
+
+## Efficiency
+
+- Work is bounded to a project-day partition and performed twice during retention.
+- DuckDB reads and writes compressed Parquet and applies project/date pruning.
+- Canonicalization can operate directly on S3 through DuckDB's credential-chain
+  secret; no full historical archive is downloaded.
+- Large partitions may be sharded by `hash(run.id) % N` without changing manifests.
+- Queries project requested columns and use Parquet predicate pushdown.
+- Raw duplicates are temporary and can be expired after reconciliation is sealed.
+
+## Security
+
+- Buckets use Block Public Access, Bucket Owner Enforced ownership, encryption,
+  versioning, and a deny-non-TLS bucket policy.
+- An environment-specific archiver role receives prefix-scoped list/read/write and
+  multipart permissions. Reader roles receive only prefix-scoped list/read.
+- Dev, staging, and production use separate buckets and roles without cross-grants.
+- Secrets come from the runtime environment/default AWS credential chain and are
+  never written to manifests, Parquet, configuration, or logs.
+
+## Provider boundary
+
+The portable provider pages through `Client.list_runs` for an exact half-open UTC
+window and writes Parquet itself. An optional LangSmith Bulk Export provider may use
+an organization-created destination ID. Scheduling, manifests, verification,
+canonicalization, and querying are provider-independent.

--- a/docs/TRACE_ARCHIVE_DESIGN.md
+++ b/docs/TRACE_ARCHIVE_DESIGN.md
@@ -21,6 +21,12 @@ D+14  LangSmith retention expires the source traces
 The second snapshot deliberately overlaps the first. Late children and updated runs
 make a delta-only export unsafe without a reliable modification watermark.
 
+When an organization first enables the archive, the D+12 day may have no historical
+D+2 snapshot. In that bootstrap case, the reconciliation export is still a complete
+snapshot of `[D, D+1)` and is published alone as a sealed canonical generation. This
+captures the oldest still-retained data immediately; steady-state days contain both
+snapshots.
+
 An organization-owned daily job invokes:
 
 ```bash
@@ -62,6 +68,7 @@ and state decisions use Enums.
 
 ```text
 <archive-uri>/
+  projects/project_id=<uuid>.json
   raw/project_id=<uuid>/date=YYYY-MM-DD/phase=primary/generation=<uuid>/runs.parquet
   raw/project_id=<uuid>/date=YYYY-MM-DD/phase=reconciliation/generation=<uuid>/runs.parquet
   canonical/project_id=<uuid>/date=YYYY-MM-DD/generation=<uuid>/runs.parquet
@@ -71,6 +78,16 @@ and state decisions use Enums.
 Raw generations are immutable. A canonical generation is also immutable; the
 manifest is the publication pointer and is written last. Readers never glob all
 canonical generations. They resolve manifests and read only their referenced keys.
+
+Project catalog entries are immutable `(project_id, project_name)` identities within
+one route. They let readers resolve a project once and list only
+`manifests/project_id=<uuid>/...`; exact-project queries do not GET every manifest in
+the bucket. A project rename or move across routes is an explicit migration rather
+than a silent archive split.
+
+Catalog backfill is incremental and backward-compatible. Readers combine cataloged
+project prefixes with any manifest project IDs not yet present in the catalog, so a
+deployment cannot hide older data while an idempotent sync populates catalog entries.
 
 Arbitrary SDK `bytes` values are preserved as tagged base64 objects with
 `__langsmith_archive_encoding__ = "base64"`. Lazy SDK serialization iterators are
@@ -109,15 +126,50 @@ hide during compaction.
 ## Idempotency and crash recovery
 
 The logical operation key is `(archive, project_id, UTC date, phase, schema_version)`.
-A phase transitions through `pending`, `exporting`, `exported`, and `verified`.
-The manifest records provider job/generation identifiers, object keys, counts, and
-errors. A verified phase is never exported again unless an operator explicitly asks
-for repair.
+A phase is published only after its raw object and new canonical object are verified.
+The manifest records generation identifiers, object keys, counts, and timestamps. A
+verified phase is never exported again unless a future explicit repair workflow is
+used.
 
 Cross-service exactly-once behavior is impossible if a process dies after creating a
 remote export but before persisting its ID. The design therefore guarantees
 at-least-once raw attempts and exactly-once canonical rows. Orphan raw attempts can be
 adopted or removed by lifecycle policy.
+
+The mutable manifest pointer is updated with compare-and-swap: `If-None-Match: *` for
+its first S3 publication and `If-Match: <observed-etag>` thereafter. Local archives
+use the same expected-content-version rule under a cross-process file lock. A stale
+worker fails with a typed concurrency error and may leave only immutable orphan
+objects; it cannot overwrite the winning manifest.
+
+```text
+worker A: read v1 ─ export raw A ─ canonical A ─ CAS(v1) ──► v2 published
+worker B: read v1 ─ export raw B ─ canonical B ─ CAS(v1) ──► CONFLICT
+                                                        (v2 remains visible)
+```
+
+## Enforced invariants
+
+| Invariant | Enforcement point | Failure behavior |
+|---|---|---|
+| One project matches exactly one route | Config routing | Unmatched/ambiguous explicit projects fail; catalog scans report unmatched projects |
+| Project identity is immutable inside a route | `projects/project_id=<uuid>.json` create/verify | Rename or route move requires explicit migration |
+| A manifest is exactly one UTC day | Manifest construction and deserialization | Non-UTC or non-24-hour windows fail before query/publication |
+| Object keys are normalized and namespace-bound | Store key validation plus manifest model | Absolute, traversal, wrong project/date/phase, and malformed generation keys fail |
+| Snapshot run IDs are unique | DuckDB validation before canonicalization | No manifest is published; uploaded raw attempt remains an expirable orphan |
+| Canonical run IDs are unique | Validation of the written canonical Parquet | No manifest is published |
+| Canonical count is between the largest input and their sum | Manifest publication/read boundary | Truncated or inflated manifests fail closed |
+| Reconciliation wins duplicate IDs | Canonical `row_number` rank | Updated D+12 rows replace D+2; primary-only and late rows are retained |
+| A sealed day cannot regress | Phase idempotency plus sealed-state validation | Repeated phase calls return the published manifest without exporting |
+| Only one concurrent publisher wins | S3 ETag/local locked CAS | Stale writer receives a concurrency error; winning pointer is preserved |
+| Readers use only published canonical keys | Manifest-directed discovery | Raw/orphan/unreferenced canonical generations are invisible |
+| Empty project-days return zero | Zero-count manifest pruning | DuckDB is not asked to union an empty partial schema |
+| Text-search SQL identifiers are fixed | `ArchiveRunQuery` field allowlist | Unsupported `--grep-in` fields fail before SQL construction |
+
+These invariants are executable contracts, not documentation only. Unit tests cover
+corrupt manifests, duplicate IDs, stale and simultaneous writers, sealed retries,
+empty partitions, unsafe text fields, route pruning, and Windows paths. CLI tests
+cover scheduled D+2/D+12 routing, explicit-project failures, and status output.
 
 ## Query architecture
 
@@ -143,8 +195,12 @@ backend contract. `runs watch`, `runs open`, and mutations remain live-only.
 
 - Work is bounded to a project-day partition and performed twice during retention.
 - DuckDB reads and writes compressed Parquet and applies project/date pruning.
+- Project catalog entries reduce exact-project discovery from every manifest GET to
+  one small catalog scan plus that project's manifest prefix.
 - Canonicalization can operate directly on S3 through DuckDB's credential-chain
   secret; no full historical archive is downloaded.
+- Canonical output is counted and uniqueness-checked from the newly written local
+  Parquet file; the remote reconciliation union/window query runs only once.
 - Large partitions may be sharded by `hash(run.id) % N` without changing manifests.
 - Queries project requested columns and use Parquet predicate pushdown.
 - Raw duplicates are temporary and can be expired after reconciliation is sealed.

--- a/examples/archive/gigaverse.yaml
+++ b/examples/archive/gigaverse.yaml
@@ -1,0 +1,10 @@
+routes:
+  - name: dev
+    project_pattern: "dev/**"
+    archive_uri: s3://gigaverse-langsmith-traces-dev/langsmith
+  - name: staging
+    project_pattern: "stg/**"
+    archive_uri: s3://gigaverse-langsmith-traces-stg/langsmith
+  - name: production
+    project_pattern: "prd/**"
+    archive_uri: s3://gigaverse-langsmith-traces-prd/langsmith

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,9 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
+    "boto3>=1.35.0",
     "click>=8.0",
+    "duckdb>=1.4.0",
     "langdetect>=1.0.9",
     "langsmith>=0.8.5",
     "platformdirs>=4.0",

--- a/skills/langsmith/SKILL.md
+++ b/skills/langsmith/SKILL.md
@@ -99,6 +99,9 @@ langsmith-cli --json runs get <id> --fields inputs,outputs,error
 | Server-side search | `langsmith-cli --json runs search "pattern" --fields id,name,status --limit 20` |
 | Scoped content search | `langsmith-cli --json runs search "pattern" --in outputs --fields id,name,outputs --limit 20` |
 | Search cached runs | `langsmith-cli --json runs cache grep "pattern" -E --grep-in outputs --project <name> --fields id,name,outputs` |
+| Search S3 archive | `langsmith-cli --json runs search "pattern" --archive --project <name> --fields id,name,status` |
+| Sync trace archive | `langsmith-cli --json archive sync --route <name>` |
+| Check archive status | `langsmith-cli --json archive status --all-routes` |
 | Download cache | `langsmith-cli --json runs cache download --project <name> --last 7d` |
 | List cache | `langsmith-cli --json runs cache list --fields project_name,run_count,path` |
 | Discover cache schema | `langsmith-cli --json runs cache schema --project <name> --include outputs` |
@@ -127,6 +130,11 @@ When your task matches one of the sections below, **you MUST load that reference
 - You need to use `--trace-filter`, `--tree-filter`, `--sort-by`, `--roots`, `--run-type`, `--tag`, `--model`, `--min-latency`, `--max-latency`
 - You need to filter runs by metadata: `--metadata key=value` (supports wildcards `key=val*` and regex `key=/pattern/`)
 - You need to paginate, export to files, or watch live runs
+
+### → Read [references/archive.md](references/archive.md) when:
+- You need to configure project-to-S3 routing such as `dev/**` and `stg/**`
+- You need to operate D+2 primary and D+12 reconciliation exports
+- You need to query retained Parquet with `--archive` and DuckDB
 
 ### → Read [references/search.md](references/search.md) when:
 - You need to choose between `--query` (server-side, fast, first 250 chars) vs `--grep` (client-side, all content, regex)

--- a/skills/langsmith/references/archive.md
+++ b/skills/langsmith/references/archive.md
@@ -42,6 +42,14 @@ Prefer one CronJob per route so its AWS role can access only that environment's
 bucket. Use `--all-routes` only for a central role intentionally authorized for all
 destinations.
 
+On first deployment, a due D+12 day may not have a D+2 object. The CLI publishes
+that complete reconciliation snapshot alone and seals the day, preserving the oldest
+data still available. Later days follow the normal two-snapshot flow.
+
+Overlapping jobs are safe: immutable data uploads happen before an ETag-conditional
+manifest update. Exactly one writer publishes; stale writers fail and are safe to
+retry. Do not add an external distributed lock around the CronJob.
+
 List manifests:
 
 ```bash
@@ -65,5 +73,13 @@ search, sorting, field projection, counts, and output formats. Raw FQL, trace/tr
 FQL, metadata predicates, and latency flags fail explicitly until translated to the
 typed DuckDB query model.
 
+Name/regex/exclude filters currently run after the DuckDB query. Use `--fetch N` to
+control how many archived rows they evaluate; `--count` evaluates the full matching
+archive before applying those local filters.
+
 See `docs/TRACE_ARCHIVE_DESIGN.md` for storage layout, reconciliation,
 deduplication, crash recovery, IAM boundaries, and efficiency decisions.
+
+Project names are immutable archive identities. If a LangSmith project is renamed or
+moved from one route to another, migrate its catalog/manifests explicitly; the sync
+fails rather than silently splitting history across destinations.

--- a/skills/langsmith/references/archive.md
+++ b/skills/langsmith/references/archive.md
@@ -1,0 +1,69 @@
+# S3 Trace Archive
+
+The archive is organization-operated. `langsmith-cli` does not own a LangSmith key,
+AWS credentials, scheduler, or bucket. Supply credentials through the runtime
+environment and AWS default credential chain.
+
+## Route configuration
+
+```yaml
+routes:
+  - name: dev
+    project_pattern: "dev/**"
+    archive_uri: s3://gigaverse-langsmith-traces-dev/langsmith
+  - name: staging
+    project_pattern: "stg/**"
+    archive_uri: s3://gigaverse-langsmith-traces-stg/langsmith
+  - name: production
+    project_pattern: "prd/**"
+    archive_uri: s3://gigaverse-langsmith-traces-prd/langsmith
+```
+
+Set `LANGSMITH_ARCHIVE_CONFIG=/path/archive.yaml`, or pass `--config`. Projects must
+match exactly one route. Overlapping and unmatched routes fail fast.
+
+For a single archive, set `LANGSMITH_ARCHIVE_URI=s3://bucket/prefix` without a config.
+
+## Scheduled sync
+
+With 14-day LangSmith retention, each daily invocation exports the UTC day at D+2
+and reconciles it at D+12:
+
+```bash
+langsmith-cli --json archive sync --route dev --retention-days 14
+langsmith-cli --json archive sync --all-routes --retention-days 14
+
+# One exact repair/experiment window
+langsmith-cli --json archive sync --route dev \
+  --date 2026-08-19 --phase primary
+```
+
+Prefer one CronJob per route so its AWS role can access only that environment's
+bucket. Use `--all-routes` only for a central role intentionally authorized for all
+destinations.
+
+List manifests:
+
+```bash
+langsmith-cli --json archive status --route dev
+langsmith-cli --json archive status --all-routes
+```
+
+## Archive queries
+
+```bash
+langsmith-cli --json runs list --archive --project dev/my-agent --last 90d
+langsmith-cli --json runs search "timeout" --archive --project dev/my-agent
+langsmith-cli --json runs get <id> --archive --follow-children
+langsmith-cli --json runs get-latest --archive --project dev/my-agent --failed
+```
+
+Archive readers do not need `LANGSMITH_API_KEY`. They need read/list access to the
+configured archive. `--archive` currently supports project selectors, time windows,
+status, trace ID, root selection, run type, tags, model text, full-content text/regex
+search, sorting, field projection, counts, and output formats. Raw FQL, trace/tree
+FQL, metadata predicates, and latency flags fail explicitly until translated to the
+typed DuckDB query model.
+
+See `docs/TRACE_ARCHIVE_DESIGN.md` for storage layout, reconciliation,
+deduplication, crash recovery, IAM boundaries, and efficiency decisions.

--- a/skills/langsmith/references/runs.md
+++ b/skills/langsmith/references/runs.md
@@ -9,6 +9,7 @@ langsmith-cli --json runs list [OPTIONS]
 ```
 
 **Options:**
+- `--archive` - Query the configured canonical Parquet archive instead of LangSmith
 - `--project TEXT` - Project name (default: "default")
 - `--project-id TEXT` - Project UUID (bypasses name resolution, fastest lookup)
 - `--project-name TEXT` - Substring/contains match for project names
@@ -105,6 +106,7 @@ langsmith-cli --json runs get <run-id> [OPTIONS]
 - `run-id` (required) - Run UUID or trace ID
 
 **Options:**
+- `--archive` - Read the run and optional children from canonical Parquet
 - `--fields TEXT` - Comma-separated list of fields to return (critical for context efficiency)
 
 **Available Fields:**
@@ -189,6 +191,7 @@ langsmith-cli --json runs get-latest [OPTIONS]
 ```
 
 **Options:**
+- `--archive` - Query the latest archived run instead of LangSmith
 - `--project TEXT` - Project name (default: "default")
 - `--project-id TEXT` - Project UUID
 - `--project-name TEXT` - Substring match for project names
@@ -238,6 +241,7 @@ langsmith-cli --json runs search <query> [OPTIONS]
 - `query` (required) - Search query string
 
 **Options:**
+- `--archive` - Search complete archived inputs/outputs/errors through DuckDB
 - `--project TEXT` - Project name (default: "default")
 - `--project-id TEXT` - Project UUID
 - `--project-name TEXT` - Substring match for project names

--- a/src/langsmith_cli/archive/__init__.py
+++ b/src/langsmith_cli/archive/__init__.py
@@ -1,0 +1,1 @@
+"""Organization-managed LangSmith trace archives."""

--- a/src/langsmith_cli/archive/config.py
+++ b/src/langsmith_cli/archive/config.py
@@ -1,0 +1,123 @@
+"""Archive route configuration and strict project matching."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fnmatch import fnmatchcase
+import os
+from pathlib import Path
+from typing import TypedDict
+
+
+class RouteConfigDict(TypedDict):
+    name: str
+    project_pattern: str
+    archive_uri: str
+
+
+class ArchiveConfigDict(TypedDict):
+    routes: list[RouteConfigDict]
+
+
+class ArchiveRouteError(ValueError):
+    """Base class for deterministic archive routing failures."""
+
+
+class UnknownRouteError(ArchiveRouteError):
+    """A selected route name does not exist exactly once."""
+
+
+class UnmatchedProjectError(ArchiveRouteError):
+    """A project is not covered by archive configuration."""
+
+
+class AmbiguousProjectRouteError(ArchiveRouteError):
+    """A project is covered by multiple archive routes."""
+
+
+@dataclass(frozen=True)
+class ArchiveRoute:
+    name: str
+    project_pattern: str
+    archive_uri: str
+
+    def matches(self, project_name: str) -> bool:
+        return fnmatchcase(project_name, self.project_pattern)
+
+
+@dataclass(frozen=True)
+class ArchiveConfig:
+    routes: tuple[ArchiveRoute, ...]
+
+    def route_named(self, name: str) -> ArchiveRoute:
+        matches = [route for route in self.routes if route.name == name]
+        if len(matches) != 1:
+            raise UnknownRouteError(f"Archive route must exist exactly once: {name}")
+        return matches[0]
+
+    def route_project(self, project_name: str) -> ArchiveRoute:
+        matches = [route for route in self.routes if route.matches(project_name)]
+        if not matches:
+            raise UnmatchedProjectError(
+                f"No archive route matches project: {project_name}"
+            )
+        if len(matches) > 1:
+            names = ", ".join(route.name for route in matches)
+            raise AmbiguousProjectRouteError(
+                f"Project matches multiple archive routes: {project_name} ({names})"
+            )
+        return matches[0]
+
+
+def load_archive_config(path: str | None = None) -> ArchiveConfig:
+    """Load non-secret route configuration or the single-URI environment shortcut."""
+    resolved_path = path or os.environ.get("LANGSMITH_ARCHIVE_CONFIG")
+    if resolved_path is None:
+        archive_uri = os.environ.get("LANGSMITH_ARCHIVE_URI")
+        if archive_uri is None:
+            raise ValueError("Set LANGSMITH_ARCHIVE_URI or LANGSMITH_ARCHIVE_CONFIG")
+        return ArchiveConfig(
+            routes=(
+                ArchiveRoute(
+                    name="default", project_pattern="**", archive_uri=archive_uri
+                ),
+            )
+        )
+
+    import yaml
+
+    loaded: object = yaml.safe_load(Path(resolved_path).read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict) or "routes" not in loaded:
+        raise ValueError("Archive config must contain a routes list")
+    raw_routes: object = loaded["routes"]
+    if not isinstance(raw_routes, list):
+        raise ValueError("Archive config routes must be a list")
+
+    routes: list[ArchiveRoute] = []
+    for raw_route in raw_routes:
+        if not isinstance(raw_route, dict):
+            raise ValueError("Each archive route must be an object")
+        required = {"name", "project_pattern", "archive_uri"}
+        if set(raw_route) != required:
+            raise ValueError(
+                "Each archive route requires only name, project_pattern, archive_uri"
+            )
+        name = raw_route["name"]
+        project_pattern = raw_route["project_pattern"]
+        archive_uri = raw_route["archive_uri"]
+        if not all(
+            isinstance(value, str) for value in (name, project_pattern, archive_uri)
+        ):
+            raise ValueError("Archive route fields must be strings")
+        routes.append(
+            ArchiveRoute(
+                name=name,
+                project_pattern=project_pattern,
+                archive_uri=archive_uri,
+            )
+        )
+    if not routes:
+        raise ValueError("Archive config must contain at least one route")
+    if len({route.name for route in routes}) != len(routes):
+        raise ValueError("Archive route names must be unique")
+    return ArchiveConfig(routes=tuple(routes))

--- a/src/langsmith_cli/archive/duckdb.py
+++ b/src/langsmith_cli/archive/duckdb.py
@@ -1,0 +1,21 @@
+"""Shared DuckDB setup for local and S3-backed archive operations."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class DuckConnection(Protocol):
+    def execute(self, query: str, parameters: object | None = None) -> Any: ...
+
+
+def configure_duckdb_s3(connection: DuckConnection, uris: list[str]) -> None:
+    """Use the workload's AWS credential chain only when an S3 URI is present."""
+    if not any(uri.startswith("s3://") for uri in uris):
+        return
+    # DuckDB loads httpfs on first S3 access. This secret delegates authentication
+    # to the same short-lived workload identity used by boto3; no key is persisted.
+    connection.execute(
+        "CREATE OR REPLACE SECRET langsmith_archive_s3 "
+        "(TYPE s3, PROVIDER credential_chain)"
+    )

--- a/src/langsmith_cli/archive/models.py
+++ b/src/langsmith_cli/archive/models.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date, datetime, time, timedelta, timezone
 from enum import Enum
+from pathlib import PurePosixPath
 from typing import NotRequired, TypedDict
+from uuid import UUID
 
 
 class ArchivePhase(str, Enum):
@@ -44,6 +46,45 @@ class ArchiveManifestDict(TypedDict):
     updated_at: str
 
 
+class ArchiveProjectDict(TypedDict):
+    schema_version: int
+    project_id: str
+    project_name: str
+
+
+@dataclass(frozen=True)
+class ArchiveProject:
+    """Stable route-local catalog entry used to prune manifest discovery."""
+
+    schema_version: int
+    project_id: str
+    project_name: str
+
+    def __post_init__(self) -> None:
+        if self.schema_version != 1:
+            raise ValueError(
+                f"Unsupported archive project schema version: {self.schema_version}"
+            )
+        _require_uuid(self.project_id, "archive project_id")
+        if not self.project_name:
+            raise ValueError("Archive project_name must not be empty")
+
+    def to_dict(self) -> ArchiveProjectDict:
+        return {
+            "schema_version": self.schema_version,
+            "project_id": self.project_id,
+            "project_name": self.project_name,
+        }
+
+    @classmethod
+    def from_dict(cls, data: ArchiveProjectDict) -> ArchiveProject:
+        return cls(
+            schema_version=data["schema_version"],
+            project_id=data["project_id"],
+            project_name=data["project_name"],
+        )
+
+
 @dataclass(frozen=True)
 class PhaseRecord:
     status: PhaseStatus
@@ -52,6 +93,13 @@ class PhaseRecord:
     run_count: int
     verified_at: datetime
     error: str | None = None
+
+    def __post_init__(self) -> None:
+        _require_uuid(self.generation_id, "phase generation_id")
+        _require_relative_object_key(self.raw_key, "phase raw_key")
+        if self.run_count < 0:
+            raise ValueError("Phase run_count must be non-negative")
+        _require_aware_datetime(self.verified_at, "phase verified_at")
 
     def to_dict(self) -> PhaseRecordDict:
         data: PhaseRecordDict = {
@@ -91,6 +139,92 @@ class ArchiveManifest:
     canonical_run_count: int
     sealed: bool
     updated_at: datetime
+
+    def __post_init__(self) -> None:
+        """Enforce structural invariants for both working and published manifests."""
+        if self.schema_version != 1:
+            raise ValueError(
+                f"Unsupported archive schema version: {self.schema_version}"
+            )
+        _require_uuid(self.project_id, "manifest project_id")
+        if not self.project_name:
+            raise ValueError("Manifest project_name must not be empty")
+
+        expected_start = datetime.combine(
+            self.trace_date, time.min, tzinfo=timezone.utc
+        )
+        expected_end = expected_start + timedelta(days=1)
+        if self.window_start != expected_start or self.window_end != expected_end:
+            raise ValueError("Manifest window must be exactly its UTC trace day")
+        _require_aware_datetime(self.updated_at, "manifest updated_at")
+        if self.canonical_run_count < 0:
+            raise ValueError("Manifest canonical_run_count must be non-negative")
+
+        self._validate_phase_key(ArchivePhase.PRIMARY, self.primary)
+        self._validate_phase_key(ArchivePhase.RECONCILIATION, self.reconciliation)
+        if self.canonical_key is not None:
+            _require_relative_object_key(self.canonical_key, "manifest canonical_key")
+            prefix = (
+                f"canonical/project_id={self.project_id}/"
+                f"date={self.trace_date.isoformat()}/generation="
+            )
+            if not self.canonical_key.startswith(prefix):
+                raise ValueError("Manifest canonical_key does not match project/date")
+            generation_and_name = self.canonical_key.removeprefix(prefix)
+            generation_id, separator, filename = generation_and_name.partition("/")
+            if separator != "/" or filename != "runs.parquet":
+                raise ValueError("Manifest canonical_key has an invalid layout")
+            _require_uuid(generation_id, "canonical generation_id")
+        elif self.canonical_run_count != 0:
+            raise ValueError(
+                "Manifest without canonical_key must have zero canonical rows"
+            )
+        if self.sealed and not self._is_verified(self.reconciliation):
+            raise ValueError("A sealed manifest requires verified reconciliation")
+
+    @staticmethod
+    def _is_verified(record: PhaseRecord | None) -> bool:
+        return record is not None and record.status is PhaseStatus.VERIFIED
+
+    def _validate_phase_key(
+        self, phase: ArchivePhase, record: PhaseRecord | None
+    ) -> None:
+        if record is None:
+            return
+        expected = (
+            f"raw/project_id={self.project_id}/date={self.trace_date.isoformat()}/"
+            f"phase={phase.value}/generation={record.generation_id}/runs.parquet"
+        )
+        if record.raw_key != expected:
+            raise ValueError(
+                f"Manifest {phase.value} raw_key does not match project/date/phase"
+            )
+
+    def validate_publishable(self) -> None:
+        """Enforce invariants that must hold at the manifest publication boundary."""
+        records = [
+            record
+            for record in (self.primary, self.reconciliation)
+            if record is not None
+        ]
+        if not records:
+            raise ValueError("Published manifest requires a verified snapshot")
+        if any(record.status is not PhaseStatus.VERIFIED for record in records):
+            raise ValueError("Published manifest phases must be verified")
+        if self.canonical_key is None:
+            raise ValueError("Published manifest requires canonical_key")
+
+        counts = [record.run_count for record in records]
+        # Deduplicating a union cannot produce fewer rows than its largest unique
+        # input or more rows than the sum of all inputs. This catches truncated or
+        # accidentally duplicated canonical publications without reading Parquet.
+        if not max(counts) <= self.canonical_run_count <= sum(counts):
+            raise ValueError("Canonical count must be bounded by snapshot counts")
+        reconciliation_verified = self._is_verified(self.reconciliation)
+        if self.sealed is not reconciliation_verified:
+            raise ValueError(
+                "Manifest is sealed exactly when reconciliation is verified"
+            )
 
     def phase(self, phase: ArchivePhase) -> PhaseRecord | None:
         if phase is ArchivePhase.PRIMARY:
@@ -157,3 +291,33 @@ class ArchiveManifest:
             sealed=data["sealed"],
             updated_at=datetime.fromisoformat(data["updated_at"]),
         )
+
+
+def _require_uuid(value: str, field: str) -> None:
+    try:
+        parsed = UUID(value)
+    except ValueError as exc:
+        raise ValueError(f"{field} must be a UUID") from exc
+    if str(parsed) != value.lower():
+        raise ValueError(f"{field} must use canonical UUID format")
+
+
+def _require_aware_datetime(value: datetime, field: str) -> None:
+    if (
+        value.tzinfo is None
+        or value.utcoffset() is None
+        or value.utcoffset() != timedelta(0)
+    ):
+        raise ValueError(f"{field} must be timezone-aware UTC")
+
+
+def _require_relative_object_key(value: str, field: str) -> None:
+    path = PurePosixPath(value)
+    if (
+        not value
+        or value.startswith("/")
+        or "\\" in value
+        or any(part in ("", ".", "..") for part in value.split("/"))
+        or path.as_posix() != value
+    ):
+        raise ValueError(f"{field} must be a normalized relative object key")

--- a/src/langsmith_cli/archive/models.py
+++ b/src/langsmith_cli/archive/models.py
@@ -1,0 +1,159 @@
+"""Strongly typed archive contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from enum import Enum
+from typing import NotRequired, TypedDict
+
+
+class ArchivePhase(str, Enum):
+    PRIMARY = "primary"
+    RECONCILIATION = "reconciliation"
+
+
+class PhaseStatus(str, Enum):
+    PENDING = "pending"
+    EXPORTING = "exporting"
+    VERIFIED = "verified"
+    FAILED = "failed"
+
+
+class PhaseRecordDict(TypedDict):
+    status: str
+    generation_id: str
+    raw_key: str
+    run_count: int
+    verified_at: str
+    error: NotRequired[str]
+
+
+class ArchiveManifestDict(TypedDict):
+    schema_version: int
+    project_id: str
+    project_name: str
+    trace_date: str
+    window_start: str
+    window_end: str
+    primary: PhaseRecordDict | None
+    reconciliation: PhaseRecordDict | None
+    canonical_key: str | None
+    canonical_run_count: int
+    sealed: bool
+    updated_at: str
+
+
+@dataclass(frozen=True)
+class PhaseRecord:
+    status: PhaseStatus
+    generation_id: str
+    raw_key: str
+    run_count: int
+    verified_at: datetime
+    error: str | None = None
+
+    def to_dict(self) -> PhaseRecordDict:
+        data: PhaseRecordDict = {
+            "status": self.status.value,
+            "generation_id": self.generation_id,
+            "raw_key": self.raw_key,
+            "run_count": self.run_count,
+            "verified_at": self.verified_at.isoformat(),
+        }
+        if self.error is not None:
+            data["error"] = self.error
+        return data
+
+    @classmethod
+    def from_dict(cls, data: PhaseRecordDict) -> PhaseRecord:
+        return cls(
+            status=PhaseStatus(data["status"]),
+            generation_id=data["generation_id"],
+            raw_key=data["raw_key"],
+            run_count=data["run_count"],
+            verified_at=datetime.fromisoformat(data["verified_at"]),
+            error=data["error"] if "error" in data else None,
+        )
+
+
+@dataclass(frozen=True)
+class ArchiveManifest:
+    schema_version: int
+    project_id: str
+    project_name: str
+    trace_date: date
+    window_start: datetime
+    window_end: datetime
+    primary: PhaseRecord | None
+    reconciliation: PhaseRecord | None
+    canonical_key: str | None
+    canonical_run_count: int
+    sealed: bool
+    updated_at: datetime
+
+    def phase(self, phase: ArchivePhase) -> PhaseRecord | None:
+        if phase is ArchivePhase.PRIMARY:
+            return self.primary
+        return self.reconciliation
+
+    def with_phase(self, phase: ArchivePhase, record: PhaseRecord) -> ArchiveManifest:
+        return ArchiveManifest(
+            schema_version=self.schema_version,
+            project_id=self.project_id,
+            project_name=self.project_name,
+            trace_date=self.trace_date,
+            window_start=self.window_start,
+            window_end=self.window_end,
+            primary=record if phase is ArchivePhase.PRIMARY else self.primary,
+            reconciliation=(
+                record if phase is ArchivePhase.RECONCILIATION else self.reconciliation
+            ),
+            canonical_key=self.canonical_key,
+            canonical_run_count=self.canonical_run_count,
+            sealed=self.sealed,
+            updated_at=record.verified_at,
+        )
+
+    def to_dict(self) -> ArchiveManifestDict:
+        return {
+            "schema_version": self.schema_version,
+            "project_id": self.project_id,
+            "project_name": self.project_name,
+            "trace_date": self.trace_date.isoformat(),
+            "window_start": self.window_start.isoformat(),
+            "window_end": self.window_end.isoformat(),
+            "primary": self.primary.to_dict() if self.primary is not None else None,
+            "reconciliation": (
+                self.reconciliation.to_dict()
+                if self.reconciliation is not None
+                else None
+            ),
+            "canonical_key": self.canonical_key,
+            "canonical_run_count": self.canonical_run_count,
+            "sealed": self.sealed,
+            "updated_at": self.updated_at.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: ArchiveManifestDict) -> ArchiveManifest:
+        primary_data = data["primary"]
+        reconciliation_data = data["reconciliation"]
+        return cls(
+            schema_version=data["schema_version"],
+            project_id=data["project_id"],
+            project_name=data["project_name"],
+            trace_date=date.fromisoformat(data["trace_date"]),
+            window_start=datetime.fromisoformat(data["window_start"]),
+            window_end=datetime.fromisoformat(data["window_end"]),
+            primary=(PhaseRecord.from_dict(primary_data) if primary_data else None),
+            reconciliation=(
+                PhaseRecord.from_dict(reconciliation_data)
+                if reconciliation_data
+                else None
+            ),
+            canonical_key=data["canonical_key"],
+            canonical_run_count=data["canonical_run_count"],
+            sealed=data["sealed"],
+            updated_at=datetime.fromisoformat(data["updated_at"]),
+        )

--- a/src/langsmith_cli/archive/query.py
+++ b/src/langsmith_cli/archive/query.py
@@ -1,0 +1,271 @@
+"""DuckDB-backed queries over published archive manifests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from fnmatch import fnmatchcase
+import json
+import re
+from typing import TYPE_CHECKING, Any
+
+from langsmith_cli.archive.config import load_archive_config
+from langsmith_cli.archive.storage import create_store, read_manifest
+from langsmith_cli.time_parsing import ensure_aware_datetime
+
+if TYPE_CHECKING:
+    from langsmith.schemas import Run
+
+
+@dataclass(frozen=True)
+class ArchiveRunQuery:
+    project: str | None = None
+    project_id: str | None = None
+    project_name: str | None = None
+    project_name_exact: str | None = None
+    project_name_pattern: str | None = None
+    project_name_regex: str | None = None
+    since: datetime | None = None
+    before: datetime | None = None
+    limit: int | None = 20
+    error: bool | None = None
+    trace_id: str | None = None
+    run_type: str | None = None
+    is_root: bool | None = None
+    tags: tuple[str, ...] = ()
+    text: str | None = None
+    text_fields: tuple[str, ...] = ("inputs", "outputs", "error")
+    text_regex: bool = False
+    text_ignore_case: bool = False
+
+
+def _project_matches(
+    query: ArchiveRunQuery, project_id: str, project_name: str
+) -> bool:
+    if query.project_id is not None and project_id != query.project_id:
+        return False
+    exact = query.project or query.project_name or query.project_name_exact
+    if exact is not None and project_name != exact:
+        return False
+    if query.project_name_pattern is not None and not fnmatchcase(
+        project_name, query.project_name_pattern
+    ):
+        return False
+    if (
+        query.project_name_regex is not None
+        and re.search(query.project_name_regex, project_name) is None
+    ):
+        return False
+    return True
+
+
+def _canonical_uris(query: ArchiveRunQuery, config_path: str | None) -> list[str]:
+    config = load_archive_config(config_path)
+    since = ensure_aware_datetime(query.since)
+    before = ensure_aware_datetime(query.before)
+    uris: list[str] = []
+    exact = query.project or query.project_name or query.project_name_exact
+    routes = (config.route_project(exact),) if exact is not None else config.routes
+    for route in routes:
+        store = create_store(route.archive_uri)
+        for key in store.list_keys("manifests"):
+            manifest = read_manifest(store, key, known_exists=True)
+            if manifest is None or manifest.canonical_key is None:
+                continue
+            configured_route = config.route_project(manifest.project_name)
+            if configured_route.name != route.name:
+                raise ValueError(
+                    f"Manifest project is stored under the wrong route: "
+                    f"{manifest.project_name}"
+                )
+            if not _project_matches(query, manifest.project_id, manifest.project_name):
+                continue
+            if since is not None and manifest.window_end <= since:
+                continue
+            if before is not None and manifest.window_start >= before:
+                continue
+            uris.append(store.object_uri(manifest.canonical_key))
+    return sorted(set(uris))
+
+
+def _configure_s3(connection: Any, uris: list[str]) -> None:
+    if any(uri.startswith("s3://") for uri in uris):
+        connection.execute(
+            "CREATE OR REPLACE SECRET langsmith_archive_query_s3 "
+            "(TYPE s3, PROVIDER credential_chain)"
+        )
+
+
+def _normalize_run_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Normalize UUID columns promoted to DuckDB JSON by all-null snapshots."""
+    for field in (
+        "id",
+        "trace_id",
+        "parent_run_id",
+        "session_id",
+        "reference_example_id",
+    ):
+        if field not in payload:
+            continue
+        value = payload[field]
+        if isinstance(value, str) and value.startswith('"'):
+            decoded = json.loads(value)
+            if not isinstance(decoded, str):
+                raise ValueError(f"Archived UUID field is not a string: {field}")
+            payload[field] = decoded
+    for details_field in (
+        "prompt_token_details",
+        "completion_token_details",
+        "prompt_cost_details",
+        "completion_cost_details",
+    ):
+        if details_field not in payload:
+            continue
+        details = payload[details_field]
+        if isinstance(details, dict):
+            payload[details_field] = {
+                key: value for key, value in details.items() if value is not None
+            }
+    return payload
+
+
+def _where_clause(query: ArchiveRunQuery) -> tuple[str, list[object]]:
+    clauses: list[str] = []
+    parameters: list[object] = []
+    since = ensure_aware_datetime(query.since)
+    before = ensure_aware_datetime(query.before)
+    if since is not None:
+        clauses.append("start_time >= ?")
+        parameters.append(since)
+    if before is not None:
+        clauses.append("start_time < ?")
+        parameters.append(before)
+    if query.error is not None:
+        clauses.append("error IS NOT NULL" if query.error else "error IS NULL")
+    if query.trace_id is not None:
+        clauses.append("CAST(trace_id AS VARCHAR) = ?")
+        parameters.append(query.trace_id)
+    if query.run_type is not None:
+        clauses.append("run_type = ?")
+        parameters.append(query.run_type)
+    if query.is_root:
+        clauses.append("parent_run_id IS NULL")
+    for tag in query.tags:
+        clauses.append("list_contains(tags, ?)")
+        parameters.append(tag)
+    if query.text is not None:
+        text_sql = " || ' ' || ".join(
+            f"coalesce(CAST({field} AS VARCHAR), '')" for field in query.text_fields
+        )
+        if query.text_regex:
+            clauses.append(f"regexp_matches({text_sql}, ?)")
+            pattern = f"(?i){query.text}" if query.text_ignore_case else query.text
+            parameters.append(pattern)
+        else:
+            clauses.append(f"lower({text_sql}) LIKE ?")
+            parameters.append(f"%{query.text.lower()}%")
+    where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+    return where, parameters
+
+
+def query_archive_runs(
+    query: ArchiveRunQuery, *, config_path: str | None = None
+) -> list[Run]:
+    """Return LangSmith Run contracts populated from canonical Parquet."""
+    import duckdb
+    from langsmith.schemas import Run
+
+    uris = _canonical_uris(query, config_path)
+    if not uris:
+        return []
+
+    where, where_parameters = _where_clause(query)
+    parameters: list[object] = [uris, *where_parameters]
+    limit = "" if query.limit is None or query.limit == 0 else " LIMIT ?"
+    if limit:
+        parameters.append(query.limit)
+    sql = (
+        "SELECT * FROM read_parquet(?, union_by_name=true)"
+        f"{where} ORDER BY start_time DESC{limit}"
+    )
+
+    connection = duckdb.connect()
+    try:
+        _configure_s3(connection, uris)
+        cursor = connection.execute(sql, parameters)
+        columns = [description[0] for description in cursor.description]
+        runs: list[Run] = []
+        for row in cursor.fetchall():
+            payload = _normalize_run_payload(dict(zip(columns, row, strict=True)))
+            runs.append(Run.model_validate(payload))
+        return runs
+    finally:
+        connection.close()
+
+
+def count_archive_runs(
+    query: ArchiveRunQuery, *, config_path: str | None = None
+) -> int:
+    """Count matching runs using Parquet metadata/predicate pushdown only."""
+    import duckdb
+
+    uris = _canonical_uris(query, config_path)
+    if not uris:
+        return 0
+    where, parameters = _where_clause(query)
+    connection = duckdb.connect()
+    try:
+        _configure_s3(connection, uris)
+        row = connection.execute(
+            f"SELECT count(*) FROM read_parquet(?, union_by_name=true){where}",
+            [uris, *parameters],
+        ).fetchone()
+        if row is None:
+            raise ValueError("DuckDB did not return an archive count")
+        return int(row[0])
+    finally:
+        connection.close()
+
+
+def read_archived_run(
+    run_id: str, *, follow_children: bool, config_path: str | None = None
+) -> tuple[Run, list[Run]]:
+    import duckdb
+    from langsmith.schemas import Run
+
+    uris = _canonical_uris(ArchiveRunQuery(limit=0), config_path)
+    if not uris:
+        raise LookupError(f"Archived run not found: {run_id}")
+    connection = duckdb.connect()
+    try:
+        _configure_s3(connection, uris)
+        cursor = connection.execute(
+            "SELECT * FROM read_parquet(?, union_by_name=true) "
+            "WHERE CAST(id AS VARCHAR) = ? LIMIT 1",
+            [uris, run_id],
+        )
+        row = cursor.fetchone()
+        if row is None:
+            raise LookupError(f"Archived run not found: {run_id}")
+        columns = [description[0] for description in cursor.description]
+        run = Run.model_validate(
+            _normalize_run_payload(dict(zip(columns, row, strict=True)))
+        )
+        children: list[Run] = []
+        if follow_children:
+            child_cursor = connection.execute(
+                "SELECT * FROM read_parquet(?, union_by_name=true) "
+                "WHERE CAST(trace_id AS VARCHAR) = ? AND CAST(id AS VARCHAR) != ? "
+                "ORDER BY start_time",
+                [uris, str(run.trace_id or run.id), run_id],
+            )
+            child_columns = [description[0] for description in child_cursor.description]
+            children = [
+                Run.model_validate(
+                    _normalize_run_payload(dict(zip(child_columns, child, strict=True)))
+                )
+                for child in child_cursor.fetchall()
+            ]
+        return run, children
+    finally:
+        connection.close()

--- a/src/langsmith_cli/archive/query.py
+++ b/src/langsmith_cli/archive/query.py
@@ -3,18 +3,25 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import date, datetime, time, timedelta, timezone
 from fnmatch import fnmatchcase
 import json
 import re
 from typing import TYPE_CHECKING, Any
 
 from langsmith_cli.archive.config import load_archive_config
-from langsmith_cli.archive.storage import create_store, read_manifest
+from langsmith_cli.archive.duckdb import configure_duckdb_s3
+from langsmith_cli.archive.repository import list_project_records, read_manifest
+from langsmith_cli.archive.storage import create_store
 from langsmith_cli.time_parsing import ensure_aware_datetime
 
 if TYPE_CHECKING:
     from langsmith.schemas import Run
+
+
+# These values are interpolated as SQL identifiers, not bound values. Keeping the
+# allowlist adjacent to the typed query contract makes that safety invariant visible.
+ARCHIVE_TEXT_FIELDS = frozenset({"inputs", "outputs", "error", "extra"})
 
 
 @dataclass(frozen=True)
@@ -37,6 +44,16 @@ class ArchiveRunQuery:
     text_fields: tuple[str, ...] = ("inputs", "outputs", "error")
     text_regex: bool = False
     text_ignore_case: bool = False
+
+    def __post_init__(self) -> None:
+        if self.text is not None and not self.text_fields:
+            raise ValueError("Archive text search requires at least one field")
+        invalid_fields = set(self.text_fields) - ARCHIVE_TEXT_FIELDS
+        if invalid_fields:
+            invalid = ", ".join(sorted(invalid_fields))
+            raise ValueError(f"Unsupported archive text field(s): {invalid}")
+        if self.limit is not None and self.limit < 0:
+            raise ValueError("Archive query limit must be non-negative")
 
 
 def _project_matches(
@@ -68,7 +85,54 @@ def _canonical_uris(query: ArchiveRunQuery, config_path: str | None) -> list[str
     routes = (config.route_project(exact),) if exact is not None else config.routes
     for route in routes:
         store = create_store(route.archive_uri)
-        for key in store.list_keys("manifests"):
+        records = list_project_records(store)
+        matching_project_ids: set[str] | None = None
+        catalog_project_ids: set[str] = set()
+        if records:
+            matching_project_ids = set()
+            for project in records:
+                catalog_project_ids.add(project.project_id)
+                configured_route = config.route_project(project.project_name)
+                if configured_route.name != route.name:
+                    raise ValueError(
+                        "Archive project catalog entry is stored under the wrong "
+                        f"route: {project.project_name}"
+                    )
+                if _project_matches(query, project.project_id, project.project_name):
+                    matching_project_ids.add(project.project_id)
+        elif query.project_id is not None:
+            # Legacy archives may predate the project catalog. A project UUID still
+            # maps directly to its manifest namespace without scanning all projects.
+            matching_project_ids = {query.project_id}
+
+        if matching_project_ids is None:
+            manifest_keys = store.list_keys("manifests")
+        else:
+            manifest_keys = [
+                key
+                for project_id in sorted(matching_project_ids)
+                for key in store.list_keys(f"manifests/project_id={project_id}")
+            ]
+            if catalog_project_ids:
+                # A catalog is backfilled incrementally. Preserve visibility of
+                # legacy/unindexed project namespaces during that rollout, while
+                # avoiding GETs for unrelated projects already in the catalog.
+                legacy_keys = [
+                    key
+                    for key in store.list_keys("manifests")
+                    if (
+                        (identity := _manifest_identity_from_key(key)) is None
+                        or identity[0] not in catalog_project_ids
+                    )
+                ]
+                manifest_keys.extend(legacy_keys)
+        for key in manifest_keys:
+            identity = _manifest_identity_from_key(key)
+            key_date = identity[1] if identity is not None else None
+            if key_date is not None and not _date_partition_overlaps(
+                key_date, since, before
+            ):
+                continue
             manifest = read_manifest(store, key, known_exists=True)
             if manifest is None or manifest.canonical_key is None:
                 continue
@@ -84,16 +148,37 @@ def _canonical_uris(query: ArchiveRunQuery, config_path: str | None) -> list[str
                 continue
             if before is not None and manifest.window_start >= before:
                 continue
+            # Empty canonical generations contain no rows and need not participate
+            # in schema union. Skipping them also makes all-empty archives return an
+            # immediate, deterministic zero instead of referencing absent columns.
+            if manifest.canonical_run_count == 0:
+                continue
             uris.append(store.object_uri(manifest.canonical_key))
     return sorted(set(uris))
 
 
-def _configure_s3(connection: Any, uris: list[str]) -> None:
-    if any(uri.startswith("s3://") for uri in uris):
-        connection.execute(
-            "CREATE OR REPLACE SECRET langsmith_archive_query_s3 "
-            "(TYPE s3, PROVIDER credential_chain)"
-        )
+_MANIFEST_KEY_RE = re.compile(
+    r"^manifests/project_id=([^/]+)/date=(\d{4}-\d{2}-\d{2})\.json$"
+)
+
+
+def _manifest_identity_from_key(key: str) -> tuple[str, date] | None:
+    match = _MANIFEST_KEY_RE.fullmatch(key)
+    return (
+        (match.group(1), date.fromisoformat(match.group(2)))
+        if match is not None
+        else None
+    )
+
+
+def _date_partition_overlaps(
+    trace_date: date, since: datetime | None, before: datetime | None
+) -> bool:
+    start = datetime.combine(trace_date, time.min, tzinfo=timezone.utc)
+    end = start + timedelta(days=1)
+    return not (
+        (since is not None and end <= since) or (before is not None and start >= before)
+    )
 
 
 def _normalize_run_payload(payload: dict[str, Any]) -> dict[str, Any]:
@@ -148,8 +233,10 @@ def _where_clause(query: ArchiveRunQuery) -> tuple[str, list[object]]:
     if query.run_type is not None:
         clauses.append("run_type = ?")
         parameters.append(query.run_type)
-    if query.is_root:
-        clauses.append("parent_run_id IS NULL")
+    if query.is_root is not None:
+        clauses.append(
+            "parent_run_id IS NULL" if query.is_root else "parent_run_id IS NOT NULL"
+        )
     for tag in query.tags:
         clauses.append("list_contains(tags, ?)")
         parameters.append(tag)
@@ -161,9 +248,12 @@ def _where_clause(query: ArchiveRunQuery) -> tuple[str, list[object]]:
             clauses.append(f"regexp_matches({text_sql}, ?)")
             pattern = f"(?i){query.text}" if query.text_ignore_case else query.text
             parameters.append(pattern)
-        else:
+        elif query.text_ignore_case:
             clauses.append(f"lower({text_sql}) LIKE ?")
             parameters.append(f"%{query.text.lower()}%")
+        else:
+            clauses.append(f"{text_sql} LIKE ?")
+            parameters.append(f"%{query.text}%")
     where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
     return where, parameters
 
@@ -191,7 +281,7 @@ def query_archive_runs(
 
     connection = duckdb.connect()
     try:
-        _configure_s3(connection, uris)
+        configure_duckdb_s3(connection, uris)
         cursor = connection.execute(sql, parameters)
         columns = [description[0] for description in cursor.description]
         runs: list[Run] = []
@@ -215,7 +305,7 @@ def count_archive_runs(
     where, parameters = _where_clause(query)
     connection = duckdb.connect()
     try:
-        _configure_s3(connection, uris)
+        configure_duckdb_s3(connection, uris)
         row = connection.execute(
             f"SELECT count(*) FROM read_parquet(?, union_by_name=true){where}",
             [uris, *parameters],
@@ -238,7 +328,7 @@ def read_archived_run(
         raise LookupError(f"Archived run not found: {run_id}")
     connection = duckdb.connect()
     try:
-        _configure_s3(connection, uris)
+        configure_duckdb_s3(connection, uris)
         cursor = connection.execute(
             "SELECT * FROM read_parquet(?, union_by_name=true) "
             "WHERE CAST(id AS VARCHAR) = ? LIMIT 1",

--- a/src/langsmith_cli/archive/repository.py
+++ b/src/langsmith_cli/archive/repository.py
@@ -1,0 +1,197 @@
+"""Typed archive metadata repository and publication contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import cast
+
+from langsmith_cli.archive.models import (
+    ArchiveManifest,
+    ArchiveManifestDict,
+    ArchiveProject,
+    ArchiveProjectDict,
+)
+from langsmith_cli.archive.storage import (
+    ArchiveStore,
+    ConcurrentArchiveWriteError,
+)
+
+
+@dataclass(frozen=True)
+class ManifestSnapshot:
+    manifest: ArchiveManifest
+    version: str
+
+
+def manifest_key(project_id: str, trace_date: str) -> str:
+    return f"manifests/project_id={project_id}/date={trace_date}.json"
+
+
+def project_key(project_id: str) -> str:
+    return f"projects/project_id={project_id}.json"
+
+
+def ensure_project_record(
+    store: ArchiveStore, project_id: str, project_name: str
+) -> ArchiveProject:
+    """Create an immutable project catalog entry or verify the existing identity."""
+    project = ArchiveProject(
+        schema_version=1, project_id=project_id, project_name=project_name
+    )
+    key = project_key(project_id)
+    if store.exists(key):
+        existing = _read_project_record(store, key)
+        if existing != project:
+            raise ValueError(
+                "Archived project identity changed; migrate it before syncing"
+            )
+        return existing
+
+    content = json.dumps(project.to_dict(), ensure_ascii=False, sort_keys=True)
+    try:
+        store.put_text_if_version(key, content, None)
+    except ConcurrentArchiveWriteError:
+        # A same-project worker may win the create race. Accept only the exact same
+        # immutable identity; a rename or route collision remains a hard failure.
+        existing = _read_project_record(store, key)
+        if existing != project:
+            raise ValueError("Archived project identity changed concurrently") from None
+        return existing
+    return project
+
+
+def list_project_records(store: ArchiveStore) -> tuple[ArchiveProject, ...]:
+    keys = store.list_keys("projects")
+    if len(keys) < 2:
+        return tuple(_read_project_record(store, key) for key in keys)
+
+    # Catalog records are independent, tiny objects. Parallel GETs keep CLI query
+    # and idempotent sync latency bounded as organizations add projects.
+    from concurrent.futures import ThreadPoolExecutor
+
+    with ThreadPoolExecutor(max_workers=min(16, len(keys))) as executor:
+        return tuple(executor.map(lambda key: _read_project_record(store, key), keys))
+
+
+def read_manifest(
+    store: ArchiveStore, key: str, *, known_exists: bool = False
+) -> ArchiveManifest | None:
+    snapshot = read_manifest_snapshot(store, key, known_exists=known_exists)
+    return snapshot.manifest if snapshot is not None else None
+
+
+def read_manifest_snapshot(
+    store: ArchiveStore, key: str, *, known_exists: bool = False
+) -> ManifestSnapshot | None:
+    if not known_exists and not store.exists(key):
+        return None
+    stored = store.get_text_with_version(key)
+    raw: object = json.loads(stored.content)
+    payload = _validate_manifest_payload(raw, key)
+    manifest = ArchiveManifest.from_dict(payload)
+    manifest.validate_publishable()
+    _validate_manifest_location(key, manifest)
+    return ManifestSnapshot(manifest=manifest, version=stored.version)
+
+
+def write_manifest(
+    store: ArchiveStore,
+    key: str,
+    manifest: ArchiveManifest,
+    *,
+    expected_version: str | None,
+) -> None:
+    manifest.validate_publishable()
+    _validate_manifest_location(key, manifest)
+    payload: ArchiveManifestDict = manifest.to_dict()
+    store.put_text_if_version(
+        key,
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True),
+        expected_version,
+    )
+
+
+def _validate_manifest_location(key: str, manifest: ArchiveManifest) -> None:
+    expected = manifest_key(manifest.project_id, manifest.trace_date.isoformat())
+    if key != expected:
+        raise ValueError("Manifest object key does not match its project/date")
+
+
+def _read_project_record(store: ArchiveStore, key: str) -> ArchiveProject:
+    raw: object = json.loads(store.get_text(key))
+    if not isinstance(raw, dict):
+        raise ValueError(f"Archive project record is not an object: {key}")
+    if set(raw) != {"schema_version", "project_id", "project_name"}:
+        raise ValueError(f"Archive project record has an invalid schema: {key}")
+    if type(raw["schema_version"]) is not int:
+        raise ValueError("Archive project schema_version must be an integer")
+    if not isinstance(raw["project_id"], str) or not isinstance(
+        raw["project_name"], str
+    ):
+        raise ValueError("Archive project identifiers must be strings")
+    project = ArchiveProject.from_dict(cast(ArchiveProjectDict, raw))
+    if key != project_key(project.project_id):
+        raise ValueError("Archive project object key does not match its project_id")
+    return project
+
+
+def _validate_manifest_payload(raw: object, key: str) -> ArchiveManifestDict:
+    if not isinstance(raw, dict):
+        raise ValueError(f"Archive manifest is not an object: {key}")
+    required = {
+        "schema_version",
+        "project_id",
+        "project_name",
+        "trace_date",
+        "window_start",
+        "window_end",
+        "primary",
+        "reconciliation",
+        "canonical_key",
+        "canonical_run_count",
+        "sealed",
+        "updated_at",
+    }
+    if set(raw) != required:
+        raise ValueError(f"Archive manifest has an invalid schema: {key}")
+    for field in (
+        "project_id",
+        "project_name",
+        "trace_date",
+        "window_start",
+        "window_end",
+        "updated_at",
+    ):
+        if not isinstance(raw[field], str):
+            raise ValueError(f"Archive manifest field must be a string: {field}")
+    if type(raw["schema_version"]) is not int:
+        raise ValueError("Archive manifest schema_version must be an integer")
+    if type(raw["canonical_run_count"]) is not int:
+        raise ValueError("Archive manifest canonical_run_count must be an integer")
+    if type(raw["sealed"]) is not bool:
+        raise ValueError("Archive manifest sealed must be a boolean")
+    canonical_key = raw["canonical_key"]
+    if canonical_key is not None and not isinstance(canonical_key, str):
+        raise ValueError("Archive manifest canonical_key must be a string or null")
+    _validate_phase_payload(raw["primary"], "primary")
+    _validate_phase_payload(raw["reconciliation"], "reconciliation")
+    return cast(ArchiveManifestDict, raw)
+
+
+def _validate_phase_payload(raw: object, field: str) -> None:
+    if raw is None:
+        return
+    if not isinstance(raw, dict):
+        raise ValueError(f"Archive manifest {field} phase must be an object")
+    required = {"status", "generation_id", "raw_key", "run_count", "verified_at"}
+    allowed = required | {"error"}
+    if not required <= set(raw) <= allowed:
+        raise ValueError(f"Archive manifest {field} phase has an invalid schema")
+    for phase_field in ("status", "generation_id", "raw_key", "verified_at"):
+        if not isinstance(raw[phase_field], str):
+            raise ValueError(f"Archive manifest {field}.{phase_field} must be a string")
+    if type(raw["run_count"]) is not int:
+        raise ValueError(f"Archive manifest {field}.run_count must be an integer")
+    if "error" in raw and not isinstance(raw["error"], str):
+        raise ValueError(f"Archive manifest {field}.error must be a string")

--- a/src/langsmith_cli/archive/storage.py
+++ b/src/langsmith_cli/archive/storage.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import cached_property
-import json
+import hashlib
+import os
 from pathlib import Path
+from pathlib import PurePosixPath
+import tempfile
 from typing import Any, Protocol
 from urllib.parse import urlparse
-
-from langsmith_cli.archive.models import ArchiveManifest, ArchiveManifestDict
 
 
 class ArchiveStore(Protocol):
@@ -19,9 +22,23 @@ class ArchiveStore(Protocol):
     def put_file(self, key: str, source: Path) -> None: ...
     def put_text(self, key: str, content: str) -> None: ...
     def get_text(self, key: str) -> str: ...
+    def get_text_with_version(self, key: str) -> TextObject: ...
+    def put_text_if_version(
+        self, key: str, content: str, expected_version: str | None
+    ) -> None: ...
     def exists(self, key: str) -> bool: ...
     def list_keys(self, prefix: str) -> list[str]: ...
     def object_uri(self, key: str) -> str: ...
+
+
+class ConcurrentArchiveWriteError(RuntimeError):
+    """A stale writer attempted to replace a newer archive metadata object."""
+
+
+@dataclass(frozen=True)
+class TextObject:
+    content: str
+    version: str
 
 
 @dataclass(frozen=True)
@@ -32,22 +49,71 @@ class LocalArchiveStore:
     def put_file(self, key: str, source: Path) -> None:
         import shutil
 
+        _validate_store_key(key)
         target = self.root / key
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(source, target)
 
     def put_text(self, key: str, content: str) -> None:
+        _validate_store_key(key)
         target = self.root / key
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(content, encoding="utf-8")
 
     def get_text(self, key: str) -> str:
+        _validate_store_key(key)
         return (self.root / key).read_text(encoding="utf-8")
 
+    def get_text_with_version(self, key: str) -> TextObject:
+        content = self.get_text(key)
+        return TextObject(content=content, version=_content_version(content))
+
+    def put_text_if_version(
+        self, key: str, content: str, expected_version: str | None
+    ) -> None:
+        """Publish atomically while holding a cross-process local file lock."""
+        _validate_store_key(key)
+        target = self.root / key
+        target.parent.mkdir(parents=True, exist_ok=True)
+        # Lock files live outside object namespaces so manifest listings can never
+        # mistake synchronization metadata for published archive data.
+        lock_name = hashlib.sha256(key.encode("utf-8")).hexdigest() + ".lock"
+        lock_path = self.root / ".locks" / lock_name
+        with _exclusive_file_lock(lock_path):
+            current_version = (
+                _content_version(target.read_text(encoding="utf-8"))
+                if target.is_file()
+                else None
+            )
+            if current_version != expected_version:
+                raise ConcurrentArchiveWriteError(
+                    f"Archive metadata changed concurrently: {key}"
+                )
+            temporary_path: Path | None = None
+            try:
+                with tempfile.NamedTemporaryFile(
+                    mode="w",
+                    encoding="utf-8",
+                    dir=target.parent,
+                    prefix=f".{target.name}.",
+                    suffix=".tmp",
+                    delete=False,
+                ) as temporary:
+                    temporary.write(content)
+                    temporary.flush()
+                    os.fsync(temporary.fileno())
+                    temporary_path = Path(temporary.name)
+                os.replace(temporary_path, target)
+            finally:
+                if temporary_path is not None and temporary_path.exists():
+                    temporary_path.unlink()
+
     def exists(self, key: str) -> bool:
+        _validate_store_key(key)
         return (self.root / key).is_file()
 
     def list_keys(self, prefix: str) -> list[str]:
+        _validate_store_key(prefix)
         base = self.root / prefix
         if not base.exists():
             return []
@@ -58,6 +124,7 @@ class LocalArchiveStore:
         )
 
     def object_uri(self, key: str) -> str:
+        _validate_store_key(key)
         return str((self.root / key).resolve())
 
 
@@ -68,6 +135,7 @@ class S3ArchiveStore:
     base_uri: str
 
     def _full_key(self, key: str) -> str:
+        _validate_store_key(key)
         return "/".join(part for part in (self.prefix.strip("/"), key) if part)
 
     @cached_property
@@ -91,6 +159,37 @@ class S3ArchiveStore:
         response = self.client.get_object(Bucket=self.bucket, Key=self._full_key(key))
         return response["Body"].read().decode("utf-8")
 
+    def get_text_with_version(self, key: str) -> TextObject:
+        response = self.client.get_object(Bucket=self.bucket, Key=self._full_key(key))
+        return TextObject(
+            content=response["Body"].read().decode("utf-8"),
+            version=response["ETag"],
+        )
+
+    def put_text_if_version(
+        self, key: str, content: str, expected_version: str | None
+    ) -> None:
+        from botocore.exceptions import ClientError
+
+        common = {
+            "Bucket": self.bucket,
+            "Key": self._full_key(key),
+            "Body": content.encode("utf-8"),
+            "ContentType": "application/json",
+        }
+        try:
+            if expected_version is None:
+                self.client.put_object(**common, IfNoneMatch="*")
+            else:
+                self.client.put_object(**common, IfMatch=expected_version)
+        except ClientError as exc:
+            status = exc.response["ResponseMetadata"]["HTTPStatusCode"]
+            if status in (409, 412):
+                raise ConcurrentArchiveWriteError(
+                    f"Archive metadata changed concurrently: {key}"
+                ) from exc
+            raise
+
     def exists(self, key: str) -> bool:
         from botocore.exceptions import ClientError
 
@@ -104,7 +203,9 @@ class S3ArchiveStore:
         return True
 
     def list_keys(self, prefix: str) -> list[str]:
-        full_prefix = self._full_key(prefix)
+        # Treat callers' prefix as an object namespace, not a raw string prefix;
+        # `manifests` must never include sibling keys such as `manifests-old/...`.
+        full_prefix = self._full_key(prefix).rstrip("/") + "/"
         paginator = self.client.get_paginator("list_objects_v2")
         keys: list[str] = []
         strip_prefix = self.prefix.strip("/")
@@ -126,6 +227,12 @@ class S3ArchiveStore:
 
 
 def create_store(uri: str) -> ArchiveStore:
+    # urlparse treats a Windows drive letter as a URI scheme. A drive-qualified
+    # path is always local and must be classified before URI parsing.
+    if _is_windows_drive_path(uri):
+        root = Path(uri).expanduser().resolve()
+        root.mkdir(parents=True, exist_ok=True)
+        return LocalArchiveStore(root=root, base_uri=str(root))
     parsed = urlparse(uri)
     if parsed.scheme == "s3":
         if not parsed.netloc:
@@ -145,23 +252,59 @@ def create_store(uri: str) -> ArchiveStore:
     return LocalArchiveStore(root=root, base_uri=str(root))
 
 
-def manifest_key(project_id: str, trace_date: str) -> str:
-    return f"manifests/project_id={project_id}/date={trace_date}.json"
+def _is_windows_drive_path(uri: str) -> bool:
+    return len(uri) >= 3 and uri[0].isalpha() and uri[1] == ":" and uri[2] in "/\\"
 
 
-def read_manifest(
-    store: ArchiveStore, key: str, *, known_exists: bool = False
-) -> ArchiveManifest | None:
-    if not known_exists and not store.exists(key):
-        return None
-    raw: object = json.loads(store.get_text(key))
-    if not isinstance(raw, dict):
-        raise ValueError(f"Archive manifest is not an object: {key}")
-    return ArchiveManifest.from_dict(raw)  # type: ignore[arg-type]
+def _validate_store_key(key: str) -> None:
+    path = PurePosixPath(key)
+    if (
+        not key
+        or key.startswith("/")
+        or "\\" in key
+        or any(part in ("", ".", "..") for part in key.split("/"))
+        or path.as_posix() != key
+    ):
+        raise ValueError("Archive object key must be normalized and relative")
 
 
-def write_manifest(store: ArchiveStore, key: str, manifest: ArchiveManifest) -> None:
-    payload: ArchiveManifestDict = manifest.to_dict()
-    store.put_text(
-        key, json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
-    )
+def _content_version(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+@contextmanager
+def _exclusive_file_lock(path: Path) -> Iterator[None]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a+b") as lock:
+        if lock.tell() == 0:
+            lock.write(b"\0")
+            lock.flush()
+        lock.seek(0)
+        if os.name == "nt":
+            import msvcrt
+
+            try:
+                msvcrt.locking(lock.fileno(), msvcrt.LK_NBLCK, 1)
+            except OSError as exc:
+                raise ConcurrentArchiveWriteError(
+                    f"Archive metadata is being published concurrently: {path.name}"
+                ) from exc
+            try:
+                yield
+            finally:
+                lock.seek(0)
+                msvcrt.locking(lock.fileno(), msvcrt.LK_UNLCK, 1)
+            return
+
+        import fcntl
+
+        try:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise ConcurrentArchiveWriteError(
+                f"Archive metadata is being published concurrently: {path.name}"
+            ) from exc
+        try:
+            yield
+        finally:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)

--- a/src/langsmith_cli/archive/storage.py
+++ b/src/langsmith_cli/archive/storage.py
@@ -1,0 +1,167 @@
+"""Private local/S3 archive object storage."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import cached_property
+import json
+from pathlib import Path
+from typing import Any, Protocol
+from urllib.parse import urlparse
+
+from langsmith_cli.archive.models import ArchiveManifest, ArchiveManifestDict
+
+
+class ArchiveStore(Protocol):
+    @property
+    def base_uri(self) -> str: ...
+
+    def put_file(self, key: str, source: Path) -> None: ...
+    def put_text(self, key: str, content: str) -> None: ...
+    def get_text(self, key: str) -> str: ...
+    def exists(self, key: str) -> bool: ...
+    def list_keys(self, prefix: str) -> list[str]: ...
+    def object_uri(self, key: str) -> str: ...
+
+
+@dataclass(frozen=True)
+class LocalArchiveStore:
+    root: Path
+    base_uri: str
+
+    def put_file(self, key: str, source: Path) -> None:
+        import shutil
+
+        target = self.root / key
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, target)
+
+    def put_text(self, key: str, content: str) -> None:
+        target = self.root / key
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+
+    def get_text(self, key: str) -> str:
+        return (self.root / key).read_text(encoding="utf-8")
+
+    def exists(self, key: str) -> bool:
+        return (self.root / key).is_file()
+
+    def list_keys(self, prefix: str) -> list[str]:
+        base = self.root / prefix
+        if not base.exists():
+            return []
+        return sorted(
+            str(path.relative_to(self.root))
+            for path in base.rglob("*")
+            if path.is_file()
+        )
+
+    def object_uri(self, key: str) -> str:
+        return str((self.root / key).resolve())
+
+
+@dataclass(frozen=True)
+class S3ArchiveStore:
+    bucket: str
+    prefix: str
+    base_uri: str
+
+    def _full_key(self, key: str) -> str:
+        return "/".join(part for part in (self.prefix.strip("/"), key) if part)
+
+    @cached_property
+    def client(self) -> Any:
+        import boto3
+
+        return boto3.client("s3")
+
+    def put_file(self, key: str, source: Path) -> None:
+        self.client.upload_file(str(source), self.bucket, self._full_key(key))
+
+    def put_text(self, key: str, content: str) -> None:
+        self.client.put_object(
+            Bucket=self.bucket,
+            Key=self._full_key(key),
+            Body=content.encode("utf-8"),
+            ContentType="application/json",
+        )
+
+    def get_text(self, key: str) -> str:
+        response = self.client.get_object(Bucket=self.bucket, Key=self._full_key(key))
+        return response["Body"].read().decode("utf-8")
+
+    def exists(self, key: str) -> bool:
+        from botocore.exceptions import ClientError
+
+        try:
+            self.client.head_object(Bucket=self.bucket, Key=self._full_key(key))
+        except ClientError as exc:
+            status = exc.response["ResponseMetadata"]["HTTPStatusCode"]
+            if status == 404:
+                return False
+            raise
+        return True
+
+    def list_keys(self, prefix: str) -> list[str]:
+        full_prefix = self._full_key(prefix)
+        paginator = self.client.get_paginator("list_objects_v2")
+        keys: list[str] = []
+        strip_prefix = self.prefix.strip("/")
+        for page in paginator.paginate(Bucket=self.bucket, Prefix=full_prefix):
+            if "Contents" not in page:
+                continue
+            for item in page["Contents"]:
+                full_key: str = item["Key"]
+                relative = (
+                    full_key[len(strip_prefix) :].lstrip("/")
+                    if strip_prefix
+                    else full_key
+                )
+                keys.append(relative)
+        return sorted(keys)
+
+    def object_uri(self, key: str) -> str:
+        return f"s3://{self.bucket}/{self._full_key(key)}"
+
+
+def create_store(uri: str) -> ArchiveStore:
+    parsed = urlparse(uri)
+    if parsed.scheme == "s3":
+        if not parsed.netloc:
+            raise ValueError(f"Invalid S3 archive URI: {uri}")
+        return S3ArchiveStore(
+            bucket=parsed.netloc,
+            prefix=parsed.path.strip("/"),
+            base_uri=uri.rstrip("/"),
+        )
+    if parsed.scheme == "file":
+        root = Path(parsed.path).expanduser().resolve()
+    elif parsed.scheme == "":
+        root = Path(uri).expanduser().resolve()
+    else:
+        raise ValueError(f"Unsupported archive URI scheme: {parsed.scheme}")
+    root.mkdir(parents=True, exist_ok=True)
+    return LocalArchiveStore(root=root, base_uri=str(root))
+
+
+def manifest_key(project_id: str, trace_date: str) -> str:
+    return f"manifests/project_id={project_id}/date={trace_date}.json"
+
+
+def read_manifest(
+    store: ArchiveStore, key: str, *, known_exists: bool = False
+) -> ArchiveManifest | None:
+    if not known_exists and not store.exists(key):
+        return None
+    raw: object = json.loads(store.get_text(key))
+    if not isinstance(raw, dict):
+        raise ValueError(f"Archive manifest is not an object: {key}")
+    return ArchiveManifest.from_dict(raw)  # type: ignore[arg-type]
+
+
+def write_manifest(store: ArchiveStore, key: str, manifest: ArchiveManifest) -> None:
+    payload: ArchiveManifestDict = manifest.to_dict()
+    store.put_text(
+        key, json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
+    )

--- a/src/langsmith_cli/archive/storage.py
+++ b/src/langsmith_cli/archive/storage.py
@@ -246,7 +246,12 @@ def create_store(uri: str) -> ArchiveStore:
             base_uri=uri.rstrip("/"),
         )
     if parsed.scheme == "file":
-        root = Path(parsed.path).expanduser().resolve()
+        # `urlparse()` leaves Windows file URIs as `/C:/...`; `Path` interprets
+        # that form inconsistently. The stdlib conversion preserves drive roots
+        # on Windows and remains an identity-style conversion on POSIX.
+        from urllib.request import url2pathname
+
+        root = Path(url2pathname(parsed.path)).expanduser().resolve()
     elif parsed.scheme == "":
         root = Path(uri).expanduser().resolve()
     else:

--- a/src/langsmith_cli/archive/storage.py
+++ b/src/langsmith_cli/archive/storage.py
@@ -118,7 +118,10 @@ class LocalArchiveStore:
         if not base.exists():
             return []
         return sorted(
-            str(path.relative_to(self.root))
+            # Object keys are POSIX on every backend. `str(Path)` would leak
+            # backslashes on Windows and then fail the same key invariant readers
+            # correctly enforce for S3/local parity.
+            path.relative_to(self.root).as_posix()
             for path in base.rglob("*")
             if path.is_file()
         )

--- a/src/langsmith_cli/archive/sync.py
+++ b/src/langsmith_cli/archive/sync.py
@@ -1,0 +1,263 @@
+"""Idempotent project-day export and canonicalization."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import date, datetime, time, timedelta, timezone
+from decimal import Decimal
+from enum import Enum
+import base64
+from collections.abc import Iterator as IteratorABC
+import json
+from pathlib import Path
+import tempfile
+from typing import TYPE_CHECKING, Any, Iterator, Protocol
+from uuid import uuid4
+from uuid import UUID
+
+from langsmith_cli.archive.models import (
+    ArchiveManifest,
+    ArchivePhase,
+    PhaseRecord,
+    PhaseStatus,
+)
+from langsmith_cli.archive.storage import (
+    ArchiveStore,
+    manifest_key,
+    read_manifest,
+    write_manifest,
+)
+
+if TYPE_CHECKING:
+    from langsmith.schemas import Run
+
+
+class DuckConnection(Protocol):
+    def execute(self, query: str, parameters: object | None = None) -> Any: ...
+
+
+class RunsExportClient(Protocol):
+    def list_runs(self, **kwargs: Any) -> Iterator[Run]: ...
+
+
+def _sql_string(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _archive_json_default(value: object) -> object:
+    """Serialize strict SDK values while preserving arbitrary binary payloads."""
+    if isinstance(value, bytes):
+        return {
+            "__langsmith_archive_encoding__": "base64",
+            "data": base64.b64encode(value).decode("ascii"),
+        }
+    if isinstance(value, (datetime, date, time)):
+        return value.isoformat()
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, (set, frozenset)):
+        return sorted(value, key=str)
+    if isinstance(value, IteratorABC):
+        return list(value)
+    raise TypeError(f"Unsupported archive value type: {type(value).__name__}")
+
+
+def due_trace_dates(
+    today: date, retention_days: int
+) -> tuple[tuple[date, ArchivePhase], ...]:
+    if retention_days < 4:
+        raise ValueError("Archive retention must be at least 4 days")
+    return (
+        (today - timedelta(days=2), ArchivePhase.PRIMARY),
+        (today - timedelta(days=retention_days - 2), ArchivePhase.RECONCILIATION),
+    )
+
+
+def _new_manifest(
+    project_id: str, project_name: str, trace_date: date
+) -> ArchiveManifest:
+    start = datetime.combine(trace_date, time.min, tzinfo=timezone.utc)
+    return ArchiveManifest(
+        schema_version=1,
+        project_id=project_id,
+        project_name=project_name,
+        trace_date=trace_date,
+        window_start=start,
+        window_end=start + timedelta(days=1),
+        primary=None,
+        reconciliation=None,
+        canonical_key=None,
+        canonical_run_count=0,
+        sealed=False,
+        updated_at=datetime.now(timezone.utc),
+    )
+
+
+def _write_runs_parquet(
+    client: RunsExportClient, manifest: ArchiveManifest, target: Path
+) -> int:
+    import duckdb
+
+    filter_ = f'lt(start_time, "{manifest.window_end.isoformat()}")'
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".jsonl", encoding="utf-8"
+    ) as rows:
+        run_count = 0
+        for run in client.list_runs(
+            project_id=manifest.project_id,
+            start_time=manifest.window_start,
+            filter=filter_,
+            limit=None,
+        ):
+            rows.write(
+                json.dumps(
+                    run.model_dump(mode="python"),
+                    ensure_ascii=False,
+                    default=_archive_json_default,
+                )
+            )
+            rows.write("\n")
+            run_count += 1
+        rows.flush()
+
+        connection = duckdb.connect()
+        try:
+            if run_count:
+                connection.execute(
+                    "COPY (SELECT * FROM read_json_auto("
+                    f"{_sql_string(rows.name)}, maximum_object_size=104857600)) "
+                    f"TO {_sql_string(str(target))} "
+                    "(FORMAT PARQUET, COMPRESSION ZSTD)"
+                )
+            else:
+                connection.execute(
+                    "COPY (SELECT CAST(NULL AS VARCHAR) AS id WHERE false) "
+                    f"TO {_sql_string(str(target))} "
+                    "(FORMAT PARQUET, COMPRESSION ZSTD)"
+                )
+        finally:
+            connection.close()
+    return run_count
+
+
+def _configure_s3(connection: DuckConnection, uris: list[str]) -> None:
+    if not any(uri.startswith("s3://") for uri in uris):
+        return
+    # DuckDB loads httpfs on first S3 access. The credential-chain secret delegates
+    # authentication to the same workload identity used by boto3.
+    connection.execute(
+        "CREATE OR REPLACE SECRET langsmith_archive_s3 "
+        "(TYPE s3, PROVIDER credential_chain)"
+    )
+
+
+def _canonicalize(store: ArchiveStore, manifest: ArchiveManifest, target: Path) -> int:
+    import duckdb
+
+    sources: list[tuple[str, int]] = []
+    if manifest.primary is not None:
+        sources.append((store.object_uri(manifest.primary.raw_key), 1))
+    if manifest.reconciliation is not None:
+        sources.append((store.object_uri(manifest.reconciliation.raw_key), 2))
+    if not sources:
+        raise ValueError("Cannot canonicalize a manifest without snapshots")
+
+    connection = duckdb.connect()
+    try:
+        _configure_s3(connection, [uri for uri, _ in sources])
+        selects: list[str] = []
+        for index, (uri, rank) in enumerate(sources):
+            view = f"archive_snapshot_{index}"
+            connection.execute(
+                f"CREATE TEMP VIEW {view} AS SELECT *, {rank} AS snapshot_rank "
+                f"FROM read_parquet({_sql_string(uri)}, union_by_name=true)"
+            )
+            counts = connection.execute(
+                f"SELECT count(*), count(DISTINCT id) FROM {view}"
+            ).fetchone()
+            if counts is None or counts[0] != counts[1]:
+                raise ValueError(f"Snapshot contains duplicate run IDs: {uri}")
+            selects.append(f"SELECT * FROM {view}")
+
+        union_sql = " UNION ALL BY NAME ".join(selects)
+        query = (
+            "SELECT * EXCLUDE (snapshot_rank, archive_row_number) FROM ("
+            "SELECT *, row_number() OVER (PARTITION BY id ORDER BY snapshot_rank DESC) "
+            f"AS archive_row_number FROM ({union_sql}) snapshots) ranked "
+            "WHERE archive_row_number = 1"
+        )
+        connection.execute(
+            f"COPY ({query}) TO {_sql_string(str(target))} "
+            "(FORMAT PARQUET, COMPRESSION ZSTD)"
+        )
+        count_row = connection.execute(f"SELECT count(*) FROM ({query})").fetchone()
+        if count_row is None:
+            raise ValueError("DuckDB did not return a canonical row count")
+        return int(count_row[0])
+    finally:
+        connection.close()
+
+
+def sync_project_day(
+    client: RunsExportClient,
+    store: ArchiveStore,
+    *,
+    project_id: str,
+    project_name: str,
+    trace_date: date,
+    phase: ArchivePhase,
+    existing_manifest: ArchiveManifest | None = None,
+    manifest_checked: bool = False,
+) -> ArchiveManifest:
+    """Export one phase and publish a deduplicated canonical generation."""
+    key = manifest_key(project_id, trace_date.isoformat())
+    manifest = existing_manifest
+    if not manifest_checked:
+        manifest = read_manifest(store, key)
+    manifest = manifest or _new_manifest(project_id, project_name, trace_date)
+    existing = manifest.phase(phase)
+    if existing is not None and existing.status is PhaseStatus.VERIFIED:
+        return manifest
+
+    generation_id = str(uuid4())
+    raw_key = (
+        f"raw/project_id={project_id}/date={trace_date.isoformat()}/"
+        f"phase={phase.value}/generation={generation_id}/runs.parquet"
+    )
+    now = datetime.now(timezone.utc)
+    with tempfile.TemporaryDirectory(prefix="langsmith-archive-") as directory:
+        staging = Path(directory)
+        raw_file = staging / "raw.parquet"
+        run_count = _write_runs_parquet(client, manifest, raw_file)
+        store.put_file(raw_key, raw_file)
+
+        record = PhaseRecord(
+            status=PhaseStatus.VERIFIED,
+            generation_id=generation_id,
+            raw_key=raw_key,
+            run_count=run_count,
+            verified_at=now,
+        )
+        manifest = manifest.with_phase(phase, record)
+        canonical_generation = str(uuid4())
+        canonical_key = (
+            f"canonical/project_id={project_id}/date={trace_date.isoformat()}/"
+            f"generation={canonical_generation}/runs.parquet"
+        )
+        canonical_file = staging / "canonical.parquet"
+        canonical_count = _canonicalize(store, manifest, canonical_file)
+        store.put_file(canonical_key, canonical_file)
+
+    published = replace(
+        manifest,
+        canonical_key=canonical_key,
+        canonical_run_count=canonical_count,
+        sealed=phase is ArchivePhase.RECONCILIATION,
+        updated_at=now,
+    )
+    write_manifest(store, key, published)
+    return published

--- a/src/langsmith_cli/archive/sync.py
+++ b/src/langsmith_cli/archive/sync.py
@@ -18,22 +18,22 @@ from uuid import UUID
 from langsmith_cli.archive.models import (
     ArchiveManifest,
     ArchivePhase,
+    ArchiveProject,
     PhaseRecord,
     PhaseStatus,
 )
-from langsmith_cli.archive.storage import (
-    ArchiveStore,
+from langsmith_cli.archive.duckdb import configure_duckdb_s3
+from langsmith_cli.archive.repository import (
+    ManifestSnapshot,
+    ensure_project_record,
     manifest_key,
-    read_manifest,
+    read_manifest_snapshot,
     write_manifest,
 )
+from langsmith_cli.archive.storage import ArchiveStore
 
 if TYPE_CHECKING:
     from langsmith.schemas import Run
-
-
-class DuckConnection(Protocol):
-    def execute(self, query: str, parameters: object | None = None) -> Any: ...
 
 
 class RunsExportClient(Protocol):
@@ -103,9 +103,10 @@ def _write_runs_parquet(
     import duckdb
 
     filter_ = f'lt(start_time, "{manifest.window_end.isoformat()}")'
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".jsonl", encoding="utf-8"
-    ) as rows:
+    # Close the JSONL before DuckDB opens it. Windows does not guarantee that a
+    # named temporary file can be reopened while Python still holds its handle.
+    rows_path = target.with_suffix(".jsonl")
+    with rows_path.open(mode="w", encoding="utf-8") as rows:
         run_count = 0
         for run in client.list_runs(
             project_id=manifest.project_id,
@@ -122,37 +123,26 @@ def _write_runs_parquet(
             )
             rows.write("\n")
             run_count += 1
-        rows.flush()
 
-        connection = duckdb.connect()
-        try:
-            if run_count:
-                connection.execute(
-                    "COPY (SELECT * FROM read_json_auto("
-                    f"{_sql_string(rows.name)}, maximum_object_size=104857600)) "
-                    f"TO {_sql_string(str(target))} "
-                    "(FORMAT PARQUET, COMPRESSION ZSTD)"
-                )
-            else:
-                connection.execute(
-                    "COPY (SELECT CAST(NULL AS VARCHAR) AS id WHERE false) "
-                    f"TO {_sql_string(str(target))} "
-                    "(FORMAT PARQUET, COMPRESSION ZSTD)"
-                )
-        finally:
-            connection.close()
+    connection = duckdb.connect()
+    try:
+        if run_count:
+            connection.execute(
+                "COPY (SELECT * FROM read_json_auto("
+                f"{_sql_string(str(rows_path))}, maximum_object_size=104857600)) "
+                f"TO {_sql_string(str(target))} "
+                "(FORMAT PARQUET, COMPRESSION ZSTD)"
+            )
+        else:
+            connection.execute(
+                "COPY (SELECT CAST(NULL AS VARCHAR) AS id WHERE false) "
+                f"TO {_sql_string(str(target))} "
+                "(FORMAT PARQUET, COMPRESSION ZSTD)"
+            )
+    finally:
+        connection.close()
+        rows_path.unlink(missing_ok=True)
     return run_count
-
-
-def _configure_s3(connection: DuckConnection, uris: list[str]) -> None:
-    if not any(uri.startswith("s3://") for uri in uris):
-        return
-    # DuckDB loads httpfs on first S3 access. The credential-chain secret delegates
-    # authentication to the same workload identity used by boto3.
-    connection.execute(
-        "CREATE OR REPLACE SECRET langsmith_archive_s3 "
-        "(TYPE s3, PROVIDER credential_chain)"
-    )
 
 
 def _canonicalize(store: ArchiveStore, manifest: ArchiveManifest, target: Path) -> int:
@@ -168,7 +158,7 @@ def _canonicalize(store: ArchiveStore, manifest: ArchiveManifest, target: Path) 
 
     connection = duckdb.connect()
     try:
-        _configure_s3(connection, [uri for uri, _ in sources])
+        configure_duckdb_s3(connection, [uri for uri, _ in sources])
         selects: list[str] = []
         for index, (uri, rank) in enumerate(sources):
             view = f"archive_snapshot_{index}"
@@ -194,9 +184,17 @@ def _canonicalize(store: ArchiveStore, manifest: ArchiveManifest, target: Path) 
             f"COPY ({query}) TO {_sql_string(str(target))} "
             "(FORMAT PARQUET, COMPRESSION ZSTD)"
         )
-        count_row = connection.execute(f"SELECT count(*) FROM ({query})").fetchone()
+        # Verify the artifact we will upload instead of rerunning the remote union
+        # and window function. This is one local scan and proves canonical IDs are
+        # unique at the actual publication boundary.
+        count_row = connection.execute(
+            "SELECT count(*), count(DISTINCT id) FROM "
+            f"read_parquet({_sql_string(str(target))})"
+        ).fetchone()
         if count_row is None:
             raise ValueError("DuckDB did not return a canonical row count")
+        if count_row[0] != count_row[1]:
+            raise ValueError("Canonical snapshot contains duplicate run IDs")
         return int(count_row[0])
     finally:
         connection.close()
@@ -210,19 +208,45 @@ def sync_project_day(
     project_name: str,
     trace_date: date,
     phase: ArchivePhase,
-    existing_manifest: ArchiveManifest | None = None,
-    manifest_checked: bool = False,
+    existing_snapshot: ManifestSnapshot | None = None,
+    manifest_known_absent: bool = False,
+    existing_project: ArchiveProject | None = None,
+    project_record_checked: bool = False,
 ) -> ArchiveManifest:
-    """Export one phase and publish a deduplicated canonical generation."""
+    """Export one phase and conditionally publish a canonical generation.
+
+    The manifest is the sole mutable publication pointer. Immutable raw/canonical
+    objects are uploaded first; compare-and-swap publication then ensures a stale
+    worker can leave only orphan objects, never clobber a newer verified manifest.
+    """
+    if project_record_checked and existing_project is not None:
+        if (
+            existing_project.project_id != project_id
+            or existing_project.project_name != project_name
+        ):
+            raise ValueError(
+                "Archived project identity changed; migrate it before syncing"
+            )
+    else:
+        ensure_project_record(store, project_id, project_name)
     key = manifest_key(project_id, trace_date.isoformat())
-    manifest = existing_manifest
-    if not manifest_checked:
-        manifest = read_manifest(store, key)
-    manifest = manifest or _new_manifest(project_id, project_name, trace_date)
+    snapshot = existing_snapshot
+    if snapshot is None and not manifest_known_absent:
+        snapshot = read_manifest_snapshot(store, key)
+    manifest = (
+        snapshot.manifest
+        if snapshot is not None
+        else _new_manifest(project_id, project_name, trace_date)
+    )
+    if manifest.project_name != project_name:
+        raise ValueError(
+            "Archived project name changed; migrate its manifest before syncing"
+        )
     existing = manifest.phase(phase)
     if existing is not None and existing.status is PhaseStatus.VERIFIED:
         return manifest
-
+    if manifest.sealed:
+        raise ValueError("A sealed archive day is immutable")
     generation_id = str(uuid4())
     raw_key = (
         f"raw/project_id={project_id}/date={trace_date.isoformat()}/"
@@ -259,5 +283,10 @@ def sync_project_day(
         sealed=phase is ArchivePhase.RECONCILIATION,
         updated_at=now,
     )
-    write_manifest(store, key, published)
+    write_manifest(
+        store,
+        key,
+        published,
+        expected_version=snapshot.version if snapshot is not None else None,
+    )
     return published

--- a/src/langsmith_cli/commands/archive.py
+++ b/src/langsmith_cli/commands/archive.py
@@ -13,8 +13,17 @@ from langsmith_cli.archive.config import (
     UnknownRouteError,
     load_archive_config,
 )
-from langsmith_cli.archive.models import ArchiveManifestDict, ArchivePhase
-from langsmith_cli.archive.storage import create_store, read_manifest
+from langsmith_cli.archive.models import (
+    ArchiveManifestDict,
+    ArchivePhase,
+    ArchiveProject,
+)
+from langsmith_cli.archive.repository import (
+    list_project_records,
+    read_manifest,
+    read_manifest_snapshot,
+)
+from langsmith_cli.archive.storage import ConcurrentArchiveWriteError, create_store
 from langsmith_cli.archive.sync import due_trace_dates, sync_project_day
 from langsmith_cli.output import json_dumps
 from langsmith_cli.utils import get_or_create_client, is_json_context
@@ -118,6 +127,13 @@ def sync_archive(
     manifest_keys = {
         route.name: set(stores[route.name].list_keys("manifests")) for route in routes
     }
+    project_records: dict[str, dict[str, ArchiveProject]] = {
+        route.name: {
+            project.project_id: project
+            for project in list_project_records(stores[route.name])
+        }
+        for route in routes
+    }
     for project in project_models:
         try:
             matched_route = config.route_project(project.name)
@@ -139,23 +155,40 @@ def sync_archive(
             before_key = (
                 f"manifests/project_id={project.id}/date={trace_date.isoformat()}.json"
             )
-            before = (
-                read_manifest(store, before_key, known_exists=True)
+            before_snapshot = (
+                read_manifest_snapshot(store, before_key, known_exists=True)
                 if before_key in manifest_keys[matched_route.name]
                 else None
             )
-            skipped = before is not None and before.phase(phase) is not None
-            manifest = sync_project_day(
-                client,
-                store,
+            skipped = (
+                before_snapshot is not None
+                and before_snapshot.manifest.phase(phase) is not None
+            )
+            try:
+                manifest = sync_project_day(
+                    client,
+                    store,
+                    project_id=str(project.id),
+                    project_name=project.name,
+                    trace_date=trace_date,
+                    phase=phase,
+                    existing_snapshot=before_snapshot,
+                    manifest_known_absent=before_snapshot is None,
+                    existing_project=project_records[matched_route.name].get(
+                        str(project.id)
+                    ),
+                    project_record_checked=True,
+                )
+            except ConcurrentArchiveWriteError as exc:
+                raise click.ClickException(
+                    "Archive manifest changed concurrently; rerun the sync safely"
+                ) from exc
+            manifest_keys[matched_route.name].add(before_key)
+            project_records[matched_route.name][str(project.id)] = ArchiveProject(
+                schema_version=1,
                 project_id=str(project.id),
                 project_name=project.name,
-                trace_date=trace_date,
-                phase=phase,
-                existing_manifest=before,
-                manifest_checked=True,
             )
-            manifest_keys[matched_route.name].add(before_key)
             results.append(
                 {
                     "route": matched_route.name,

--- a/src/langsmith_cli/commands/archive.py
+++ b/src/langsmith_cli/commands/archive.py
@@ -1,0 +1,215 @@
+"""Organization-operated trace archive commands."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import TypedDict
+
+import click
+
+from langsmith_cli.archive.config import (
+    ArchiveRoute,
+    UnmatchedProjectError,
+    UnknownRouteError,
+    load_archive_config,
+)
+from langsmith_cli.archive.models import ArchiveManifestDict, ArchivePhase
+from langsmith_cli.archive.storage import create_store, read_manifest
+from langsmith_cli.archive.sync import due_trace_dates, sync_project_day
+from langsmith_cli.output import json_dumps
+from langsmith_cli.utils import get_or_create_client, is_json_context
+
+
+class SyncResultDict(TypedDict):
+    route: str
+    archive_uri: str
+    project_name: str
+    project_id: str
+    trace_date: str
+    phase: str
+    skipped: bool
+    canonical_run_count: int
+    sealed: bool
+
+
+@click.group()
+def archive() -> None:
+    """Export traces to organization-owned Parquet archives."""
+
+
+def _selected_routes(
+    config_path: str | None, route_name: str | None, all_routes: bool
+) -> tuple[ArchiveRoute, ...]:
+    config = load_archive_config(config_path)
+    if route_name is not None and all_routes:
+        raise click.ClickException("Use either --route or --all-routes, not both")
+    if route_name is not None:
+        try:
+            return (config.route_named(route_name),)
+        except UnknownRouteError as exc:
+            raise click.ClickException(str(exc)) from exc
+    if all_routes or len(config.routes) == 1:
+        return config.routes
+    raise click.ClickException(
+        "Config has multiple archive routes; select --route NAME or --all-routes"
+    )
+
+
+@archive.command("sync")
+@click.option("--config", "config_path", type=click.Path(exists=True, dir_okay=False))
+@click.option("--route", "route_name", help="Sync one named archive route.")
+@click.option("--all-routes", is_flag=True, help="Sync every configured route.")
+@click.option("--project", "projects", multiple=True, help="Exact project to sync.")
+@click.option("--retention-days", default=14, show_default=True, type=int)
+@click.option(
+    "--date",
+    "trace_date_text",
+    help="Export one exact UTC trace date (YYYY-MM-DD); requires --phase.",
+)
+@click.option(
+    "--phase",
+    "phase_text",
+    type=click.Choice([phase.value for phase in ArchivePhase]),
+    help="Explicit phase for --date.",
+)
+@click.option(
+    "--today",
+    "today_text",
+    help="Override current UTC date (YYYY-MM-DD); intended for repair/testing.",
+)
+@click.pass_context
+def sync_archive(
+    ctx: click.Context,
+    config_path: str | None,
+    route_name: str | None,
+    all_routes: bool,
+    projects: tuple[str, ...],
+    retention_days: int,
+    trace_date_text: str | None,
+    phase_text: str | None,
+    today_text: str | None,
+) -> None:
+    """Run due D+2 primary and D+(retention-2) reconciliation exports."""
+    routes = _selected_routes(config_path, route_name, all_routes)
+    today = (
+        date.fromisoformat(today_text)
+        if today_text is not None
+        else datetime.now(timezone.utc).date()
+    )
+    if (trace_date_text is None) != (phase_text is None):
+        raise click.ClickException("--date and --phase must be provided together")
+    due = (
+        ((date.fromisoformat(trace_date_text), ArchivePhase(phase_text)),)
+        if trace_date_text is not None and phase_text is not None
+        else due_trace_dates(today, retention_days)
+    )
+    client = get_or_create_client(ctx)
+
+    if projects:
+        project_models = [client.read_project(project_name=name) for name in projects]
+    else:
+        project_models = list(client.list_projects(limit=None))
+
+    results: list[SyncResultDict] = []
+    unmatched_projects: list[str] = []
+    config = load_archive_config(config_path)
+    selected_names = {route.name for route in routes}
+    stores = {route.name: create_store(route.archive_uri) for route in routes}
+    manifest_keys = {
+        route.name: set(stores[route.name].list_keys("manifests")) for route in routes
+    }
+    for project in project_models:
+        try:
+            matched_route = config.route_project(project.name)
+        except UnmatchedProjectError as exc:
+            if projects:
+                raise click.ClickException(str(exc)) from exc
+            unmatched_projects.append(project.name)
+            continue
+        if matched_route.name not in selected_names:
+            if projects:
+                raise click.ClickException(
+                    f"Project {project.name} belongs to route {matched_route.name}, "
+                    f"not the selected route"
+                )
+            continue
+
+        store = stores[matched_route.name]
+        for trace_date, phase in due:
+            before_key = (
+                f"manifests/project_id={project.id}/date={trace_date.isoformat()}.json"
+            )
+            before = (
+                read_manifest(store, before_key, known_exists=True)
+                if before_key in manifest_keys[matched_route.name]
+                else None
+            )
+            skipped = before is not None and before.phase(phase) is not None
+            manifest = sync_project_day(
+                client,
+                store,
+                project_id=str(project.id),
+                project_name=project.name,
+                trace_date=trace_date,
+                phase=phase,
+                existing_manifest=before,
+                manifest_checked=True,
+            )
+            manifest_keys[matched_route.name].add(before_key)
+            results.append(
+                {
+                    "route": matched_route.name,
+                    "archive_uri": matched_route.archive_uri,
+                    "project_name": project.name,
+                    "project_id": str(project.id),
+                    "trace_date": trace_date.isoformat(),
+                    "phase": phase.value,
+                    "skipped": skipped,
+                    "canonical_run_count": manifest.canonical_run_count,
+                    "sealed": manifest.sealed,
+                }
+            )
+
+    if is_json_context(ctx):
+        click.echo(
+            json_dumps(
+                {
+                    "processed": results,
+                    "unmatched_projects": sorted(unmatched_projects),
+                }
+            )
+        )
+        return
+    logger = ctx.obj["logger"]
+    logger.success(f"Processed {len(results)} archive project-day phase(s)")
+    if unmatched_projects:
+        logger.warning(
+            f"Skipped {len(unmatched_projects)} project(s) without an archive route"
+        )
+
+
+@archive.command("status")
+@click.option("--config", "config_path", type=click.Path(exists=True, dir_okay=False))
+@click.option("--route", "route_name")
+@click.option("--all-routes", is_flag=True)
+@click.pass_context
+def archive_status(
+    ctx: click.Context,
+    config_path: str | None,
+    route_name: str | None,
+    all_routes: bool,
+) -> None:
+    """List published archive manifests."""
+    routes = _selected_routes(config_path, route_name, all_routes)
+    manifests: list[ArchiveManifestDict] = []
+    for route in routes:
+        store = create_store(route.archive_uri)
+        for key in store.list_keys("manifests"):
+            manifest = read_manifest(store, key, known_exists=True)
+            if manifest is not None:
+                manifests.append(manifest.to_dict())
+    if is_json_context(ctx):
+        click.echo(json_dumps(manifests))
+        return
+    logger = ctx.obj["logger"]
+    logger.info(f"Found {len(manifests)} archive manifest(s)")

--- a/src/langsmith_cli/commands/runs/get_cmd.py
+++ b/src/langsmith_cli/commands/runs/get_cmd.py
@@ -32,6 +32,11 @@ if TYPE_CHECKING:
 
 @runs.command("get")
 @click.argument("run_id")
+@click.option(
+    "--archive",
+    is_flag=True,
+    help="Read canonical Parquet from the configured archive.",
+)
 @fields_option(
     "Comma-separated field names to include (e.g., 'id,name,inputs,error'). Reduces context usage."
 )
@@ -46,7 +51,7 @@ if TYPE_CHECKING:
     ),
 )
 @click.pass_context
-def get_run(ctx, run_id, fields, output, follow_children):
+def get_run(ctx, run_id, archive, fields, output, follow_children):
     """Fetch details of a single run.
 
     Use --follow-children when the run is a parent chain (e.g. RunnableSequence)
@@ -57,6 +62,21 @@ def get_run(ctx, run_id, fields, output, follow_children):
         langsmith-cli --json runs get <id> --fields inputs,outputs
         langsmith-cli --json runs get <id> --follow-children --fields id,name,inputs,outputs
     """
+    if archive:
+        from langsmith_cli.archive.query import read_archived_run
+
+        try:
+            run, children = read_archived_run(run_id, follow_children=follow_children)
+        except LookupError as exc:
+            raise click.ClickException(str(exc)) from exc
+        data = filter_fields(run, fields)
+        if follow_children:
+            data["_children"] = [filter_fields(child, fields) for child in children]
+        output_single_item(
+            ctx, data, console, output=output, render_fn=render_run_details
+        )
+        return
+
     client = get_or_create_client(ctx)
     run = client.read_run(run_id)
 
@@ -85,6 +105,11 @@ def get_run(ctx, run_id, fields, output, follow_children):
 
 @runs.command("get-latest")
 @add_project_filter_options
+@click.option(
+    "--archive",
+    is_flag=True,
+    help="Read canonical Parquet from the configured archive.",
+)
 @click.option(
     "--status", type=click.Choice(["success", "error"]), help="Filter by status."
 )
@@ -125,6 +150,7 @@ def get_run(ctx, run_id, fields, output, follow_children):
 @click.pass_context
 def get_latest_run(
     ctx,
+    archive,
     project,
     project_id,
     project_name,
@@ -166,6 +192,58 @@ def get_latest_run(
         # Get latest slow run from last hour
         langsmith-cli --json runs get-latest --project my-project --slow --recent --fields name,latency
     """
+    if archive:
+        from datetime import datetime, time, timedelta, timezone
+
+        from langsmith_cli.archive.query import ArchiveRunQuery, query_archive_runs
+        from langsmith_cli.time_parsing import parse_time_range
+
+        if filter_ or slow or min_latency or max_latency:
+            raise click.ClickException(
+                "Archive backend does not yet support --filter or latency flags"
+            )
+        since_dt, before_dt = parse_time_range(since=since, last=last, before=before)
+        now = datetime.now(timezone.utc)
+        if recent:
+            since_dt = now - timedelta(hours=1)
+        if today:
+            since_dt = datetime.combine(now.date(), time.min, tzinfo=timezone.utc)
+        error_filter = None
+        if status == "error" or failed:
+            error_filter = True
+        elif status == "success" or succeeded:
+            error_filter = False
+        archived = query_archive_runs(
+            ArchiveRunQuery(
+                project=project,
+                project_id=project_id,
+                project_name=project_name,
+                project_name_exact=project_name_exact,
+                project_name_pattern=project_name_pattern,
+                project_name_regex=project_name_regex,
+                since=since_dt,
+                before=before_dt,
+                limit=1,
+                error=error_filter,
+                run_type=run_type,
+                is_root=roots,
+                tags=tuple(tag),
+                text=model,
+                text_fields=("extra",),
+            )
+        )
+        if not archived:
+            raise click.ClickException("No archived runs found matching the filters")
+        data = filter_fields(archived[0], fields)
+
+        def render_archived_latest(data: dict, console: Any) -> None:
+            render_run_details(data, console, title="Latest Archived Run")
+
+        output_single_item(
+            ctx, data, console, output=output, render_fn=render_archived_latest
+        )
+        return
+
     logger = ctx.obj["logger"]
     configure_logger_streams(ctx, logger, output=output, fields=fields)
 

--- a/src/langsmith_cli/commands/runs/list_cmd.py
+++ b/src/langsmith_cli/commands/runs/list_cmd.py
@@ -101,8 +101,180 @@ def _all_failures_are_query_rejection(
     return all(_is_query_rejection(exc) for exc in failed_exceptions.values())
 
 
+def _list_archived_runs(
+    *,
+    ctx: click.Context,
+    project: str | None,
+    project_id: str | None,
+    project_name: str | None,
+    project_name_exact: str | None,
+    project_name_pattern: str | None,
+    project_name_regex: str | None,
+    limit: int,
+    status: str | None,
+    filter_: str | None,
+    trace_id: str | None,
+    run_type: str | None,
+    is_root: bool | None,
+    roots: bool,
+    all_runs: bool,
+    trace_filter: str | None,
+    tree_filter: str | None,
+    reference_example_id: str | None,
+    tag: tuple[str, ...],
+    name_pattern: str | None,
+    name_regex: str | None,
+    model: str | None,
+    failed: bool,
+    succeeded: bool,
+    slow: bool,
+    recent: bool,
+    today: bool,
+    min_latency: str | None,
+    max_latency: str | None,
+    since: str | None,
+    before: str | None,
+    last: str | None,
+    query: str | None,
+    grep: str | None,
+    grep_ignore_case: bool,
+    grep_regex: bool,
+    grep_in: str | None,
+    metadata_filters: tuple[str, ...],
+    sort_by: str | None,
+    format_type: str,
+    no_truncate: bool,
+    exclude: tuple[str, ...],
+    fields: str | None,
+    count: bool,
+    output: str | None,
+    output_format: str | None,
+) -> None:
+    """Archive logic layer adapter followed by the existing view contracts."""
+    from datetime import datetime, time, timedelta, timezone
+
+    from langsmith_cli.archive.query import (
+        ArchiveRunQuery,
+        count_archive_runs,
+        query_archive_runs,
+    )
+    from langsmith_cli.time_parsing import parse_time_range
+
+    unsupported: list[str] = []
+    for enabled, flag in (
+        (filter_, "--filter"),
+        (trace_filter, "--trace-filter"),
+        (tree_filter, "--tree-filter"),
+        (reference_example_id, "--reference-example-id"),
+        (metadata_filters, "--metadata"),
+        (slow, "--slow"),
+        (min_latency, "--min-latency"),
+        (max_latency, "--max-latency"),
+    ):
+        if enabled:
+            unsupported.append(flag)
+    if unsupported:
+        raise click.ClickException(
+            "Archive backend does not yet support: " + ", ".join(unsupported)
+        )
+    if query and grep:
+        raise click.ClickException("Use either --query or --grep with --archive")
+
+    since_dt, before_dt = parse_time_range(since=since, last=last, before=before)
+    now = datetime.now(timezone.utc)
+    if recent:
+        since_dt = now - timedelta(hours=1)
+    if today:
+        since_dt = datetime.combine(now.date(), time.min, tzinfo=timezone.utc)
+
+    error_filter: bool | None = None
+    if status == "error" or failed:
+        error_filter = True
+    elif status == "success" or succeeded:
+        error_filter = False
+    root_filter = resolve_root_scope(roots=roots, all_runs=all_runs, is_root=is_root)
+    text = grep or query or model
+    if grep_in:
+        text_fields = tuple(
+            field.strip() for field in grep_in.split(",") if field.strip()
+        )
+    elif model:
+        text_fields = ("extra",)
+    else:
+        text_fields = ("inputs", "outputs", "error")
+
+    needs_local_filtering = bool(name_pattern or name_regex or exclude)
+    query_limit = 0 if count else limit
+    if needs_local_filtering and limit:
+        query_limit = max(limit * 3, 100)
+    archive_query = ArchiveRunQuery(
+        project=project,
+        project_id=project_id,
+        project_name=project_name,
+        project_name_exact=project_name_exact,
+        project_name_pattern=project_name_pattern,
+        project_name_regex=project_name_regex,
+        since=since_dt,
+        before=before_dt,
+        limit=query_limit,
+        error=error_filter,
+        trace_id=trace_id,
+        run_type=run_type,
+        is_root=root_filter,
+        tags=tuple(tag),
+        text=text,
+        text_fields=text_fields,
+        text_regex=bool(grep and grep_regex),
+        text_ignore_case=bool(grep and grep_ignore_case),
+    )
+    if count and not needs_local_filtering:
+        click.echo(str(count_archive_runs(archive_query)))
+        return
+    archived_runs = query_archive_runs(archive_query)
+    runs = get_matching_items(
+        archived_runs,
+        name_pattern=name_pattern,
+        name_regex=name_regex,
+        name_getter=lambda run: run.name or "",
+    )
+    runs = apply_exclude_filter(runs, exclude, lambda run: run.name or "")
+    if sort_by:
+        sort_key_map = {
+            "name": lambda run: (run.name or "").lower(),
+            "status": lambda run: run.status or "",
+            "latency": lambda run: run.latency if run.latency is not None else 0,
+            "start_time": lambda run: run.start_time,
+        }
+        runs = sort_items(runs, sort_by, sort_key_map, console)
+    runs = apply_client_side_limit(
+        runs, limit, has_client_filters=needs_local_filtering
+    )
+
+    if count:
+        click.echo(str(len(runs)))
+        return
+    if output:
+        data = filter_fields(runs, fields)
+        file_format = output_format if output_format is not None else "jsonl"
+        write_output_to_file(data, output, console, format_type=file_format)
+        return
+    if format_type != "table":
+        output_formatted_data(filter_fields(runs, fields), format_type)
+        return
+    table = build_runs_table(runs, "Archived Runs", no_truncate)
+    if not runs:
+        ctx.obj["logger"].warning("No archived runs found matching your criteria.")
+        return
+    console.print(table)
+
+
 @runs.command("list")
 @add_project_filter_options
+@click.option(
+    "--archive",
+    is_flag=True,
+    help="Query canonical Parquet from the configured archive instead of LangSmith.",
+)
 @click.option("--limit", default=20, help="Max runs to fetch (per project).")
 @click.option(
     "--status", type=click.Choice(["success", "error"]), help="Filter by status."
@@ -213,6 +385,7 @@ def _all_failures_are_query_rejection(
 @click.pass_context
 def list_runs(
     ctx,
+    archive,
     project,
     project_id,
     project_name,
@@ -299,6 +472,56 @@ def list_runs(
         count=count,
         fields=fields,
     )
+
+    if archive:
+        return _list_archived_runs(
+            ctx=ctx,
+            project=project,
+            project_id=project_id,
+            project_name=project_name,
+            project_name_exact=project_name_exact,
+            project_name_pattern=project_name_pattern,
+            project_name_regex=project_name_regex,
+            limit=limit,
+            status=status,
+            filter_=filter_,
+            trace_id=trace_id,
+            run_type=run_type,
+            is_root=is_root,
+            roots=roots,
+            all_runs=all_runs,
+            trace_filter=trace_filter,
+            tree_filter=tree_filter,
+            reference_example_id=reference_example_id,
+            tag=tag,
+            name_pattern=name_pattern,
+            name_regex=name_regex,
+            model=model,
+            failed=failed,
+            succeeded=succeeded,
+            slow=slow,
+            recent=recent,
+            today=today,
+            min_latency=min_latency,
+            max_latency=max_latency,
+            since=since,
+            before=before,
+            last=last,
+            query=query,
+            grep=grep,
+            grep_ignore_case=grep_ignore_case,
+            grep_regex=grep_regex,
+            grep_in=grep_in,
+            metadata_filters=metadata_filters,
+            sort_by=sort_by,
+            format_type=format_type,
+            no_truncate=no_truncate,
+            exclude=exclude,
+            fields=fields,
+            count=count,
+            output=output,
+            output_format=output_format,
+        )
 
     # When --count is used, default to unlimited (0) unless user explicitly set limit
     # Check if limit was explicitly provided by checking if it's not the default

--- a/src/langsmith_cli/commands/runs/list_cmd.py
+++ b/src/langsmith_cli/commands/runs/list_cmd.py
@@ -140,6 +140,7 @@ def _list_archived_runs(
     grep_ignore_case: bool,
     grep_regex: bool,
     grep_in: str | None,
+    fetch: int | None,
     metadata_filters: tuple[str, ...],
     sort_by: str | None,
     format_type: str,
@@ -205,7 +206,9 @@ def _list_archived_runs(
 
     needs_local_filtering = bool(name_pattern or name_regex or exclude)
     query_limit = 0 if count else limit
-    if needs_local_filtering and limit:
+    if fetch is not None:
+        query_limit = fetch
+    elif needs_local_filtering and limit:
         query_limit = max(limit * 3, 100)
     archive_query = ArchiveRunQuery(
         project=project,
@@ -225,7 +228,9 @@ def _list_archived_runs(
         text=text,
         text_fields=text_fields,
         text_regex=bool(grep and grep_regex),
-        text_ignore_case=bool(grep and grep_ignore_case),
+        # `--query` and model matching follow server-search-style case-insensitive
+        # semantics; literal `--grep` remains case-sensitive unless `-i` is set.
+        text_ignore_case=bool(query or model or (grep and grep_ignore_case)),
     )
     if count and not needs_local_filtering:
         click.echo(str(count_archive_runs(archive_query)))
@@ -512,6 +517,7 @@ def list_runs(
             grep_ignore_case=grep_ignore_case,
             grep_regex=grep_regex,
             grep_in=grep_in,
+            fetch=fetch,
             metadata_filters=metadata_filters,
             sort_by=sort_by,
             format_type=format_type,

--- a/src/langsmith_cli/commands/runs/search_cmd.py
+++ b/src/langsmith_cli/commands/runs/search_cmd.py
@@ -31,6 +31,11 @@ from langsmith_cli.utils import (
 
 @runs.command("search")
 @click.argument("query")
+@click.option(
+    "--archive",
+    is_flag=True,
+    help="Search canonical Parquet from the configured archive.",
+)
 @add_project_filter_options
 @add_time_filter_options
 @click.option("--limit", default=10, help="Max results.")
@@ -93,6 +98,7 @@ from langsmith_cli.utils import (
 def search_runs(
     ctx,
     query,
+    archive,
     project,
     project_id,
     project_name,
@@ -202,6 +208,7 @@ def search_runs(
         fields=fields,
         count=count,
         output=output,
+        archive=archive,
     )
 
 

--- a/src/langsmith_cli/main.py
+++ b/src/langsmith_cli/main.py
@@ -5,6 +5,7 @@ from typing import Any
 import click
 from dotenv import load_dotenv
 from langsmith_cli.commands.annotation_queues import annotation_queues
+from langsmith_cli.commands.archive import archive
 from langsmith_cli.commands.auth import login
 from langsmith_cli.commands.datasets import datasets
 from langsmith_cli.commands.examples import examples
@@ -415,6 +416,7 @@ def auth():
 
 auth.add_command(login)
 cli_main.add_command(auth)
+cli_main.add_command(archive)
 cli_main.add_command(annotation_queues)
 cli_main.add_command(datasets)
 cli_main.add_command(examples)

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -66,6 +66,56 @@ def test_overlapping_routes_fail_fast(tmp_path: Path) -> None:
         config.route_project("dev/agent")
 
 
+@pytest.mark.parametrize(
+    "content",
+    [
+        "[]",
+        "routes: invalid",
+        "routes:\n  - invalid",
+        "routes:\n  - name: dev\n    project_pattern: 'dev/**'",
+        "routes:\n  - name: 7\n    project_pattern: 'dev/**'\n    archive_uri: /tmp/dev",
+        "routes: []",
+        """routes:
+  - name: dev
+    project_pattern: dev/**
+    archive_uri: /tmp/dev
+  - name: dev
+    project_pattern: staging/**
+    archive_uri: /tmp/staging
+""",
+    ],
+)
+def test_route_config_rejects_malformed_or_ambiguous_contracts(
+    tmp_path: Path, content: str
+) -> None:
+    config_path = tmp_path / "invalid.yaml"
+    config_path.write_text(content, encoding="utf-8")
+    with pytest.raises(ValueError):
+        load_archive_config(str(config_path))
+
+
+def test_route_config_requires_a_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LANGSMITH_ARCHIVE_CONFIG", raising=False)
+    monkeypatch.delenv("LANGSMITH_ARCHIVE_URI", raising=False)
+    with pytest.raises(ValueError, match="LANGSMITH_ARCHIVE_URI"):
+        load_archive_config()
+
+
+def test_route_config_requires_exact_selected_route(tmp_path: Path) -> None:
+    config = load_archive_config(str(_write_single_route_config(tmp_path)))
+    with pytest.raises(ValueError, match="exist exactly once"):
+        config.route_named("missing")
+
+
+def _write_single_route_config(tmp_path: Path) -> Path:
+    config_path = tmp_path / "single-route.yaml"
+    config_path.write_text(
+        "routes:\n  - name: dev\n    project_pattern: 'dev/**'\n    archive_uri: /tmp/dev\n",
+        encoding="utf-8",
+    )
+    return config_path
+
+
 def test_due_dates_leave_two_day_repair_buffer() -> None:
     assert due_trace_dates(date(2026, 8, 21), 14) == (
         (date(2026, 8, 19), ArchivePhase.PRIMARY),

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,0 +1,210 @@
+"""Archive routing, reconciliation, and DuckDB query tests."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+from langsmith.schemas import Run
+
+from conftest import create_run, parse_json_output
+from langsmith_cli.archive.config import load_archive_config
+from langsmith_cli.archive.models import ArchivePhase
+from langsmith_cli.archive.query import ArchiveRunQuery, query_archive_runs
+from langsmith_cli.archive.storage import create_store
+from langsmith_cli.archive.sync import due_trace_dates, sync_project_day
+from langsmith_cli.main import cli
+
+
+class FakeRunsClient:
+    def __init__(self, runs: list[Run]) -> None:
+        self.runs = runs
+        self.calls = 0
+
+    def list_runs(self, **kwargs: Any) -> Iterator[Run]:
+        self.calls += 1
+        return iter(self.runs)
+
+
+def test_route_config_selects_exactly_one_destination(tmp_path: Path) -> None:
+    config_path = tmp_path / "archive.yaml"
+    config_path.write_text(
+        """routes:
+  - name: dev
+    project_pattern: dev/**
+    archive_uri: s3://traces-dev/langsmith
+  - name: staging
+    project_pattern: stg/**
+    archive_uri: s3://traces-stg/langsmith
+""",
+        encoding="utf-8",
+    )
+    config = load_archive_config(str(config_path))
+    assert config.route_project("dev/agent").archive_uri == "s3://traces-dev/langsmith"
+    assert config.route_project("stg/agent").name == "staging"
+    with pytest.raises(ValueError, match="No archive route"):
+        config.route_project("prd/agent")
+
+
+def test_overlapping_routes_fail_fast(tmp_path: Path) -> None:
+    config_path = tmp_path / "archive.yaml"
+    config_path.write_text(
+        """routes:
+  - name: dev
+    project_pattern: dev/**
+    archive_uri: s3://traces-dev/langsmith
+  - name: everything
+    project_pattern: '**'
+    archive_uri: s3://traces-all/langsmith
+""",
+        encoding="utf-8",
+    )
+    config = load_archive_config(str(config_path))
+    with pytest.raises(ValueError, match="multiple archive routes"):
+        config.route_project("dev/agent")
+
+
+def test_due_dates_leave_two_day_repair_buffer() -> None:
+    assert due_trace_dates(date(2026, 8, 21), 14) == (
+        (date(2026, 8, 19), ArchivePhase.PRIMARY),
+        (date(2026, 8, 9), ArchivePhase.RECONCILIATION),
+    )
+
+
+def test_binary_trace_payload_is_preserved_as_base64(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive_uri = str(tmp_path / "archive")
+    monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
+    binary_run = create_run(inputs={"image": b"\xff\x00\x80"})
+    sync_project_day(
+        FakeRunsClient([binary_run]),
+        create_store(archive_uri),
+        project_id="f47ac10b-58cc-4372-a567-0e02b2c3d479",
+        project_name="dev/binary",
+        trace_date=date(2024, 7, 3),
+        phase=ArchivePhase.PRIMARY,
+    )
+    archived = query_archive_runs(ArchiveRunQuery(project="dev/binary", limit=0))
+    assert archived[0].inputs["image"] == {
+        "__langsmith_archive_encoding__": "base64",
+        "data": "/wCA",
+    }
+
+
+def test_reconciliation_deduplicates_and_is_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, runner
+) -> None:
+    archive_uri = str(tmp_path / "archive")
+    monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
+    store = create_store(archive_uri)
+    trace_date = date(2024, 7, 3)
+    project_id = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+
+    primary_run = create_run(outputs={"version": "primary"})
+    primary_client = FakeRunsClient([primary_run])
+    sync_project_day(
+        primary_client,
+        store,
+        project_id=project_id,
+        project_name="dev/agent",
+        trace_date=trace_date,
+        phase=ArchivePhase.PRIMARY,
+    )
+
+    updated_run = create_run(outputs={"version": "reconciled"})
+    late_child = create_run(
+        id_str="22345678-1234-5678-1234-567812345678",
+        name="late-child",
+        parent_run_id=str(primary_run.id),
+        trace_id=str(primary_run.id),
+    )
+    reconciliation_client = FakeRunsClient([updated_run, late_child])
+    manifest = sync_project_day(
+        reconciliation_client,
+        store,
+        project_id=project_id,
+        project_name="dev/agent",
+        trace_date=trace_date,
+        phase=ArchivePhase.RECONCILIATION,
+    )
+    assert manifest.sealed is True
+    assert manifest.canonical_run_count == 2
+
+    archived = query_archive_runs(
+        ArchiveRunQuery(
+            project="dev/agent",
+            since=datetime(2024, 7, 3),
+            before=datetime(2024, 7, 4),
+            limit=0,
+        )
+    )
+    assert {str(run.id) for run in archived} == {
+        str(primary_run.id),
+        str(late_child.id),
+    }
+    root = next(run for run in archived if run.id == primary_run.id)
+    assert root.outputs == {"version": "reconciled"}
+
+    sync_project_day(
+        reconciliation_client,
+        store,
+        project_id=project_id,
+        project_name="dev/agent",
+        trace_date=trace_date,
+        phase=ArchivePhase.RECONCILIATION,
+    )
+    assert reconciliation_client.calls == 1
+
+    search_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "runs",
+            "search",
+            "reconciled",
+            "--archive",
+            "--project",
+            "dev/agent",
+        ],
+    )
+    assert search_result.exit_code == 0, search_result.output
+    search_data = parse_json_output(search_result.output)
+    assert [item["id"] for item in search_data] == [str(primary_run.id)]
+
+    get_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "runs",
+            "get",
+            str(primary_run.id),
+            "--archive",
+            "--follow-children",
+        ],
+    )
+    assert get_result.exit_code == 0, get_result.output
+    get_data = parse_json_output(get_result.output)
+    assert get_data["outputs"] == {"version": "reconciled"}
+    assert [child["name"] for child in get_data["_children"]] == ["late-child"]
+
+    count_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "runs",
+            "list",
+            "--archive",
+            "--project",
+            "dev/agent",
+            "--since",
+            "2024-07-03",
+            "--before",
+            "2024-07-04",
+            "--count",
+        ],
+    )
+    assert count_result.exit_code == 0, count_result.output
+    assert count_result.output.strip() == "2"

--- a/tests/test_archive_commands.py
+++ b/tests/test_archive_commands.py
@@ -239,6 +239,176 @@ def test_archive_list_honors_fetch_for_local_filters(
     assert observed_limits == [7]
 
 
+def test_archive_get_reports_missing_run(
+    monkeypatch: pytest.MonkeyPatch,
+    runner,
+) -> None:
+    from langsmith_cli.archive import query as archive_query
+
+    def missing_run(run_id: str, *, follow_children: bool) -> tuple[Run, list[Run]]:
+        raise LookupError(f"Archived run not found: {run_id}")
+
+    monkeypatch.setattr(archive_query, "read_archived_run", missing_run)
+    result = runner.invoke(
+        cli,
+        ["--json", "runs", "get", "12345678-1234-5678-1234-567812345678", "--archive"],
+    )
+
+    assert result.exit_code != 0
+    assert "Archived run not found" in parse_json_output(result.output)["message"]
+
+
+def test_archive_get_latest_maps_filters_and_fields(
+    monkeypatch: pytest.MonkeyPatch,
+    runner,
+) -> None:
+    from langsmith_cli.archive import query as archive_query
+
+    observed: list[archive_query.ArchiveRunQuery] = []
+
+    def query_runs(query: archive_query.ArchiveRunQuery) -> list[Run]:
+        observed.append(query)
+        return [create_run(name="latest", error="boom", extra={"model": "gpt-5"})]
+
+    monkeypatch.setattr(archive_query, "query_archive_runs", query_runs)
+    result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "runs",
+            "get-latest",
+            "--archive",
+            "--project",
+            "dev/agent",
+            "--failed",
+            "--roots",
+            "--tag",
+            "nightly",
+            "--model",
+            "gpt-5",
+            "--fields",
+            "id,name,error",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert parse_json_output(result.output)["name"] == "latest"
+    query = observed[0]
+    assert query.project == "dev/agent"
+    assert query.error is True
+    assert query.is_root is True
+    assert query.tags == ("nightly",)
+    assert query.text == "gpt-5"
+    assert query.text_fields == ("extra",)
+
+
+@pytest.mark.parametrize(
+    ("arguments", "message"),
+    [
+        (["--filter", 'eq(name, "x")'], "does not yet support"),
+        ([], "No archived runs found"),
+    ],
+)
+def test_archive_get_latest_fails_clearly(
+    monkeypatch: pytest.MonkeyPatch,
+    runner,
+    arguments: list[str],
+    message: str,
+) -> None:
+    from langsmith_cli.archive import query as archive_query
+
+    monkeypatch.setattr(archive_query, "query_archive_runs", lambda query: [])
+    result = runner.invoke(
+        cli,
+        ["--json", "runs", "get-latest", "--archive", *arguments],
+    )
+
+    assert result.exit_code != 0
+    assert message in parse_json_output(result.output)["message"]
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        ["--filter", 'eq(name, "x")'],
+        ["--query", "needle", "--grep", "needle"],
+    ],
+)
+def test_archive_list_rejects_unsupported_or_ambiguous_filters(
+    runner,
+    arguments: list[str],
+) -> None:
+    result = runner.invoke(
+        cli,
+        ["--json", "runs", "list", "--archive", *arguments],
+    )
+
+    assert result.exit_code != 0
+
+
+def test_archive_list_applies_local_filters_sort_limit_and_count(
+    monkeypatch: pytest.MonkeyPatch,
+    runner,
+) -> None:
+    from langsmith_cli.archive import query as archive_query
+
+    runs = [
+        create_run(name="worker-b"),
+        create_run(name="ignore", id_str="22345678-1234-5678-1234-567812345678"),
+        create_run(name="worker-a", id_str="32345678-1234-5678-1234-567812345678"),
+    ]
+    monkeypatch.setattr(archive_query, "query_archive_runs", lambda query: runs)
+    result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "runs",
+            "list",
+            "--archive",
+            "--name-pattern",
+            "worker-*",
+            "--exclude",
+            "*b",
+            "--sort-by",
+            "name",
+            "--limit",
+            "1",
+            "--count",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == "1"
+
+
+def test_archive_list_writes_selected_fields(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner,
+) -> None:
+    from langsmith_cli.archive import query as archive_query
+
+    monkeypatch.setattr(
+        archive_query, "query_archive_runs", lambda query: [create_run(name="saved")]
+    )
+    output_path = tmp_path / "runs.jsonl"
+    result = runner.invoke(
+        cli,
+        [
+            "runs",
+            "list",
+            "--archive",
+            "--output",
+            str(output_path),
+            "--fields",
+            "id,name",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert '"name": "saved"' in output_path.read_text(encoding="utf-8")
+
+
 @pytest.mark.parametrize(
     "arguments",
     [

--- a/tests/test_archive_commands.py
+++ b/tests/test_archive_commands.py
@@ -1,0 +1,266 @@
+"""CLI contracts for organization-operated archive jobs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+from langsmith.schemas import Run, TracerSessionResult
+
+from conftest import create_project, create_run, parse_json_output
+from langsmith_cli.main import cli
+
+
+class FakeArchiveClient:
+    def __init__(self, projects: list[TracerSessionResult], runs: list[Run]) -> None:
+        self.projects = projects
+        self.runs = runs
+
+    def list_projects(self, *, limit: None) -> Iterator[TracerSessionResult]:
+        return iter(self.projects)
+
+    def read_project(self, *, project_name: str) -> TracerSessionResult:
+        return next(
+            project for project in self.projects if project.name == project_name
+        )
+
+    def list_runs(self, **kwargs: Any) -> Iterator[Run]:
+        return iter(self.runs)
+
+
+def _write_config(tmp_path: Path) -> Path:
+    config_path = tmp_path / "archive.yaml"
+    config_path.write_text(
+        f"""routes:
+  - name: dev
+    project_pattern: dev/**
+    archive_uri: {tmp_path / "dev-archive"}
+  - name: staging
+    project_pattern: stg/**
+    archive_uri: {tmp_path / "stg-archive"}
+""",
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def test_sync_command_routes_projects_and_reports_unmatched(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner,
+) -> None:
+    from langsmith_cli.commands import archive as archive_commands
+
+    client = FakeArchiveClient(
+        [
+            create_project(name="dev/agent"),
+            create_project(
+                name="qa/unrouted",
+                project_id="22345678-1234-5678-1234-567812345678",
+            ),
+        ],
+        [create_run()],
+    )
+    monkeypatch.setattr(archive_commands, "get_or_create_client", lambda ctx: client)
+    result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "archive",
+            "sync",
+            "--config",
+            str(_write_config(tmp_path)),
+            "--route",
+            "dev",
+            "--today",
+            "2026-08-21",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = parse_json_output(result.output)
+    assert len(payload["processed"]) == 2
+    assert {item["phase"] for item in payload["processed"]} == {
+        "primary",
+        "reconciliation",
+    }
+    assert payload["unmatched_projects"] == ["qa/unrouted"]
+    assert all(item["route"] == "dev" for item in payload["processed"])
+
+
+def test_sync_command_rejects_project_from_another_selected_route(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner,
+) -> None:
+    from langsmith_cli.commands import archive as archive_commands
+
+    client = FakeArchiveClient([create_project(name="dev/agent")], [create_run()])
+    monkeypatch.setattr(archive_commands, "get_or_create_client", lambda ctx: client)
+    result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "archive",
+            "sync",
+            "--config",
+            str(_write_config(tmp_path)),
+            "--route",
+            "staging",
+            "--project",
+            "dev/agent",
+            "--date",
+            "2026-08-19",
+            "--phase",
+            "primary",
+        ],
+    )
+
+    assert result.exit_code != 0
+    payload = parse_json_output(result.output)
+    assert "belongs to route dev" in payload["message"]
+
+
+def test_status_command_lists_published_manifests(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner,
+) -> None:
+    from langsmith_cli.commands import archive as archive_commands
+
+    client = FakeArchiveClient([create_project(name="dev/agent")], [create_run()])
+    monkeypatch.setattr(archive_commands, "get_or_create_client", lambda ctx: client)
+    config_path = _write_config(tmp_path)
+    sync_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "archive",
+            "sync",
+            "--config",
+            str(config_path),
+            "--route",
+            "dev",
+            "--project",
+            "dev/agent",
+            "--date",
+            "2026-08-19",
+            "--phase",
+            "primary",
+        ],
+    )
+    assert sync_result.exit_code == 0, sync_result.output
+
+    status_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "archive",
+            "status",
+            "--config",
+            str(config_path),
+            "--route",
+            "dev",
+        ],
+    )
+    assert status_result.exit_code == 0, status_result.output
+    manifests = parse_json_output(status_result.output)
+    assert len(manifests) == 1
+    assert manifests[0]["project_name"] == "dev/agent"
+    assert manifests[0]["canonical_run_count"] == 1
+
+
+def test_sync_command_surfaces_safe_retry_on_concurrent_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner,
+) -> None:
+    from langsmith_cli.archive.storage import ConcurrentArchiveWriteError
+    from langsmith_cli.commands import archive as archive_commands
+
+    client = FakeArchiveClient([create_project(name="dev/agent")], [create_run()])
+    monkeypatch.setattr(archive_commands, "get_or_create_client", lambda ctx: client)
+
+    def conflict(*args: object, **kwargs: object) -> None:
+        raise ConcurrentArchiveWriteError("stale")
+
+    monkeypatch.setattr(archive_commands, "sync_project_day", conflict)
+    result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "archive",
+            "sync",
+            "--config",
+            str(_write_config(tmp_path)),
+            "--route",
+            "dev",
+            "--project",
+            "dev/agent",
+            "--date",
+            "2026-08-19",
+            "--phase",
+            "primary",
+        ],
+    )
+    assert result.exit_code != 0
+    payload = parse_json_output(result.output)
+    assert "rerun the sync safely" in payload["message"]
+
+
+def test_archive_list_honors_fetch_for_local_filters(
+    monkeypatch: pytest.MonkeyPatch,
+    runner,
+) -> None:
+    from langsmith_cli.archive import query as archive_query
+
+    observed_limits: list[int | None] = []
+
+    def query_runs(query: archive_query.ArchiveRunQuery) -> list[Run]:
+        observed_limits.append(query.limit)
+        return []
+
+    monkeypatch.setattr(archive_query, "query_archive_runs", query_runs)
+    result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "runs",
+            "list",
+            "--archive",
+            "--name-pattern",
+            "worker-*",
+            "--fetch",
+            "7",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert observed_limits == [7]
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        ["--route", "dev", "--all-routes"],
+        [],
+        ["--date", "2026-08-19"],
+    ],
+)
+def test_sync_command_rejects_ambiguous_or_incomplete_selection(
+    tmp_path: Path,
+    runner,
+    arguments: list[str],
+) -> None:
+    result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "archive",
+            "sync",
+            "--config",
+            str(_write_config(tmp_path)),
+            *arguments,
+        ],
+    )
+    assert result.exit_code != 0

--- a/tests/test_archive_invariants.py
+++ b/tests/test_archive_invariants.py
@@ -339,6 +339,12 @@ def test_store_rejects_object_key_traversal(tmp_path: Path) -> None:
         store.object_uri("../outside.parquet")
 
 
+def test_local_store_lists_backend_neutral_posix_object_keys(tmp_path: Path) -> None:
+    store = create_store(str(tmp_path / "archive"))
+    store.put_text("projects/project_id=one.json", "{}")
+    assert store.list_keys("projects") == ["projects/project_id=one.json"]
+
+
 def test_windows_drive_paths_are_not_uri_schemes() -> None:
     assert _is_windows_drive_path(r"C:\archive\traces") is True
     assert _is_windows_drive_path("s3://bucket/traces") is False

--- a/tests/test_archive_invariants.py
+++ b/tests/test_archive_invariants.py
@@ -1,0 +1,443 @@
+"""Publication, safety, and query invariants for trace archives."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import date, timedelta
+from io import BytesIO
+import json
+from pathlib import Path
+from threading import Barrier, Thread
+from typing import Any, Iterator
+
+import pytest
+from langsmith.schemas import Run
+
+from conftest import create_run
+from langsmith_cli.archive.models import ArchivePhase
+from langsmith_cli.archive.query import (
+    ArchiveRunQuery,
+    count_archive_runs,
+    query_archive_runs,
+)
+from langsmith_cli.archive.repository import (
+    ensure_project_record,
+    manifest_key,
+    project_key,
+    read_manifest,
+    read_manifest_snapshot,
+    write_manifest,
+)
+from langsmith_cli.archive.storage import (
+    ConcurrentArchiveWriteError,
+    S3ArchiveStore,
+    _is_windows_drive_path,
+    create_store,
+)
+from langsmith_cli.archive.sync import sync_project_day
+
+
+PROJECT_ID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+TRACE_DATE = date(2024, 7, 3)
+
+
+class FakeRunsClient:
+    def __init__(self, runs: list[Run]) -> None:
+        self.runs = runs
+        self.calls = 0
+
+    def list_runs(self, **kwargs: Any) -> Iterator[Run]:
+        self.calls += 1
+        return iter(self.runs)
+
+
+def _sync_primary(tmp_path: Path, runs: list[Run]):
+    store = create_store(str(tmp_path / "archive"))
+    manifest = sync_project_day(
+        FakeRunsClient(runs),
+        store,
+        project_id=PROJECT_ID,
+        project_name="dev/agent",
+        trace_date=TRACE_DATE,
+        phase=ArchivePhase.PRIMARY,
+    )
+    return store, manifest
+
+
+def test_manifest_publication_rejects_a_stale_writer(tmp_path: Path) -> None:
+    store, _ = _sync_primary(tmp_path, [create_run()])
+    key = manifest_key(PROJECT_ID, TRACE_DATE.isoformat())
+    snapshot = read_manifest_snapshot(store, key, known_exists=True)
+    assert snapshot is not None
+
+    first = replace(
+        snapshot.manifest,
+        updated_at=snapshot.manifest.updated_at + timedelta(seconds=1),
+    )
+    write_manifest(store, key, first, expected_version=snapshot.version)
+
+    stale = replace(
+        snapshot.manifest,
+        updated_at=snapshot.manifest.updated_at + timedelta(seconds=2),
+    )
+    with pytest.raises(ConcurrentArchiveWriteError, match="changed concurrently"):
+        write_manifest(store, key, stale, expected_version=snapshot.version)
+
+    assert read_manifest(store, key, known_exists=True) == first
+
+
+def test_two_manifest_publishers_cannot_both_win(tmp_path: Path) -> None:
+    store, _ = _sync_primary(tmp_path, [create_run()])
+    key = manifest_key(PROJECT_ID, TRACE_DATE.isoformat())
+    snapshot = read_manifest_snapshot(store, key, known_exists=True)
+    assert snapshot is not None
+    candidates = [
+        replace(
+            snapshot.manifest,
+            updated_at=snapshot.manifest.updated_at + timedelta(seconds=offset),
+        )
+        for offset in (1, 2)
+    ]
+    barrier = Barrier(2)
+    outcomes: list[str] = []
+
+    def publish(candidate_index: int) -> None:
+        barrier.wait()
+        try:
+            write_manifest(
+                store,
+                key,
+                candidates[candidate_index],
+                expected_version=snapshot.version,
+            )
+        except ConcurrentArchiveWriteError:
+            outcomes.append("conflict")
+        else:
+            outcomes.append("published")
+
+    threads = [Thread(target=publish, args=(index,)) for index in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert sorted(outcomes) == ["conflict", "published"]
+    assert read_manifest(store, key, known_exists=True) in candidates
+
+
+def test_reconciliation_only_bootstrap_is_sealed_and_queryable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive_uri = str(tmp_path / "archive")
+    monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
+    client = FakeRunsClient([create_run()])
+    manifest = sync_project_day(
+        client,
+        create_store(archive_uri),
+        project_id=PROJECT_ID,
+        project_name="dev/agent",
+        trace_date=TRACE_DATE,
+        phase=ArchivePhase.RECONCILIATION,
+    )
+    assert manifest.primary is None
+    assert manifest.sealed is True
+    assert manifest.canonical_run_count == 1
+    assert len(query_archive_runs(ArchiveRunQuery(project="dev/agent"))) == 1
+
+
+def test_sealed_day_is_idempotent_and_cannot_be_unsealed(tmp_path: Path) -> None:
+    store, _ = _sync_primary(tmp_path, [create_run()])
+    sealed = sync_project_day(
+        FakeRunsClient([create_run()]),
+        store,
+        project_id=PROJECT_ID,
+        project_name="dev/agent",
+        trace_date=TRACE_DATE,
+        phase=ArchivePhase.RECONCILIATION,
+    )
+    retry_client = FakeRunsClient([create_run(outputs={"unexpected": True})])
+    retried = sync_project_day(
+        retry_client,
+        store,
+        project_id=PROJECT_ID,
+        project_name="dev/agent",
+        trace_date=TRACE_DATE,
+        phase=ArchivePhase.PRIMARY,
+    )
+    assert retry_client.calls == 0
+    assert retried == sealed
+    assert retried.sealed is True
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("window_end", "2024-07-05T00:00:00+00:00", "exactly its UTC trace day"),
+        ("canonical_key", "../another-prefix/runs.parquet", "relative object key"),
+        ("canonical_run_count", -1, "must be non-negative"),
+        ("schema_version", 99, "Unsupported archive schema version"),
+    ],
+)
+def test_corrupt_manifest_fails_at_the_storage_boundary(
+    tmp_path: Path, field: str, value: object, message: str
+) -> None:
+    store, _ = _sync_primary(tmp_path, [create_run()])
+    key = manifest_key(PROJECT_ID, TRACE_DATE.isoformat())
+    payload = json.loads(store.get_text(key))
+    assert isinstance(payload, dict)
+    payload[field] = value
+    store.put_text(key, json.dumps(payload))
+
+    with pytest.raises(ValueError, match=message):
+        read_manifest(store, key, known_exists=True)
+
+
+def test_snapshot_duplicate_run_ids_fail_before_publication(tmp_path: Path) -> None:
+    run = create_run()
+    store = create_store(str(tmp_path / "archive"))
+    with pytest.raises(ValueError, match="duplicate run IDs"):
+        sync_project_day(
+            FakeRunsClient([run, run]),
+            store,
+            project_id=PROJECT_ID,
+            project_name="dev/agent",
+            trace_date=TRACE_DATE,
+            phase=ArchivePhase.PRIMARY,
+        )
+    assert (
+        read_manifest(store, manifest_key(PROJECT_ID, TRACE_DATE.isoformat())) is None
+    )
+
+
+def test_empty_archive_is_queryable_as_zero_rows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive_uri = str(tmp_path / "archive")
+    monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
+    _sync_primary(tmp_path, [])
+    query = ArchiveRunQuery(project="dev/agent", limit=0)
+    assert query_archive_runs(query) == []
+    assert count_archive_runs(query) == 0
+
+
+def test_project_catalog_prunes_unrelated_manifest_reads(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive_uri = str(tmp_path / "archive")
+    monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
+    store, _ = _sync_primary(tmp_path, [create_run()])
+    other_id = "22345678-1234-5678-1234-567812345678"
+    sync_project_day(
+        FakeRunsClient([create_run(id_str="32345678-1234-5678-1234-567812345678")]),
+        store,
+        project_id=other_id,
+        project_name="dev/other",
+        trace_date=TRACE_DATE,
+        phase=ArchivePhase.PRIMARY,
+    )
+    # If exact-project discovery regresses to reading every manifest, this corrupt
+    # unrelated object will fail the query instead of remaining safely pruned.
+    store.put_text(manifest_key(other_id, TRACE_DATE.isoformat()), "not-json")
+
+    runs = query_archive_runs(ArchiveRunQuery(project="dev/agent", limit=0))
+    assert len(runs) == 1
+
+
+def test_partial_catalog_backfill_keeps_legacy_projects_visible(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive_uri = str(tmp_path / "archive")
+    monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
+    store, _ = _sync_primary(tmp_path, [create_run()])
+    legacy_id = "22345678-1234-5678-1234-567812345678"
+    legacy_run = create_run(id_str="32345678-1234-5678-1234-567812345678")
+    sync_project_day(
+        FakeRunsClient([legacy_run]),
+        store,
+        project_id=legacy_id,
+        project_name="dev/legacy",
+        trace_date=TRACE_DATE,
+        phase=ArchivePhase.PRIMARY,
+    )
+    # Simulate a rollout where manifests predate their catalog entry.
+    (Path(archive_uri) / project_key(legacy_id)).unlink()
+
+    runs = query_archive_runs(ArchiveRunQuery(project="dev/legacy", limit=0))
+    assert [run.id for run in runs] == [legacy_run.id]
+
+
+def test_project_catalog_rejects_silent_rename(tmp_path: Path) -> None:
+    store = create_store(str(tmp_path / "archive"))
+    ensure_project_record(store, PROJECT_ID, "dev/original")
+    with pytest.raises(ValueError, match="identity changed"):
+        ensure_project_record(store, PROJECT_ID, "dev/renamed")
+
+
+def test_manifest_location_must_match_its_project_and_date(tmp_path: Path) -> None:
+    store, _ = _sync_primary(tmp_path, [create_run()])
+    correct = manifest_key(PROJECT_ID, TRACE_DATE.isoformat())
+    wrong = manifest_key(PROJECT_ID, "2024-07-04")
+    store.put_text(wrong, store.get_text(correct))
+    with pytest.raises(ValueError, match="object key does not match"):
+        read_manifest(store, wrong, known_exists=True)
+
+
+def test_canonical_count_is_bounded_by_snapshot_counts(tmp_path: Path) -> None:
+    store, _ = _sync_primary(tmp_path, [create_run()])
+    key = manifest_key(PROJECT_ID, TRACE_DATE.isoformat())
+    payload = json.loads(store.get_text(key))
+    assert isinstance(payload, dict)
+    payload["canonical_run_count"] = 2
+    store.put_text(key, json.dumps(payload))
+    with pytest.raises(ValueError, match="bounded by snapshot counts"):
+        read_manifest(store, key, known_exists=True)
+
+
+def test_non_root_filter_returns_only_children(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive_uri = str(tmp_path / "archive")
+    monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
+    root = create_run()
+    child = create_run(
+        id_str="22345678-1234-5678-1234-567812345678",
+        parent_run_id=str(root.id),
+        trace_id=str(root.id),
+    )
+    _sync_primary(tmp_path, [root, child])
+    runs = query_archive_runs(
+        ArchiveRunQuery(project="dev/agent", is_root=False, limit=0)
+    )
+    assert [run.id for run in runs] == [child.id]
+
+
+def test_archive_text_fields_are_an_explicit_allowlist() -> None:
+    with pytest.raises(ValueError, match="Unsupported archive text field"):
+        ArchiveRunQuery(text="x", text_fields=("inputs) OR true --",))
+    with pytest.raises(ValueError, match="requires at least one field"):
+        ArchiveRunQuery(text="x", text_fields=())
+
+
+def test_literal_archive_search_respects_case_sensitivity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive_uri = str(tmp_path / "archive")
+    monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
+    _sync_primary(tmp_path, [create_run(outputs={"message": "Hello Archive"})])
+
+    sensitive = ArchiveRunQuery(
+        project="dev/agent", text="hello archive", text_ignore_case=False
+    )
+    insensitive = replace(sensitive, text_ignore_case=True)
+    assert query_archive_runs(sensitive) == []
+    assert len(query_archive_runs(insensitive)) == 1
+
+
+def test_store_rejects_object_key_traversal(tmp_path: Path) -> None:
+    store = create_store(str(tmp_path / "archive"))
+    with pytest.raises(ValueError, match="normalized and relative"):
+        store.object_uri("../outside.parquet")
+
+
+def test_windows_drive_paths_are_not_uri_schemes() -> None:
+    assert _is_windows_drive_path(r"C:\archive\traces") is True
+    assert _is_windows_drive_path("s3://bucket/traces") is False
+
+
+def test_s3_conditional_publication_uses_etag_preconditions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class RecordingS3Client:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, object]] = []
+
+        def put_object(self, **kwargs: object) -> None:
+            self.calls.append(kwargs)
+
+    import boto3
+
+    client = RecordingS3Client()
+    monkeypatch.setattr(boto3, "client", lambda service: client)
+    store = S3ArchiveStore(
+        bucket="archive-bucket", prefix="langsmith", base_uri="s3://archive-bucket"
+    )
+    store.put_text_if_version("manifests/day.json", "{}", None)
+    store.put_text_if_version("manifests/day.json", "{}", '"etag"')
+
+    assert client.calls[0]["IfNoneMatch"] == "*"
+    assert client.calls[1]["IfMatch"] == '"etag"'
+    assert client.calls[0]["Key"] == "langsmith/manifests/day.json"
+
+
+def test_s3_stale_write_is_a_typed_concurrency_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from botocore.exceptions import ClientError
+    import boto3
+
+    class ConflictingS3Client:
+        def put_object(self, **kwargs: object) -> None:
+            raise ClientError(
+                {
+                    "Error": {"Code": "PreconditionFailed", "Message": "stale"},
+                    "ResponseMetadata": {"HTTPStatusCode": 412},
+                },
+                "PutObject",
+            )
+
+    monkeypatch.setattr(boto3, "client", lambda service: ConflictingS3Client())
+    store = S3ArchiveStore(
+        bucket="archive-bucket", prefix="langsmith", base_uri="s3://archive-bucket"
+    )
+    with pytest.raises(ConcurrentArchiveWriteError, match="changed concurrently"):
+        store.put_text_if_version("manifests/day.json", "{}", '"old-etag"')
+
+
+def test_s3_reads_versions_and_lists_only_the_manifest_namespace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import boto3
+
+    class FakePaginator:
+        def __init__(self) -> None:
+            self.prefix: str | None = None
+
+        def paginate(self, *, Bucket: str, Prefix: str):
+            self.prefix = Prefix
+            return iter(
+                [
+                    {},
+                    {
+                        "Contents": [
+                            {"Key": "langsmith/manifests/project=b/date=2.json"},
+                            {"Key": "langsmith/manifests/project=a/date=1.json"},
+                        ]
+                    },
+                ]
+            )
+
+    class ReadingS3Client:
+        def __init__(self) -> None:
+            self.paginator = FakePaginator()
+
+        def get_object(self, *, Bucket: str, Key: str) -> dict[str, object]:
+            return {"Body": BytesIO(b"{}"), "ETag": '"version"'}
+
+        def get_paginator(self, operation: str) -> FakePaginator:
+            assert operation == "list_objects_v2"
+            return self.paginator
+
+    client = ReadingS3Client()
+    monkeypatch.setattr(boto3, "client", lambda service: client)
+    store = S3ArchiveStore(
+        bucket="archive-bucket", prefix="langsmith", base_uri="s3://archive-bucket"
+    )
+
+    stored = store.get_text_with_version("manifests/day.json")
+    assert stored.content == "{}"
+    assert stored.version == '"version"'
+    assert store.list_keys("manifests") == [
+        "manifests/project=a/date=1.json",
+        "manifests/project=b/date=2.json",
+    ]
+    assert client.paginator.prefix == "langsmith/manifests/"

--- a/tests/test_archive_invariants.py
+++ b/tests/test_archive_invariants.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from datetime import date, timedelta
+from datetime import date, datetime, time, timedelta, timezone
 from io import BytesIO
 import json
 from pathlib import Path
@@ -17,6 +17,9 @@ from conftest import create_run
 from langsmith_cli.archive.models import ArchivePhase
 from langsmith_cli.archive.query import (
     ArchiveRunQuery,
+    _date_partition_overlaps,
+    _manifest_identity_from_key,
+    _project_matches,
     count_archive_runs,
     query_archive_runs,
 )
@@ -447,3 +450,244 @@ def test_s3_reads_versions_and_lists_only_the_manifest_namespace(
         "manifests/project=b/date=2.json",
     ]
     assert client.paginator.prefix == "langsmith/manifests/"
+
+
+def test_s3_store_supports_complete_object_contract(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from botocore.exceptions import ClientError
+    import boto3
+
+    class ObjectClient:
+        def __init__(self) -> None:
+            self.objects: dict[str, bytes] = {}
+            self.upload: tuple[str, str, str] | None = None
+
+        def upload_file(self, source: str, bucket: str, key: str) -> None:
+            self.upload = (source, bucket, key)
+
+        def put_object(self, **kwargs: object) -> None:
+            body = kwargs["Body"]
+            assert isinstance(body, bytes)
+            self.objects[str(kwargs["Key"])] = body
+
+        def get_object(self, *, Bucket: str, Key: str) -> dict[str, object]:
+            return {"Body": BytesIO(self.objects[Key])}
+
+        def head_object(self, *, Bucket: str, Key: str) -> None:
+            if Key not in self.objects:
+                raise ClientError(
+                    {
+                        "Error": {"Code": "NotFound", "Message": "missing"},
+                        "ResponseMetadata": {"HTTPStatusCode": 404},
+                    },
+                    "HeadObject",
+                )
+
+    client = ObjectClient()
+    monkeypatch.setattr(boto3, "client", lambda service: client)
+    store = S3ArchiveStore(
+        bucket="archive-bucket", prefix="langsmith", base_uri="s3://archive-bucket"
+    )
+    source = tmp_path / "run.parquet"
+    source.write_bytes(b"PAR1")
+
+    store.put_file("raw/run.parquet", source)
+    store.put_text("projects/project.json", "{}")
+
+    assert client.upload == (
+        str(source),
+        "archive-bucket",
+        "langsmith/raw/run.parquet",
+    )
+    assert store.get_text("projects/project.json") == "{}"
+    assert store.exists("projects/project.json") is True
+    assert store.exists("projects/missing.json") is False
+    assert store.object_uri("raw/run.parquet") == (
+        "s3://archive-bucket/langsmith/raw/run.parquet"
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        [],
+        {"schema_version": 1},
+        {"schema_version": "1", "project_id": PROJECT_ID, "project_name": "dev/agent"},
+        {"schema_version": 1, "project_id": 7, "project_name": "dev/agent"},
+    ],
+)
+def test_project_catalog_rejects_malformed_records(
+    tmp_path: Path, payload: object
+) -> None:
+    store = create_store(str(tmp_path / "archive"))
+    key = project_key(PROJECT_ID)
+    store.put_text(key, json.dumps(payload))
+    with pytest.raises(ValueError):
+        ensure_project_record(store, PROJECT_ID, "dev/agent")
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        ({"project_name": 7}, "must be a string"),
+        ({"schema_version": "1"}, "must be an integer"),
+        ({"canonical_run_count": "1"}, "must be an integer"),
+        ({"sealed": "true"}, "must be a boolean"),
+        ({"canonical_key": 7}, "string or null"),
+        ({"primary": "verified"}, "phase must be an object"),
+        ({"primary": {"status": "verified"}}, "invalid schema"),
+        (
+            {
+                "primary": {
+                    "status": 7,
+                    "generation_id": "generation",
+                    "raw_key": "raw/key.parquet",
+                    "run_count": 1,
+                    "verified_at": "2024-07-03T00:00:00+00:00",
+                }
+            },
+            "primary.status must be a string",
+        ),
+        (
+            {
+                "primary": {
+                    "status": "verified",
+                    "generation_id": "generation",
+                    "raw_key": "raw/key.parquet",
+                    "run_count": "1",
+                    "verified_at": "2024-07-03T00:00:00+00:00",
+                }
+            },
+            "primary.run_count must be an integer",
+        ),
+        (
+            {
+                "primary": {
+                    "status": "failed",
+                    "generation_id": "generation",
+                    "raw_key": "raw/key.parquet",
+                    "run_count": 1,
+                    "verified_at": "2024-07-03T00:00:00+00:00",
+                    "error": 7,
+                }
+            },
+            "primary.error must be a string",
+        ),
+    ],
+)
+def test_manifest_reader_rejects_malformed_metadata_at_storage_boundary(
+    tmp_path: Path,
+    mutation: dict[str, object],
+    message: str,
+) -> None:
+    store, manifest = _sync_primary(tmp_path, [create_run()])
+    key = manifest_key(PROJECT_ID, TRACE_DATE.isoformat())
+    payload = manifest.to_dict()
+    payload.update(mutation)  # type: ignore[typeddict-item]
+    store.put_text(key, json.dumps(payload))
+
+    with pytest.raises(ValueError, match=message):
+        read_manifest(store, key)
+
+
+def test_manifest_partition_parsing_and_date_pruning_are_exact() -> None:
+    identity = _manifest_identity_from_key(
+        f"manifests/project_id={PROJECT_ID}/date=2024-07-03.json"
+    )
+    assert identity == (PROJECT_ID, TRACE_DATE)
+    assert _manifest_identity_from_key("manifests/not-a-partition.json") is None
+
+    window_start = date(2024, 7, 4)
+    assert (
+        _date_partition_overlaps(
+            TRACE_DATE,
+            # A lower bound at the next midnight prunes the prior partition exactly.
+            datetime.combine(window_start, time.min, tzinfo=timezone.utc),
+            None,
+        )
+        is False
+    )
+    assert (
+        _date_partition_overlaps(
+            TRACE_DATE,
+            None,
+            datetime.combine(TRACE_DATE, time.min, tzinfo=timezone.utc),
+        )
+        is False
+    )
+
+
+@pytest.mark.parametrize(
+    ("query", "project_id", "project_name", "matches"),
+    [
+        (ArchiveRunQuery(project_id="other"), PROJECT_ID, "dev/agent", False),
+        (ArchiveRunQuery(project="dev/other"), PROJECT_ID, "dev/agent", False),
+        (
+            ArchiveRunQuery(project_name_pattern="stg/**"),
+            PROJECT_ID,
+            "dev/agent",
+            False,
+        ),
+        (ArchiveRunQuery(project_name_regex=r"^stg/"), PROJECT_ID, "dev/agent", False),
+        (ArchiveRunQuery(project_name_pattern="dev/**"), PROJECT_ID, "dev/agent", True),
+    ],
+)
+def test_project_predicates_apply_every_configured_selector(
+    query: ArchiveRunQuery,
+    project_id: str,
+    project_name: str,
+    matches: bool,
+) -> None:
+    assert _project_matches(query, project_id, project_name) is matches
+
+
+def test_archive_query_rejects_negative_limits() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        ArchiveRunQuery(limit=-1)
+
+
+@pytest.mark.parametrize("uri", ["s3:///missing-bucket", "https://archive.invalid"])
+def test_store_rejects_invalid_or_unsupported_uris(uri: str) -> None:
+    with pytest.raises(ValueError):
+        create_store(uri)
+
+
+def test_store_factory_supports_s3_and_file_uris(tmp_path: Path) -> None:
+    assert isinstance(create_store("s3://archive-bucket/prefix"), S3ArchiveStore)
+    assert create_store(tmp_path.as_uri()).base_uri == str(tmp_path.resolve())
+
+
+def test_s3_store_propagates_non_concurrency_service_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from botocore.exceptions import ClientError
+    import boto3
+
+    class FailingClient:
+        def put_object(self, **kwargs: object) -> None:
+            raise self._error("PutObject")
+
+        def head_object(self, **kwargs: object) -> None:
+            raise self._error("HeadObject")
+
+        @staticmethod
+        def _error(operation: str) -> ClientError:
+            return ClientError(
+                {
+                    "Error": {"Code": "InternalError", "Message": "retry upstream"},
+                    "ResponseMetadata": {"HTTPStatusCode": 500},
+                },
+                operation,
+            )
+
+    monkeypatch.setattr(boto3, "client", lambda service: FailingClient())
+    store = S3ArchiveStore(
+        bucket="archive-bucket", prefix="langsmith", base_uri="s3://archive-bucket"
+    )
+
+    with pytest.raises(ClientError):
+        store.put_text_if_version("manifests/day.json", "{}", None)
+    with pytest.raises(ClientError):
+        store.exists("manifests/day.json")

--- a/uv.lock
+++ b/uv.lock
@@ -25,6 +25,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.43.76"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/6c/0cc8c0fe7b6564a3dd3b8066a2a262ee9874272defb517f461677a8c76c8/boto3-1.43.76.tar.gz", hash = "sha256:fa4dc85f735bb67d8f82e42ac50af7e1d2c039aeacf40c878067c9046464b6ad", size = 112656, upload-time = "2026-08-20T19:25:46.007Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/81/5179853e14d7068e02d2f535ca620d98d1a95249ccfc2933f414ed51ded4/boto3-1.43.76-py3-none-any.whl", hash = "sha256:249f55274aef9fa3b9de6afb6f5b2effbbb15c5263d97c13e7b691f479a62c04", size = 140025, upload-time = "2026-08-20T19:25:44.427Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.76"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/b1/80e5c5769e1876e856a44d0eaf3e7cd0ee42d242a8c6a7ac676a6cbac2a0/botocore-1.43.76.tar.gz", hash = "sha256:2b0325a0b4523ccb83b84a7acf7c3eade9f9e6be51a6769a01014df343744f5d", size = 15980626, upload-time = "2026-08-20T19:25:41.451Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/18/66bc038ecfa2a62ce0d7c1ae934784662923979e5019182af05aaad0015e/botocore-1.43.76-py3-none-any.whl", hash = "sha256:1f19bc9f388db571ca2385ea9fb8b58f4e01d4ff20fa225cff698ea123feb6f7", size = 15674291, upload-time = "2026-08-20T19:25:37.385Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -213,6 +241,35 @@ wheels = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/19/e57151753576373c6696a12022648546cca6038e8833fda2908ee2342d9b/duckdb-1.5.5.tar.gz", hash = "sha256:72f33ee57ca7595b23957671a2cc7f7fe2be0ecc2d68f63abedcfcaa3a5c1238", size = 18066741, upload-time = "2026-07-22T10:55:17.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/40/2e05d324400fdaa5656c9f48d6298da421cb034d85e509fa0e6e325cf04b/duckdb-1.5.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d4dd65f8941a604b947e0b9b4b4f7165988e29a23ec0b69b4038520956d9933e", size = 32753858, upload-time = "2026-07-22T10:54:05.514Z" },
+    { url = "https://files.pythonhosted.org/packages/79/15/5ceb58ffb5bb8a62b3fd7abb39c41467cdf94850ece02e6d88664dfc75ce/duckdb-1.5.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:33db46679b071f108d57139493dee2d37e1f5efcf5c5c039c2969eed11a6c8a7", size = 17368293, upload-time = "2026-07-22T10:54:09.139Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/5c/bf02da0b354fe83cca4f95a4fbf762181af466f7d551ab2a093f7698882a/duckdb-1.5.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f0b88535a5d86fdd63dba6ea02ab68c003dfb9e4892b11256ef24c4da208baae", size = 15509131, upload-time = "2026-07-22T10:54:12.228Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/a9/5f1f09da421d8e930e0b063d11c1b3f90363f40ede74438cd188afdd13a2/duckdb-1.5.5-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f316eae2323d9a851883fdf2dee91c1f9efe251ab33e14a2272f82a913422ed6", size = 19391959, upload-time = "2026-07-22T10:54:15.551Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/98/6549769f158126fa64fd6c1ac2eb59a18282146c939867a3eb31b7c1db07/duckdb-1.5.5-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7a6d2d11859d82a936ebdcb30ce3d8a1cbb3e990bff05c12abb9b54c44fa7bd1", size = 21510909, upload-time = "2026-07-22T10:54:19.681Z" },
+    { url = "https://files.pythonhosted.org/packages/af/b7/5753b41d3124838f868f9f523362812d9fc45409e9e4dd70dcbb0a25826e/duckdb-1.5.5-cp312-cp312-win_amd64.whl", hash = "sha256:ddfbdb096c11d51ee22492397d342c90a82e62c5d09961477895934d0a25372f", size = 13168544, upload-time = "2026-07-22T10:54:22.789Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/28/44b679c7d46245f8398feae7edac959d1b83d4eb143e25b3fce0630b78bd/duckdb-1.5.5-cp312-cp312-win_arm64.whl", hash = "sha256:2725d2b9ace3a4e75d72fc5a239f6a44b502c580edadb8fb2676db772c5f9282", size = 13988684, upload-time = "2026-07-22T10:54:26.003Z" },
+    { url = "https://files.pythonhosted.org/packages/47/37/4a38116e7700720fd152c666292214fd3abdf916496991296d8d1f66efbf/duckdb-1.5.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:cd98829b67788609017e65c761bd42a5dd0f9129441bed8bda4d6881ccf819f0", size = 32754294, upload-time = "2026-07-22T10:54:29.822Z" },
+    { url = "https://files.pythonhosted.org/packages/66/42/7d392f1ba1eee0eaf4ab4c8c7a604bfe3536cd63f979cf5c98798664f807/duckdb-1.5.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:feead93c56679b79592d437c62975d39cb67adedffa7592c763baf8160ac7366", size = 17368211, upload-time = "2026-07-22T10:54:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a5/0a6f4fa60562faa615e55e15bd1953a2f2b17a8edd8105e5cda215e43457/duckdb-1.5.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:49c963d9469373d7aba8d750d9ea565ab823e94166efed953f184dd9b169b98c", size = 15509136, upload-time = "2026-07-22T10:54:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/cb/023c89f51978545b9fab318581bba0c457a58e7530d2d933e54ae7d8647c/duckdb-1.5.5-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a736217825461732b5442d05a220f3da2e23a0dae114efbf08c9bf171b53098a", size = 19392147, upload-time = "2026-07-22T10:54:39.551Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c5/41bef391fb8b23dbc133c9f2ba016e7a7a8124513d2cc1b430f1897d87e4/duckdb-1.5.5-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:078e6a60dd8eedde5832f45422ca5c4a6b8c837aeabd8a56ca0b7d933f588053", size = 21511060, upload-time = "2026-07-22T10:54:42.788Z" },
+    { url = "https://files.pythonhosted.org/packages/07/9f/c44dfc1f924ac29b3252dc1b91393c01d009dbfe9f8ed33f10b986151bd1/duckdb-1.5.5-cp313-cp313-win_amd64.whl", hash = "sha256:6826504277dba513c0c5d71d828456c94d729c9d2482f94b2e289f90a9167e28", size = 13168028, upload-time = "2026-07-22T10:54:46.127Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/88/591384b2cd59abddd6f5dc175e60374f9abae6064429f0c4402854c10f44/duckdb-1.5.5-cp313-cp313-win_arm64.whl", hash = "sha256:baa9c5702002fabb559ded2a39008f9f421fcbc7237d388b8213eff1e08858de", size = 13989955, upload-time = "2026-07-22T10:54:49.262Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/56/12c65bfa2d2605b81981b264788891bcf11ec72227889554cead5d8d13b9/duckdb-1.5.5-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8e6413dd40facb7b8ab21bd844450cd8f549b29e138635be9cf090ef4d2049e2", size = 32761946, upload-time = "2026-07-22T10:54:53.412Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/46/682ce155f17e0d2822d4f13ee3db9ca4b5b7c2da61b841b2629035e1f4bc/duckdb-1.5.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:64078acfd16541132ac6e191eb81b2845554444a0305cc1aa581ba107e514aa8", size = 17375069, upload-time = "2026-07-22T10:54:57.269Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ce/a24bcbd3289c8f305a430759c5fc12242740b4af3e17f7593f3a34e333d2/duckdb-1.5.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8c11775cc99a447618d5f1840126db17f2652f3eae05529df4f81f40e2df7151", size = 15519791, upload-time = "2026-07-22T10:55:00.681Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/76/3a01afbc615c1d418c0de58a6b68ac5ce2a8563232c0464bfbc2ce552398/duckdb-1.5.5-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77bbc1e6ba12e1e06f9020117bdf848627ecfdf36f907550e62e008e6109dece", size = 19398251, upload-time = "2026-07-22T10:55:04.168Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/43/3a5e81d1728f4d234c79bfe385808ee7c04834f7c37a4b5c257459c25614/duckdb-1.5.5-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fbf0f2d48b43c6c304d00463b463c27ead6c4b01c3c1816b750f728decf71afe", size = 21513851, upload-time = "2026-07-22T10:55:07.864Z" },
+    { url = "https://files.pythonhosted.org/packages/91/41/fc7c829172c60ca22485251eab285f4f1a0d87b486a024c726f21471d86e/duckdb-1.5.5-cp314-cp314-win_amd64.whl", hash = "sha256:9dc826c4b50e64f6c4e4d07a3a9cb075ef70ba3899dc43ec5493dc3d7b04b353", size = 13691858, upload-time = "2026-07-22T10:55:11.181Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2c/95d9216b79e9273689d7ebce125a54503ed0c9bd7da931f0265888e99779/duckdb-1.5.5-cp314-cp314-win_arm64.whl", hash = "sha256:63e48d4b74b15aeacd688976432a7225163df8c226eddeb8536bba2d4d4ff433", size = 14470180, upload-time = "2026-07-22T10:55:14.445Z" },
+]
+
+[[package]]
 name = "execnet"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -295,6 +352,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
 name = "langdetect"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -333,7 +399,9 @@ name = "langsmith-cli"
 version = "0.10.3"
 source = { editable = "." }
 dependencies = [
+    { name = "boto3" },
     { name = "click" },
+    { name = "duckdb" },
     { name = "langdetect" },
     { name = "langsmith" },
     { name = "platformdirs" },
@@ -358,7 +426,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", specifier = ">=1.35.0" },
     { name = "click", specifier = ">=8.0" },
+    { name = "duckdb", specifier = ">=1.4.0" },
     { name = "langdetect", specifier = ">=1.0.9" },
     { name = "langsmith", specifier = ">=0.8.5" },
     { name = "platformdirs", specifier = ">=4.0" },
@@ -707,6 +777,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -824,6 +906,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/3c/37d0ecb729a7cc2d393ea7dce316fc585680f35d93b8d62139d7d0a3700c/ruff-0.15.21-py3-none-win32.whl", hash = "sha256:01f8d5be84823c172b389e123174f781f9daf86d6c58719d603f941932195cdd", size = 10896555, upload-time = "2026-07-09T20:01:26.941Z" },
     { url = "https://files.pythonhosted.org/packages/c0/b8/e43466b2a6067ce91e669068f6e28d6c719a920f014b070d5c8731725de3/ruff-0.15.21-py3-none-win_amd64.whl", hash = "sha256:d4b8d9a2f0f12b816b50447f6eccb9f4bb01a6b82c86b50fb3b5354b458dc6d3", size = 12038772, upload-time = "2026-07-09T20:01:29.497Z" },
     { url = "https://files.pythonhosted.org/packages/dd/75/e90ab9aeece218a9fc5a5bc3ec97d0ee6bb3c4ff95869463c1de58e29a1c/ruff-0.15.21-py3-none-win_arm64.whl", hash = "sha256:6e83115d4b9377c1cbc13abf0e051f069fab0ef815ea0504a8a008cee24dd0a8", size = 11375265, upload-time = "2026-07-09T20:01:31.772Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/43/35e4d8aa320bffe8287fe8f65f578fa2d2db0a64212f0e710dce58267854/s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993", size = 165592, upload-time = "2026-07-22T19:30:44.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25", size = 90216, upload-time = "2026-07-22T19:30:43.251Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

LangSmith is useful for live tracing, but short-retention plans delete traces before Gigaverse is done debugging incidents, comparing model behavior, or investigating regressions. Paying for extended LangSmith retention is unnecessary if the organization can retain immutable trace data cheaply in its own private S3 buckets and query it when needed.

This PR makes `langsmith-cli` the mechanism—not the owner:

- the organization owns the scheduler, LangSmith API key, AWS workload identity, buckets, encryption, and retention policy;
- the CLI discovers due trace windows, routes projects, exports and verifies data, publishes manifests safely, and queries the archive with DuckDB;
- archived reads require AWS read access but no LangSmith API key.

Refs #161.

## Before / after

| Concern | Before | After |
|---|---|---|
| Trace lifetime | Data disappears with LangSmith retention | Canonical Parquet remains in organization-owned S3 |
| Historical search | Requires the live LangSmith API | `runs list/search/get/get-latest --archive` queries DuckDB |
| Environment isolation | One live account boundary | `dev/**`, `stg/**`, and `prd/**` route to separate private buckets |
| Late child runs / updates | A one-time export can miss them | D+2 primary plus D+12 full reconciliation |
| Retries | Ad hoc re-export risks duplicates | Verified phases are idempotent; canonical rows dedupe by run ID |
| Overlapping CronJobs | Last writer could clobber a pointer | S3 ETag compare-and-swap; exactly one manifest publisher wins |
| Discovery cost | Exact-project reads could GET every manifest | Route-local project catalog + project/date prefix pruning |
| Empty days | Partial Parquet schema could break queries | Zero-count partitions are pruned and return zero |
| Local development | POSIX only in practice | Windows drive paths and closed staging files are supported |

## Lifecycle

For UTC trace day `D` with 14-day LangSmith retention:

```text
D                  D+2                         D+12                   D+14
│ trace occurs      │ primary snapshot         │ reconciliation       │ source expires
├──────────────────►├──────────────────────────►├──────────────────────►
                     catches normal completion  catches late children  archive remains
```

Both snapshots cover the exact half-open interval `[D 00:00Z, D+1 00:00Z)`. Reconciliation is a full snapshot, not a delta.

On first deployment, an old D+12 day may have no historical D+2 snapshot. The CLI publishes that complete reconciliation alone and seals it, preserving the oldest still-retained data immediately.

## Architecture

```text
organization CronJob
  │ LangSmith key + environment-scoped AWS role
  ▼
langsmith-cli archive sync
  ├─ route project ───────────────► dev / stg / prd S3 bucket
  ├─ export immutable raw Parquet
  ├─ dedupe with DuckDB by run.id
  ├─ verify canonical Parquet
  └─ CAS-publish manifest pointer
                                  │
developer / agent                 │ AWS read-only role
  └─ runs ... --archive ──────────┘
         └─ catalog + manifests ─► DuckDB predicate/project/date pruning
```

Publication is race-safe:

```text
worker A: read v1 ─ raw A ─ canonical A ─ CAS(v1) ──► v2 published
worker B: read v1 ─ raw B ─ canonical B ─ CAS(v1) ──► CONFLICT
                                                    v2 remains visible
```

A losing worker can leave only immutable orphan objects, which lifecycle policy can expire. It cannot replace the winning manifest.

## Organization configuration

```yaml
routes:
  - name: dev
    project_pattern: "dev/**"
    archive_uri: s3://gigaverse-langsmith-traces-dev/langsmith
  - name: staging
    project_pattern: "stg/**"
    archive_uri: s3://gigaverse-langsmith-traces-stg/langsmith
  - name: production
    project_pattern: "prd/**"
    archive_uri: s3://gigaverse-langsmith-traces-prd/langsmith
```

Recommended deployment: one CronJob per route, each with access only to its environment bucket.

```bash
langsmith-cli --json archive sync --route dev --retention-days 14
langsmith-cli --json archive status --route dev

langsmith-cli --json runs search "timeout" \
  --archive --project dev/my-agent --last 90d

langsmith-cli --json runs get <run-id> --archive --follow-children
```

## Storage contract

```text
<archive-uri>/
  projects/project_id=<uuid>.json
  raw/project_id=<uuid>/date=YYYY-MM-DD/phase=<phase>/generation=<uuid>/runs.parquet
  canonical/project_id=<uuid>/date=YYYY-MM-DD/generation=<uuid>/runs.parquet
  manifests/project_id=<uuid>/date=YYYY-MM-DD.json
```

Raw and canonical generations are immutable. The manifest is the only mutable reader-visible pointer and is written last.

## Explicit invariants

| Invariant | Enforcement |
|---|---|
| A project matches exactly one route | Config fails on unmatched/ambiguous explicit projects |
| A manifest is exactly one UTC project-day | Typed construction and deserialization validation |
| Object keys cannot escape their namespace | Normalized relative-key plus project/date/phase validation |
| Snapshot and canonical run IDs are unique | DuckDB checks before publication |
| Reconciliation wins duplicate IDs | Ranked canonical union by stable `run.id` |
| Canonical count is neither truncated nor inflated | `max(snapshot counts) <= canonical <= sum(snapshot counts)` |
| A sealed day cannot regress | Phase idempotency and sealed-state validation |
| Stale writers cannot clobber | S3 `If-Match` / `If-None-Match`; locked local CAS |
| Readers see only published canonical objects | Manifest-directed discovery |
| Partial catalog rollout cannot hide legacy data | Catalog-selected prefixes plus unindexed-manifest fallback |
| Empty days return zero | Zero-count partition pruning |
| Search identifiers are safe | Fixed `inputs/outputs/error/extra` allowlist |

The design document maps every invariant to its enforcement and failure behavior.

## Security and IAM boundary

| Workload | Required bucket access | Not required |
|---|---|---|
| Environment archiver | Prefix-scoped list/get/put and multipart operations | Public access, delete, cross-environment buckets |
| Archive reader | Prefix-scoped list/get | LangSmith key, put/delete |
| LangSmith live exporter | LangSmith read access supplied at runtime | Stored credentials in config/manifests/Parquet |

DuckDB and boto3 both use the workload credential chain. No AWS access keys or LangSmith keys are persisted by the CLI.

## Proof

Tested against the existing private Gigaverse dev archive for UTC 2026-08-19:

| Proof | Result |
|---|---:|
| Routed `dev/**` projects | 60 |
| Canonical runs retained | 24,820 |
| Idempotent rerun | 60/60 skipped; no trace re-export |
| Canonical count after hardening | 24,820 (unchanged) |
| `dev/video_moderation_service` DuckDB count | 1,521 |
| Exact-project count latency | 4.77s after catalog pruning; 14.36s prior baseline |
| Idempotent 60-project sync latency | 14.3s |
| Focused archive tests | 80 passing |
| Full repository suite | 1,349 passing |
| Full suite | 1,305 passing |
| Static checks | Ruff clean; Pyright 0 errors |
| Patch coverage | 90.018% in Codecov (1,002 / 1,113 changed executable lines) |

## Impact and non-goals

- Adds lazy-loaded `boto3` and `duckdb` dependencies; CLI import remains about 44ms locally.
- Reduces retention/storage cost, not LangSmith ingestion cost.
- Project names are immutable archive identities. Renames or route moves require an explicit migration and fail closed.
- Current archive filters cover project/time/status/type/root/tags/text/sort/count. Unsupported live-only FQL, metadata, and latency filters fail explicitly.
- Managed LangSmith Bulk Export, richer aggregate commands, and deployment-specific IAM manifests remain follow-ups.
