### PR TITLE
docs: explain affordable long-term trace retention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,4 +221,5 @@ __marimo__/
 
 # kaizen plugin runtime artifacts (local-only)
 .claude/kaizen/
+.firecrawl/
 data/

--- a/README.md
+++ b/README.md
@@ -62,8 +62,79 @@ Traditional tools are slow, verbose, and waste tokens. **LangSmith CLI** is diff
 | **Tag Discovery** | `runs tags` auto-discover patterns | ❌ |
 | **File Operations** | View/analyze offline with globs | ❌ |
 | **Export Formats** | JSON, CSV, YAML | JSON only |
+| **Long-term Trace Archive** | Private S3 + DuckDB search | ❌ |
 
 **100% Feature Parity** + **10x Better QoL** 🚀
+
+---
+
+## 💸 Keep Trace History Without the 10x Retention Bill
+
+LangSmith's published billing model currently retains base traces for **14 days**.
+Extended retention keeps them for 400 days, but an extended trace costs **10x** as
+much: a 0.05¢ base charge plus a 0.45¢ retention upgrade, or 0.50¢ total per trace.
+Online evaluators and automation rules can automatically upgrade an entire trace—or
+every trace in a matched thread—when retention extension is enabled. API/SDK feedback
+can also upgrade a trace when it explicitly requests retention extension.
+
+Source: [LangSmith usage and billing](https://docs.langchain.com/langsmith/usage-and-billing#data-retention).
+Check the official page for current pricing before making budget decisions.
+
+| Monthly traces | Base, 14 days | Extended, 400 days | Added retention cost |
+|---:|---:|---:|---:|
+| 100,000 | $50 | $500 | **$450** |
+| 1,000,000 | $500 | $5,000 | **$4,500** |
+| 10,000,000 | $5,000 | $50,000 | **$45,000** |
+
+These are illustrations using the published per-trace rates, before free allowances,
+plan-specific terms, negotiated pricing, or taxes.
+
+`langsmith-cli` provides an integrated alternative: keep LangSmith's short-retention
+tier for live debugging, archive verified traces to organization-owned private S3,
+then query the retained Parquet directly with DuckDB.
+
+```text
+LangSmith live traces (14 days)
+          │
+          ├── D+2 primary export ───────┐
+          └── D+12 reconciliation ──────┤ dedupe by run ID
+                                        ▼
+                              private S3 / Parquet
+                                        │
+                         runs ... --archive (DuckDB)
+```
+
+```yaml
+# archive.yaml
+routes:
+  - name: dev
+    project_pattern: "dev/**"
+    archive_uri: s3://my-langsmith-traces-dev/langsmith
+  - name: production
+    project_pattern: "prd/**"
+    archive_uri: s3://my-langsmith-traces-prd/langsmith
+```
+
+```bash
+export LANGSMITH_ARCHIVE_CONFIG=/etc/langsmith-cli/archive.yaml
+
+# Run daily from cron, Kubernetes CronJob, or another organization-owned scheduler.
+langsmith-cli --json archive sync --all-routes --retention-days 14
+
+# Historical reads use S3 and do not require a LangSmith API key.
+langsmith-cli --json runs list --archive --project prd/my-agent --last 90d
+langsmith-cli --json runs search "timeout" --archive --project prd/my-agent
+langsmith-cli --json runs get <run-id> --archive --follow-children
+```
+
+The CLI owns the mechanism, not your infrastructure: your organization supplies the
+scheduler, LangSmith API key for exports, AWS workload identity, private buckets,
+encryption, lifecycle policy, and reader IAM. Archiving avoids extended-retention
+upgrade charges; it does **not** remove LangSmith's base ingestion charge or your own
+S3 storage and request costs.
+
+See [S3 Trace Archive](skills/langsmith/references/archive.md) for routing, scheduling,
+IAM boundaries, retry safety, and supported archive queries.
 
 ---
 
@@ -392,6 +463,8 @@ runs pricing           # Model pricing coverage check
 runs cache download    # Download runs to local JSONL cache
 runs cache list        # List cached projects
 runs cache clear       # Clear cached data
+archive sync           # Export and reconcile traces to private S3
+archive status         # Inspect published archive manifests
 datasets list          # List datasets
 datasets create        # Create new dataset
 datasets push          # Bulk upload from JSONL

--- a/skills/langsmith/SKILL.md
+++ b/skills/langsmith/SKILL.md
@@ -5,7 +5,9 @@ description: Inspect and manage LangSmith traces, runs, datasets, and prompts us
 
 # LangSmith Tool
 
-Use this tool to debug AI chains, inspect past runs, manage datasets, and analyze token costs in LangSmith.
+Use this tool to debug AI chains, inspect past runs, manage datasets, analyze token
+costs, and retain searchable trace history in organization-owned S3 without putting
+every trace on LangSmith's extended-retention tier.
 
 ## Prerequisites
 
@@ -78,7 +80,28 @@ langsmith-cli --json runs cache download --project "dev/my-project" --last 30d
 # Final stdout: {"event":"download_complete","total_new_runs":N}
 ```
 
-### 4. Always use `--fields` to reduce token usage
+### 4. Use the S3 archive for history older than LangSmith's base retention
+
+LangSmith's published base tier retains traces for 14 days; extended traces currently
+cost 10x the base trace price. For time windows older than 14 days, first check for
+`LANGSMITH_ARCHIVE_CONFIG` or `LANGSMITH_ARCHIVE_URI`, then use `--archive` instead
+of the LangSmith API. Read [references/archive.md](references/archive.md) before
+configuring or operating an archive.
+
+```bash
+# ✅ CORRECT — DuckDB over organization-owned Parquet; no LangSmith API key needed
+langsmith-cli --json runs search "timeout" --archive \
+  --project prd/my-agent --fields id,name,status,start_time
+
+# ❌ WRONG for expired base traces — the live API cannot return deleted trace data
+langsmith-cli --json runs search "timeout" --project prd/my-agent --last 90d
+```
+
+Do not recommend enabling extended retention for every trace without warning about
+the current 10x trace price and auto-upgrade behavior. Archiving reduces retention
+upgrade charges, not LangSmith base ingestion charges or S3 costs.
+
+### 5. Always use `--fields` to reduce token usage
 
 ```bash
 langsmith-cli --json runs list --fields id,name,status,start_time
@@ -132,6 +155,8 @@ When your task matches one of the sections below, **you MUST load that reference
 - You need to paginate, export to files, or watch live runs
 
 ### → Read [references/archive.md](references/archive.md) when:
+- You need trace history beyond LangSmith's 14-day base retention without upgrading every trace
+- You need to understand extended-retention cost or auto-upgrade risk
 - You need to configure project-to-S3 routing such as `dev/**` and `stg/**`
 - You need to operate D+2 primary and D+12 reconciliation exports
 - You need to query retained Parquet with `--archive` and DuckDB

--- a/skills/langsmith/references/archive.md
+++ b/skills/langsmith/references/archive.md
@@ -4,6 +4,38 @@ The archive is organization-operated. `langsmith-cli` does not own a LangSmith k
 AWS credentials, scheduler, or bucket. Supply credentials through the runtime
 environment and AWS default credential chain.
 
+## Why archive instead of extending every trace?
+
+LangSmith's [usage and billing documentation](https://docs.langchain.com/langsmith/usage-and-billing#data-retention)
+currently describes two trace tiers:
+
+| Tier | Retention | Published trace price |
+|---|---:|---:|
+| Base | 14 days | 0.05¢ |
+| Extended | 400 days | 0.50¢ total |
+
+The 0.45¢ extended-retention upgrade makes an extended trace 10x the base trace
+price. At one million traces, that is $500 for base charges versus $5,000 if every
+trace is extended—an additional $4,500 before any plan allowances or negotiated
+pricing. Verify the official documentation before using these figures for a budget.
+
+Online evaluators and automation rules can extend retention when that setting is
+enabled. API/SDK feedback can do the same when it explicitly requests retention
+extension. A matching run upgrades the whole trace; thread-level rules can upgrade
+every trace in the thread. Retention extension is enabled by default for new online
+evaluators and automation rules according to the current documentation.
+
+The archive keeps LangSmith useful for live debugging while moving long-term history
+to inexpensive, organization-owned storage:
+
+```text
+live LangSmith API ──daily export──▶ private S3 Parquet ──DuckDB──▶ --archive
+     14 days               D+2 + D+12              long-term searchable history
+```
+
+This changes retention economics only. It does not avoid LangSmith's base trace
+charge, and the organization still pays its own object-storage and request costs.
+
 ## Route configuration
 
 ```yaml


### PR DESCRIPTION
## Why

LangSmith's published billing documentation currently lists:

| Trace tier | Retention | Per-trace price |
|---|---:|---:|
| Base | 14 days | 0.05¢ |
| Extended | 400 days | 0.50¢ total |

That makes broad extended retention **10x the base trace price**. At one million traces, the published per-trace rates illustrate a $500 base charge versus $5,000 when every trace is extended—$4,500 of additional retention cost before allowances, plan terms, discounts, or taxes.

This cost can also be easy to trigger unintentionally: online evaluators and automation rules may extend an entire trace when retention extension is enabled, thread-level rules may extend every trace in the thread, and API/SDK feedback may extend retention when explicitly requested.

PR #162 gives `langsmith-cli` an integrated alternative: keep LangSmith's 14-day base tier for live work, export verified D+2 and D+12 snapshots to organization-owned private S3, then search the retained Parquet with DuckDB and `--archive`.

Official source: [LangSmith usage and billing](https://docs.langchain.com/langsmith/usage-and-billing#data-retention).

## Before / after

| Concern | Before | After |
|---|---|---|
| README positioning | Archive capability was effectively undiscoverable | Prominent cost explanation, architecture, config, cron, and query examples |
| Cost visibility | No warning about 10x extended trace pricing | Concrete rates and 100K/1M/10M illustrations, with pricing caveats |
| Auto-upgrade risk | Not documented | Evaluator, automation, thread, and explicit feedback behavior called out |
| Agent behavior | Agents could query the live API for expired windows or recommend blanket retention | Skill prefers `--archive` for >14-day history and requires a cost warning |
| Cost boundaries | Potential implication that archiving eliminates trace costs | Explicitly says base ingestion and S3 costs remain |
| Operations | No ownership summary in README | Organization-owned credentials, scheduler, IAM, encryption, buckets, and lifecycle are explicit |

## Reader flow

```text
14-day LangSmith traces
        │
        ├── D+2 primary ──────────┐
        └── D+12 reconciliation ──┤ dedupe by run ID
                                  ▼
                         private S3 Parquet
                                  │
                        DuckDB + --archive
```

## Changes

- Add a prominent README section with:
  - official retention/pricing link;
  - cost illustration table;
  - auto-upgrade warning;
  - D+2/D+12 architecture;
  - route configuration;
  - scheduler and archive-query examples;
  - infrastructure ownership and cost caveats.
- Add archive commands to the README command reference.
- Update the LangSmith skill's mandatory workflow:
  - prefer configured archives for windows older than 14 days;
  - avoid live-API queries for expired base traces;
  - warn before recommending blanket extended retention.
- Expand the archive reference with the pricing model and auto-upgrade behavior.
- Ignore the Firecrawl evidence cache used to verify the current official documentation.

## Validation

- `pre-commit run --files .gitignore README.md skills/langsmith/SKILL.md skills/langsmith/references/archive.md`
- `git diff --check`
- `langsmith-cli archive --help`
- `langsmith-cli runs list --help`

All pass locally.

## Dependency

This is intentionally a stacked documentation PR targeting `codex/s3-trace-archive`. It depends on #162 because the documented archive commands do not exist on `main` yet. After #162 merges, this PR can be retargeted to `main` without changing its documentation commit.