### PR TITLE
Add LangSmith Bulk Export backfill and archive provider

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "LangSmith CLI plugin marketplace",
-    "version": "0.10.3"
+    "version": "0.11.0"
   },
   "plugins": [
     {
       "name": "langsmith-cli",
       "source": "./",
       "description": "A context-efficient interface for LangSmith observability and evaluations.",
-      "version": "0.10.3",
+      "version": "0.11.0",
       "author": {
         "name": "Gigaverse",
         "email": "aviadr1@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith-cli",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "description": "A context-efficient interface for LangSmith observability and evaluations.",
   "author": {
     "name": "Aviad Rozenhek",

--- a/README.md
+++ b/README.md
@@ -105,6 +105,27 @@ langsmith-cli runs list --slow --failed --today
 langsmith-cli runs watch
 ```
 
+### 🗄️ **S3 Trace Archive**
+
+Retain traces in private S3, backfill long historical windows through LangSmith
+Bulk Export, and query the canonical Parquet directly with DuckDB:
+
+```bash
+# One-time historical export; dates are a half-open UTC range.
+langsmith-cli --json archive backfill --config archive.yaml --route production \
+  --start-date 2025-08-01 --end-date 2026-08-01 \
+  --bulk-export-destination-id <uuid> --import-workers 8
+
+# Scan the retained archive without paging through the live Runs API.
+langsmith-cli --json runs search "timeout" --archive \
+  --project prd/my-agent --last 365d --fields id,name,status,error
+```
+
+The backfill is resumable: it adopts exact matching remote jobs and skips sealed
+project-days. See the [archive operator reference](skills/langsmith/references/archive.md)
+for setup, safe scaling, progress checks, and recovery, and the
+[archive design](docs/TRACE_ARCHIVE_DESIGN.md) for storage and invariants.
+
 ### 📦 **Complete Coverage**
 Every LangSmith resource at your fingertips:
 - ✅ **Projects** - List, create, inspect

--- a/docs/TRACE_ARCHIVE_DESIGN.md
+++ b/docs/TRACE_ARCHIVE_DESIGN.md
@@ -37,6 +37,24 @@ LANGSMITH_ARCHIVE_URI=s3://gigaverse-langsmith-traces-prd/langsmith \
 Each invocation calculates both due windows. Completed phases are skipped, known
 in-flight jobs are resumed, and failures are safe to retry.
 
+For high-volume projects, the same command accepts an organization-created managed
+destination through `--bulk-export-destination-id` or
+`LANGSMITH_BULK_EXPORT_DESTINATION_ID`. LangSmith writes `v2_beta` Parquet to an S3
+prefix inside the archive; the CLI adopts matching jobs, validates all partition
+coverage and row identities, and publishes the normal canonical contract.
+
+Historical migration uses one range job per project:
+
+```bash
+langsmith-cli --json archive backfill --route production \
+  --start-date 2025-08-01 --end-date 2026-08-01 \
+  --bulk-export-destination-id <uuid>
+```
+
+All project jobs are submitted before the CLI waits, letting LangSmith control
+workspace concurrency. Each completed range is converted into sealed daily
+manifests. Re-running adopts the same range jobs and skips days already sealed.
+
 ## Project routing
 
 Archive destinations are selected by ordered, named project routes:
@@ -94,6 +112,12 @@ Arbitrary SDK `bytes` values are preserved as tagged base64 objects with
 materialized at the JSON-to-Parquet boundary. This keeps non-UTF-8 media payloads
 without weakening UTF-8 validation for the surrounding trace document.
 
+Canonical nested fields (`inputs`, `outputs`, `extra`, `events`, `tags`,
+`feedback_stats`, and `parent_run_ids`) are JSON text. Runs API JSONL inference
+produces DuckDB `STRUCT`/`LIST` values while Bulk Export v2 supplies JSON `VARCHAR`;
+canonicalization converts both forms before union. This prevents provider changes or
+different object keys on adjacent days from producing incompatible Parquet schemas.
+
 The bucket owner may expire `raw/` after a repair/audit window. Canonical objects and
 manifests are retained according to the organization's policy.
 
@@ -135,6 +159,13 @@ Cross-service exactly-once behavior is impossible if a process dies after creati
 remote export but before persisting its ID. The design therefore guarantees
 at-least-once raw attempts and exactly-once canonical rows. Orphan raw attempts can be
 adopted or removed by lifecycle policy.
+
+Managed jobs are adopted by their complete immutable request identity: destination,
+project, exact half-open window, `v2_beta`, zstandard compression, full field set,
+and no schedule/filter. The newest non-failed match is used. Reconciliation excludes
+the primary export ID, forcing a new snapshot of the same date. Concurrent creators
+may leave a redundant managed job, but conditional manifest publication still
+allows only one canonical winner.
 
 The mutable manifest pointer is updated with compare-and-swap: `If-None-Match: *` for
 its first S3 publication and `If-Match: <observed-etag>` thereafter. Local archives
@@ -218,6 +249,9 @@ backend contract. `runs watch`, `runs open`, and mutations remain live-only.
 ## Provider boundary
 
 The portable provider pages through `Client.list_runs` for an exact half-open UTC
-window and writes Parquet itself. An optional LangSmith Bulk Export provider may use
-an organization-created destination ID. Scheduling, manifests, verification,
-canonicalization, and querying are provider-independent.
+window and writes Parquet itself. The LangSmith Bulk Export provider uses an
+organization-created destination ID, submits/adopts managed jobs, verifies every
+partition covers the requested window without gaps, verifies Parquet count and run
+ID uniqueness, and compacts the provider output into the same raw/canonical layout.
+Scheduling, manifests, verification, canonicalization, and querying remain
+provider-independent.

--- a/docs/TRACE_ARCHIVE_DESIGN.md
+++ b/docs/TRACE_ARCHIVE_DESIGN.md
@@ -57,6 +57,49 @@ workspace concurrency. Completed jobs are harvested without submission-order
 blocking, and bounded workers convert independent projects into sealed daily
 manifests. Re-running adopts the same range jobs and skips days already sealed.
 
+### Historical backfill execution model
+
+Export and publication are deliberately separate concurrency domains:
+
+```text
+selected projects
+      |
+      | submit or adopt every exact project/range request
+      v
+LangSmith managed queue (remote concurrency and hourly Parquet)
+      |
+      | harvest whichever exports complete; submission order is irrelevant
+      v
+bounded project worker pool (local DuckDB + S3 concurrency)
+      |
+      | one worker owns one project and publishes its UTC days serially
+      v
+raw generation -> verified canonical generation -> manifest written last
+```
+
+The CLI never splits one project's days across workers in one invocation. This is
+the local one-writer-per-project invariant; export IDs are also required to map to
+exactly one project before any worker is scheduled. Independent projects may publish
+concurrently. For a one-time migration, operators may run multiple invocations with
+disjoint repeated `--project` selections. Overlapping project selections are safe at
+the manifest CAS boundary but waste export, DuckDB, and S3 work and therefore are not
+a scaling strategy.
+
+`--import-workers` bounds projects being compacted per invocation; it does not alter
+LangSmith's managed export concurrency. Its default is 8 and its maximum is 32.
+Total local concurrency across manual shards is `invocations * import-workers`, so
+operators must measure CPU, memory, S3 request rate, and object sizes rather than
+assuming the maximum is faster. The live 399-day Gigaverse migration measured:
+
+| Layout | Aggregate publication | Relative to serial |
+|---|---:|---:|
+| Three serial environment processes | ~45 project-days/min | 1x |
+| One 8-worker process per environment | ~350 project-days/min | ~8x |
+| Six disjoint shards, 48 aggregate workers, 6-core host | 560-630 project-days/min | ~12-14x |
+
+These measurements describe one workload and host, not a universal default. Daily
+scheduled syncs are much smaller and do not need manual sharding.
+
 ## Project routing
 
 Archive destinations are selected by ordered, named project routes:

--- a/docs/TRACE_ARCHIVE_DESIGN.md
+++ b/docs/TRACE_ARCHIVE_DESIGN.md
@@ -100,6 +100,15 @@ assuming the maximum is faster. The live 399-day Gigaverse migration measured:
 These measurements describe one workload and host, not a universal default. Daily
 scheduled syncs are much smaller and do not need manual sharding.
 
+Status has a separate fast path because publication scale makes a full metadata
+audit expensive. During the live backfill, downloading every dev manifest was still
+unfinished when interrupted at 168.42 seconds. Key-derived `status --summary`
+counted 23,404 dev manifests in 8.37 seconds and all 56,453 then-published manifests
+across three routes in 19.41 seconds, with zero invalid keys. That is at least 20x
+lower dev completion-check latency in the observed run. The summary labels itself
+`manifest_contents_verified: false`; use the bounded full audit only when manifest
+body validation is required.
+
 ## Project routing
 
 Archive destinations are selected by ordered, named project routes:
@@ -246,6 +255,7 @@ worker B: read v1 ─ export raw B ─ canonical B ─ CAS(v1) ──► CONFLIC
 | A12 | Empty project-days return zero without schema-union failures | Zero-count manifest pruning | `test_empty_archive_is_queryable_as_zero_rows` |
 | A13 | Text-search SQL identifiers come only from a fixed allowlist | `ArchiveRunQuery.__post_init__` | `test_archive_text_fields_are_an_explicit_allowlist` |
 | A14 | Full-trace semantic values and topology are provider-independent | `_normalize_run_payload`, `_validated_archive_run`, and derived `child_run_ids` | `test_bulk_json_normalization_matches_live_run_shape`, `test_bulk_reconciliation_unifies_runs_api_and_v2_json_column_types` plus the documented real three-trace comparison |
+| A15 | Archive completion counts do not require one object GET per manifest | `archive status --summary` derives identities from normalized immutable keys and labels the result `manifest_contents_verified: false`; full audits share one bounded metadata reader | `test_status_summary_is_key_derived_and_never_downloads_manifests`, `test_status_reads_independent_manifests_concurrently` |
 
 The table deliberately names the enforcing code and executable regression test for
 each contract. Tests without an enforcement point prove an accident; comments without

--- a/docs/TRACE_ARCHIVE_DESIGN.md
+++ b/docs/TRACE_ARCHIVE_DESIGN.md
@@ -109,6 +109,14 @@ lower dev completion-check latency in the observed run. The summary labels itsel
 `manifest_contents_verified: false`; use the bounded full audit only when manifest
 body validation is required.
 
+The six-shard run also exposed why process-local spill ownership is an invariant,
+not a tuning detail. Two large workers peaked near 10 GiB each and used swap; one
+failed after another process truncated the shared default
+`.tmp/duckdb_temp_storage_*.tmp`. Archive connections now create unique spill
+directories within their already-unique staging roots, so cleanup in one process
+cannot corrupt another. Publication completed before the failure remains sealed and
+the failed disjoint shard is safe to replay.
+
 ## Project routing
 
 Archive destinations are selected by ordered, named project routes:
@@ -256,6 +264,7 @@ worker B: read v1 ─ export raw B ─ canonical B ─ CAS(v1) ──► CONFLIC
 | A13 | Text-search SQL identifiers come only from a fixed allowlist | `ArchiveRunQuery.__post_init__` | `test_archive_text_fields_are_an_explicit_allowlist` |
 | A14 | Full-trace semantic values and topology are provider-independent | `_normalize_run_payload`, `_validated_archive_run`, and derived `child_run_ids` | `test_bulk_json_normalization_matches_live_run_shape`, `test_bulk_reconciliation_unifies_runs_api_and_v2_json_column_types` plus the documented real three-trace comparison |
 | A15 | Archive completion counts do not require one object GET per manifest | `archive status --summary` derives identities from normalized immutable keys and labels the result `manifest_contents_verified: false`; full audits share one bounded metadata reader | `test_status_summary_is_key_derived_and_never_downloads_manifests`, `test_status_reads_independent_manifests_concurrently` |
+| A16 | Concurrent processes never share DuckDB spill files | every archive DuckDB connection gets a unique temporary directory inside its project/query staging boundary | `test_duckdb_spill_directory_is_unique_to_each_project_staging_area`; live replay of the shard that exposed shared `.tmp` truncation |
 
 The table deliberately names the enforcing code and executable regression test for
 each contract. Tests without an enforcement point prove an accident; comments without

--- a/docs/TRACE_ARCHIVE_DESIGN.md
+++ b/docs/TRACE_ARCHIVE_DESIGN.md
@@ -109,13 +109,15 @@ lower dev completion-check latency in the observed run. The summary labels itsel
 `manifest_contents_verified: false`; use the bounded full audit only when manifest
 body validation is required.
 
-The six-shard run also exposed why process-local spill ownership is an invariant,
-not a tuning detail. Two large workers peaked near 10 GiB each and used swap; one
+The six-shard run also exposed why DuckDB resource ownership is an invariant, not a
+tuning detail. Two large workers peaked near 10 GiB each and used swap; one
 failed after another process truncated the shared default
-`.tmp/duckdb_temp_storage_*.tmp`. Archive connections now create unique spill
-directories within their already-unique staging roots, so cleanup in one process
-cannot corrupt another. Publication completed before the failure remains sealed and
-the failed disjoint shard is safe to replay.
+`.tmp/duckdb_temp_storage_*.tmp`. Every archive connection now has a 1 GiB memory
+limit and creates a unique spill directory within its already-unique staging root.
+The limit prevents several connections from each claiming most of host memory; the
+directory prevents cleanup in one process from corrupting another. Publication
+completed before the failure remains sealed and the failed disjoint shard is safe to
+replay.
 
 ## Project routing
 
@@ -264,7 +266,7 @@ worker B: read v1 ─ export raw B ─ canonical B ─ CAS(v1) ──► CONFLIC
 | A13 | Text-search SQL identifiers come only from a fixed allowlist | `ArchiveRunQuery.__post_init__` | `test_archive_text_fields_are_an_explicit_allowlist` |
 | A14 | Full-trace semantic values and topology are provider-independent | `_normalize_run_payload`, `_validated_archive_run`, and derived `child_run_ids` | `test_bulk_json_normalization_matches_live_run_shape`, `test_bulk_reconciliation_unifies_runs_api_and_v2_json_column_types` plus the documented real three-trace comparison |
 | A15 | Archive completion counts do not require one object GET per manifest | `archive status --summary` derives identities from normalized immutable keys and labels the result `manifest_contents_verified: false`; full audits share one bounded metadata reader | `test_status_summary_is_key_derived_and_never_downloads_manifests`, `test_status_reads_independent_manifests_concurrently` |
-| A16 | Concurrent processes never share DuckDB spill files | every archive DuckDB connection gets a unique temporary directory inside its project/query staging boundary | `test_duckdb_spill_directory_is_unique_to_each_project_staging_area`; live replay of the shard that exposed shared `.tmp` truncation |
+| A16 | Concurrent archive connections have bounded memory and never share spill files | every connection has a 1 GiB memory limit and a unique temporary directory inside its project/query staging boundary | `test_duckdb_resources_are_bounded_and_unique_to_each_project_staging_area`; live replay of the shard that exposed shared `.tmp` truncation and severe host-memory pressure |
 
 The table deliberately names the enforcing code and executable regression test for
 each contract. Tests without an enforcement point prove an accident; comments without

--- a/docs/TRACE_ARCHIVE_DESIGN.md
+++ b/docs/TRACE_ARCHIVE_DESIGN.md
@@ -241,11 +241,21 @@ worker B: read v1 ─ export raw B ─ canonical B ─ CAS(v1) ──► CONFLIC
 | Readers use only published canonical keys | Manifest-directed discovery | Raw/orphan/unreferenced canonical generations are invisible |
 | Empty project-days return zero | Zero-count manifest pruning | DuckDB is not asked to union an empty partial schema |
 | Text-search SQL identifiers are fixed | `ArchiveRunQuery` field allowlist | Unsupported `--grep-in` fields fail before SQL construction |
+| Full-trace semantic values are provider-independent | Archive read normalization restores Bulk nested values, UTC event offsets, and derived child IDs | Real API/archive traces match after treating missing and null object members as equivalent |
 
 These invariants are executable contracts, not documentation only. Unit tests cover
 corrupt manifests, duplicate IDs, stale and simultaneous writers, sealed retries,
 empty partitions, unsafe text fields, route pruning, and Windows paths. CLI tests
 cover scheduled D+2/D+12 routing, explicit-project failures, and status output.
+
+Bulk Export and the Runs API encode a few equivalent values differently. Bulk may
+pad inferred nested objects with null keys, add one JSON layer to LangChain's reserved
+`inputs.input`, omit the derived `child_run_ids`, and return unzoned UTC event times.
+The archive reader safely normalizes the latter three. It deliberately preserves
+nested nulls because the live CLI promises not to coerce or discard them. Parquet
+schema union cannot always distinguish an absent object member from an explicit null,
+so raw JSON is not universally byte-identical; semantic comparison must treat missing
+and null object members as equivalent.
 
 ## Query architecture
 

--- a/docs/TRACE_ARCHIVE_DESIGN.md
+++ b/docs/TRACE_ARCHIVE_DESIGN.md
@@ -226,27 +226,31 @@ worker B: read v1 ─ export raw B ─ canonical B ─ CAS(v1) ──► CONFLIC
 
 ## Enforced invariants
 
-| Invariant | Enforcement point | Failure behavior |
-|---|---|---|
-| One project matches exactly one route | Config routing | Unmatched/ambiguous explicit projects fail; catalog scans report unmatched projects |
-| Project identity is immutable inside a route | `projects/project_id=<uuid>.json` create/verify | Rename or route move requires explicit migration |
-| A manifest is exactly one UTC day | Manifest construction and deserialization | Non-UTC or non-24-hour windows fail before query/publication |
-| Object keys are normalized and namespace-bound | Store key validation plus manifest model | Absolute, traversal, wrong project/date/phase, and malformed generation keys fail |
-| Snapshot run IDs are unique | DuckDB validation before canonicalization | No manifest is published; uploaded raw attempt remains an expirable orphan |
-| Canonical run IDs are unique | Validation of the written canonical Parquet | No manifest is published |
-| Canonical count is between the largest input and their sum | Manifest publication/read boundary | Truncated or inflated manifests fail closed |
-| Reconciliation wins duplicate IDs | Canonical `row_number` rank | Updated D+12 rows replace D+2; primary-only and late rows are retained |
-| A sealed day cannot regress | Phase idempotency plus sealed-state validation | Repeated phase calls return the published manifest without exporting |
-| Only one concurrent publisher wins | S3 ETag/local locked CAS | Stale writer receives a concurrency error; winning pointer is preserved |
-| Readers use only published canonical keys | Manifest-directed discovery | Raw/orphan/unreferenced canonical generations are invisible |
-| Empty project-days return zero | Zero-count manifest pruning | DuckDB is not asked to union an empty partial schema |
-| Text-search SQL identifiers are fixed | `ArchiveRunQuery` field allowlist | Unsupported `--grep-in` fields fail before SQL construction |
-| Full-trace semantic values are provider-independent | Archive read normalization restores Bulk nested values, UTC event offsets, and derived child IDs | Real API/archive traces match after treating missing and null object members as equivalent |
+| ID | Invariant | Enforcement point | Regression proof |
+|---|---|---|---|
+| A1 | One project matches exactly one route | `ArchiveConfig.route_project` requires exactly one match | `test_route_config_selects_exactly_one_destination`, `test_overlapping_routes_fail_fast` |
+| A2 | One command processes each project identity at most once | `_routed_projects` rejects duplicate project IDs before export/worker submission | `test_bulk_backfill_rejects_duplicate_project_identity_before_export` |
+| A3 | Project identity is immutable inside a route | `ensure_project_record` create-or-verify boundary | `test_project_catalog_rejects_silent_rename` |
+| A4 | A manifest is exactly one UTC day | `ArchiveManifest` construction/deserialization validation | `test_corrupt_manifest_fails_at_the_storage_boundary` |
+| A5 | Object keys are normalized and namespace-bound | Store key validation plus manifest model | `test_store_rejects_object_key_traversal`, `test_manifest_location_must_match_its_project_and_date` |
+| B1 | Every managed job has canonical IDs, a non-empty UTC window, and the exact requested destination/project/format contract | `BulkExportJob.__post_init__`, `BulkExportSnapshot.__post_init__`, `_matches_window` | `test_bulk_export_job_model_enforces_identity_and_window_invariants`, `test_bulk_export_snapshot_model_enforces_utc_window_invariant`, `test_bulk_export_batch_rejects_polled_request_identity_drift` |
+| B2 | Every exported file remains inside the normalized configured S3 destination | `_get_validated_destination`, `_exported_file_uri`, `_require_normalized_s3_path` | `test_bulk_export_rejects_destination_outside_archive`, `test_bulk_export_rejects_invalid_completed_partitions`, `test_bulk_export_rejects_unsafe_identity_and_storage_configuration` |
+| B3 | Completed partitions exactly cover the requested UTC window | `_validate_partition_coverage` rejects missing, gapped, overlapping, reversed, or extra intervals | `test_bulk_export_rejects_missing_partition_coverage`, `test_bulk_export_partitions_exactly_cover_requested_window` |
+| B4 | Completion order never controls harvest order | `complete_exports` removes and yields every ready job before waiting or reporting a terminal peer | `test_bulk_export_batch_harvests_completed_jobs_without_head_of_line_blocking`, `test_bulk_export_batch_harvests_ready_peer_before_reporting_failure` |
+| A6 | Snapshot and canonical run IDs are unique | DuckDB `count(*) = count(DISTINCT id)` checks before and after canonicalization | `test_snapshot_duplicate_run_ids_fail_before_publication`, `test_reconciliation_deduplicates_and_is_idempotent` |
+| A7 | Canonical count is between the largest input and their sum | Manifest publication/read validation | `test_canonical_count_is_bounded_by_snapshot_counts` |
+| A8 | Reconciliation wins duplicate IDs without losing primary-only or late rows | Canonical `row_number` ordered by snapshot rank | `test_reconciliation_deduplicates_and_is_idempotent`, `test_bulk_reconciliation_unifies_runs_api_and_v2_json_column_types` |
+| A9 | A sealed day cannot regress | Phase idempotency plus sealed-state validation | `test_sealed_day_is_idempotent_and_cannot_be_unsealed`, `test_range_backfill_publishes_daily_partitions_and_resumes` |
+| A10 | Only one concurrent publisher wins | S3 ETag/local locked compare-and-swap | `test_manifest_publication_rejects_a_stale_writer`, `test_two_manifest_publishers_cannot_both_win` |
+| A11 | Readers use only published canonical keys | Manifest-directed discovery | `test_queries_ignore_unpublished_raw_and_canonical_objects` |
+| A12 | Empty project-days return zero without schema-union failures | Zero-count manifest pruning | `test_empty_archive_is_queryable_as_zero_rows` |
+| A13 | Text-search SQL identifiers come only from a fixed allowlist | `ArchiveRunQuery.__post_init__` | `test_archive_text_fields_are_an_explicit_allowlist` |
+| A14 | Full-trace semantic values and topology are provider-independent | `_normalize_run_payload`, `_validated_archive_run`, and derived `child_run_ids` | `test_bulk_json_normalization_matches_live_run_shape`, `test_bulk_reconciliation_unifies_runs_api_and_v2_json_column_types` plus the documented real three-trace comparison |
 
-These invariants are executable contracts, not documentation only. Unit tests cover
-corrupt manifests, duplicate IDs, stale and simultaneous writers, sealed retries,
-empty partitions, unsafe text fields, route pruning, and Windows paths. CLI tests
-cover scheduled D+2/D+12 routing, explicit-project failures, and status output.
+The table deliberately names the enforcing code and executable regression test for
+each contract. Tests without an enforcement point prove an accident; comments without
+a falsifying test are only claims. CLI tests additionally cover scheduled D+2/D+12
+routing, explicit-project failures, progress behavior, and status output.
 
 Bulk Export and the Runs API encode a few equivalent values differently. Bulk may
 pad inferred nested objects with null keys, add one JSON layer to LangChain's reserved

--- a/docs/TRACE_ARCHIVE_DESIGN.md
+++ b/docs/TRACE_ARCHIVE_DESIGN.md
@@ -48,11 +48,13 @@ Historical migration uses one range job per project:
 ```bash
 langsmith-cli --json archive backfill --route production \
   --start-date 2025-08-01 --end-date 2026-08-01 \
+  --import-workers 8 \
   --bulk-export-destination-id <uuid>
 ```
 
 All project jobs are submitted before the CLI waits, letting LangSmith control
-workspace concurrency. Each completed range is converted into sealed daily
+workspace concurrency. Completed jobs are harvested without submission-order
+blocking, and bounded workers convert independent projects into sealed daily
 manifests. Re-running adopts the same range jobs and skips days already sealed.
 
 ## Project routing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "langsmith-cli"
 # IMPORTANT: When bumping this version, also update .claude-plugin/plugin.json
-version = "0.10.3"
+version = "0.11.0"
 description = "Context-efficient CLI for LangSmith. Built for humans and agents."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -37,6 +37,7 @@ dependencies = [
     "platformdirs>=4.0",
     "pydantic>=2.11.0",
     "python-dotenv>=1.2.1",
+    "pytz>=2025.2",
     "pyyaml>=6.0.3",
     "rich>=14.2.0",
 ]

--- a/skills/langsmith/SKILL.md
+++ b/skills/langsmith/SKILL.md
@@ -103,7 +103,7 @@ langsmith-cli --json runs get <id> --fields inputs,outputs,error
 | Get archived run efficiently | `langsmith-cli --json runs get <id> --archive --project <name> --last 1d --fields inputs,outputs` |
 | Sync trace archive | `langsmith-cli --json archive sync --route <name>` |
 | Sync via Bulk Export | `langsmith-cli --json archive sync --route <name> --bulk-export-destination-id <uuid>` |
-| Backfill archive | `langsmith-cli --json archive backfill --route <name> --start-date <inclusive> --end-date <exclusive> --bulk-export-destination-id <uuid>` |
+| Backfill archive | `langsmith-cli --json archive backfill --route <name> --start-date <inclusive> --end-date <exclusive> --import-workers 8 --bulk-export-destination-id <uuid>` |
 | Check archive status | `langsmith-cli --json archive status --all-routes` |
 | Download cache | `langsmith-cli --json runs cache download --project <name> --last 7d` |
 | List cache | `langsmith-cli --json runs cache list --fields project_name,run_count,path` |

--- a/skills/langsmith/SKILL.md
+++ b/skills/langsmith/SKILL.md
@@ -100,7 +100,10 @@ langsmith-cli --json runs get <id> --fields inputs,outputs,error
 | Scoped content search | `langsmith-cli --json runs search "pattern" --in outputs --fields id,name,outputs --limit 20` |
 | Search cached runs | `langsmith-cli --json runs cache grep "pattern" -E --grep-in outputs --project <name> --fields id,name,outputs` |
 | Search S3 archive | `langsmith-cli --json runs search "pattern" --archive --project <name> --fields id,name,status` |
+| Get archived run efficiently | `langsmith-cli --json runs get <id> --archive --project <name> --last 1d --fields inputs,outputs` |
 | Sync trace archive | `langsmith-cli --json archive sync --route <name>` |
+| Sync via Bulk Export | `langsmith-cli --json archive sync --route <name> --bulk-export-destination-id <uuid>` |
+| Backfill archive | `langsmith-cli --json archive backfill --route <name> --start-date <inclusive> --end-date <exclusive> --bulk-export-destination-id <uuid>` |
 | Check archive status | `langsmith-cli --json archive status --all-routes` |
 | Download cache | `langsmith-cli --json runs cache download --project <name> --last 7d` |
 | List cache | `langsmith-cli --json runs cache list --fields project_name,run_count,path` |
@@ -134,6 +137,7 @@ When your task matches one of the sections below, **you MUST load that reference
 ### → Read [references/archive.md](references/archive.md) when:
 - You need to configure project-to-S3 routing such as `dev/**` and `stg/**`
 - You need to operate D+2 primary and D+12 reconciliation exports
+- You need a managed Bulk Export backfill for a large historical date range
 - You need to query retained Parquet with `--archive` and DuckDB
 
 ### → Read [references/search.md](references/search.md) when:

--- a/skills/langsmith/SKILL.md
+++ b/skills/langsmith/SKILL.md
@@ -104,7 +104,7 @@ langsmith-cli --json runs get <id> --fields inputs,outputs,error
 | Sync trace archive | `langsmith-cli --json archive sync --route <name>` |
 | Sync via Bulk Export | `langsmith-cli --json archive sync --route <name> --bulk-export-destination-id <uuid>` |
 | Backfill archive | `langsmith-cli --json archive backfill --route <name> --start-date <inclusive> --end-date <exclusive> --import-workers 8 --bulk-export-destination-id <uuid>` |
-| Check archive status | `langsmith-cli --json archive status --all-routes` |
+| Check archive status | `langsmith-cli --json archive status --summary --all-routes` |
 | Download cache | `langsmith-cli --json runs cache download --project <name> --last 7d` |
 | List cache | `langsmith-cli --json runs cache list --fields project_name,run_count,path` |
 | Discover cache schema | `langsmith-cli --json runs cache schema --project <name> --include outputs` |

--- a/skills/langsmith/references/archive.md
+++ b/skills/langsmith/references/archive.md
@@ -93,6 +93,20 @@ order and compacts independent projects concurrently. Completed output is split 
 sealed UTC-day manifests for DuckDB. Re-running the same command adopts the existing
 range export and skips already sealed days.
 
+Progress messages go to stderr even with `--json`, leaving stdout as one final
+machine-readable result. The important transitions are:
+
+```text
+Submitted or adopted N project export(s)  remote work is known and resumable
+Export ready; importing <project>         local DuckDB/S3 publication started
+Imported <project>: X new, Y sealed       that project's range finished locally
+final JSON on stdout + exit 0              every selected project finished
+```
+
+The first line does **not** mean the backfill is complete. LangSmith can have accepted
+every job while local canonical publication still has thousands of project-days to
+write.
+
 Historical exports can remain queued behind other workspace jobs. Backfill waits up
 to 73 hours without any project completing by default, slightly beyond the managed
 workflow's 72-hour terminal timeout. Each completion resets that idle deadline.
@@ -103,6 +117,83 @@ exact-window jobs.
 Use repeated `--project` options to limit a repair or trial. Keep ranges small enough
 to finish within LangSmith's managed export workflow timeout. Bulk Export cannot
 recover traces that LangSmith has already deleted under its retention policy.
+
+### Scaling a one-time backfill
+
+`--import-workers` is the number of independent projects compacted by one invocation,
+not the number of days or LangSmith export jobs. Start with the default 8 and measure
+the host and S3 before increasing it. The maximum is 32.
+
+If one process cannot use the available host capacity, split projects into disjoint
+invocations using repeated `--project` options:
+
+```bash
+# Shard A
+langsmith-cli --json archive backfill --route production \
+  --project prd/agent-a --project prd/agent-c \
+  --start-date 2025-08-01 --end-date 2026-08-01 \
+  --import-workers 8 --bulk-export-destination-id <uuid>
+
+# Shard B: no project may also appear in shard A.
+langsmith-cli --json archive backfill --route production \
+  --project prd/agent-b --project prd/agent-d \
+  --start-date 2025-08-01 --end-date 2026-08-01 \
+  --import-workers 8 --bulk-export-destination-id <uuid>
+```
+
+Keep the route, destination, and half-open date window identical across shards. The
+CLI rejects one export ID being assigned to multiple projects, and each invocation
+schedules at most one publisher per selected project. Manifest compare-and-swap is a
+last line of defense, not permission to overlap shard membership deliberately.
+
+Total local concurrency is `number of invocations * import workers`. Watch CPU,
+memory, S3 throttling, and error logs while increasing it. More workers cannot make a
+queued LangSmith export complete sooner; they only accelerate publication after an
+export is ready.
+
+### Proving completion
+
+Use the process result and the archive matrix together. For a half-open range, the
+expected day count is `end_date - start_date`. A complete rectangular backfill has
+`selected_projects * expected_days` sealed manifests:
+
+```bash
+langsmith-cli --json archive status --config archive.yaml --route production \
+  | jq '[.[] | select(
+      .trace_date >= "2025-08-01" and .trace_date < "2026-08-01"
+    )] | {
+      manifests: length,
+      sealed: map(select(.sealed)) | length,
+      projects: map(.project_id) | unique | length
+    }'
+```
+
+Completion requires all of the following:
+
+1. Every shard exits 0 and emits its final JSON result.
+2. `manifests == sealed == selected_projects * expected_days` for the requested
+   matrix. Use the original selected-project count; deriving it only from manifests
+   could hide a project with zero published days.
+3. No shard reports a terminal export, validation, DuckDB, S3, or CAS error.
+4. Representative DuckDB archive queries return the expected runs before temporary
+   Bulk Export credentials or raw source objects are retired.
+
+### Restart and cleanup
+
+Restart with the exact same destination, route, projects, and half-open window. The
+CLI adopts the newest non-failed job whose complete immutable request identity
+matches and skips each already sealed day. Changing the destination, project, range,
+format, or field contract is a different request and may create a new managed job.
+
+If a process stops after uploading immutable data but before publishing the manifest,
+the object is an invisible orphan; readers only follow manifest pointers. A later
+retry safely republishes, and the bucket's explicit raw-object lifecycle may remove
+orphans after the audit window.
+
+Keep the LangSmith destination credentials valid until both remote export and local
+publication are complete. Remove temporary credentials only after the completion
+checks above. Do not silently expire or delete Bulk Export source objects until the
+organization has chosen and documented its repair/audit retention window.
 
 ## Archive queries
 

--- a/skills/langsmith/references/archive.md
+++ b/skills/langsmith/references/archive.md
@@ -157,7 +157,10 @@ queued LangSmith export complete sooner; they only accelerate publication after 
 export is ready. On an 11 GiB host, 48 aggregate workers briefly drove two large
 DuckDB processes near 10 GiB each and into swap; scale down aggregate workers for the
 long tail instead of assuming the broad-middle throughput will hold for the largest
-projects.
+projects. Each archive DuckDB connection is limited to 1 GiB and owns a unique spill
+directory. That bounds connection memory and prevents concurrent processes from
+truncating each other's spill files; aggregate process overhead still makes worker
+count an operator-controlled capacity decision.
 
 ### Proving completion
 

--- a/skills/langsmith/references/archive.md
+++ b/skills/langsmith/references/archive.md
@@ -82,6 +82,7 @@ langsmith-cli --json archive backfill \
   --route dev \
   --start-date 2025-08-01 \
   --end-date 2026-08-01 \
+  --bulk-export-timeout-hours 73 \
   --bulk-export-destination-id <uuid>
 ```
 
@@ -89,6 +90,11 @@ The command submits/adopts every selected project export before waiting, allowin
 LangSmith to apply its workspace concurrency. Completed output is split into sealed
 UTC-day manifests for DuckDB. Re-running the same command adopts the existing range
 export and skips already sealed days.
+
+Historical exports can remain queued behind other workspace jobs. Backfill waits up
+to 73 hours per project by default, slightly beyond the managed workflow's 72-hour
+terminal timeout. Override `--bulk-export-timeout-hours` for a shorter operator
+window; rerunning adopts the same exact-window jobs.
 
 Use repeated `--project` options to limit a repair or trial. Keep ranges small enough
 to finish within LangSmith's managed export workflow timeout. Bulk Export cannot

--- a/skills/langsmith/references/archive.md
+++ b/skills/langsmith/references/archive.md
@@ -220,6 +220,12 @@ has no project/date information, so a year-scale archive otherwise requires mani
 discovery across every project and day. Pass the narrowest known `--project` or
 `--project-id` plus `--since`/`--before` or `--last` window.
 
+`runs get --follow-children --json` restores Bulk's nested `inputs.input`, UTC event
+timestamps, and API-derived `child_run_ids`. Bulk Parquet may pad an inferred object
+schema with null members, while the Runs API may omit those members. Because the CLI
+preserves explicit nested nulls, raw JSON is not universally byte-identical; compare
+missing and null object members as equivalent when validating provider parity.
+
 See `docs/TRACE_ARCHIVE_DESIGN.md` for storage layout, reconciliation,
 deduplication, crash recovery, IAM boundaries, and efficiency decisions.
 

--- a/skills/langsmith/references/archive.md
+++ b/skills/langsmith/references/archive.md
@@ -154,7 +154,10 @@ last line of defense, not permission to overlap shard membership deliberately.
 Total local concurrency is `number of invocations * import workers`. Watch CPU,
 memory, S3 throttling, and error logs while increasing it. More workers cannot make a
 queued LangSmith export complete sooner; they only accelerate publication after an
-export is ready.
+export is ready. On an 11 GiB host, 48 aggregate workers briefly drove two large
+DuckDB processes near 10 GiB each and into swap; scale down aggregate workers for the
+long tail instead of assuming the broad-middle throughput will hold for the largest
+projects.
 
 ### Proving completion
 

--- a/skills/langsmith/references/archive.md
+++ b/skills/langsmith/references/archive.md
@@ -38,6 +38,21 @@ langsmith-cli --json archive sync --route dev \
   --date 2026-08-19 --phase primary
 ```
 
+For high-volume projects, configure a LangSmith Bulk Export destination whose S3
+bucket and prefix are inside the selected archive URI. Supply its UUID through the
+environment or the command line:
+
+```bash
+LANGSMITH_BULK_EXPORT_DESTINATION_ID=<uuid> \
+  langsmith-cli --json archive sync --route dev --retention-days 14
+```
+
+The CLI creates or adopts an exact project/window `v2_beta` export, waits for all
+LangSmith partitions, verifies row counts and distinct run IDs from the published
+Parquet, then publishes the same canonical manifest contract as the Runs API
+provider. Primary export IDs are excluded when selecting reconciliation jobs, so
+D+12 always captures a fresh snapshot.
+
 Prefer one CronJob per route so its AWS role can access only that environment's
 bucket. Use `--all-routes` only for a central role intentionally authorized for all
 destinations.
@@ -57,12 +72,34 @@ langsmith-cli --json archive status --route dev
 langsmith-cli --json archive status --all-routes
 ```
 
+## Historical backfill
+
+Use one managed range export per project rather than creating one API job per day.
+`--start-date` is inclusive and `--end-date` is exclusive:
+
+```bash
+langsmith-cli --json archive backfill \
+  --route dev \
+  --start-date 2025-08-01 \
+  --end-date 2026-08-01 \
+  --bulk-export-destination-id <uuid>
+```
+
+The command submits/adopts every selected project export before waiting, allowing
+LangSmith to apply its workspace concurrency. Completed output is split into sealed
+UTC-day manifests for DuckDB. Re-running the same command adopts the existing range
+export and skips already sealed days.
+
+Use repeated `--project` options to limit a repair or trial. Keep ranges small enough
+to finish within LangSmith's managed export workflow timeout. Bulk Export cannot
+recover traces that LangSmith has already deleted under its retention policy.
+
 ## Archive queries
 
 ```bash
 langsmith-cli --json runs list --archive --project dev/my-agent --last 90d
 langsmith-cli --json runs search "timeout" --archive --project dev/my-agent
-langsmith-cli --json runs get <id> --archive --follow-children
+langsmith-cli --json runs get <id> --archive --project dev/my-agent --last 1d --follow-children
 langsmith-cli --json runs get-latest --archive --project dev/my-agent --failed
 ```
 
@@ -76,6 +113,11 @@ typed DuckDB query model.
 Name/regex/exclude filters currently run after the DuckDB query. Use `--fetch N` to
 control how many archived rows they evaluate; `--count` evaluates the full matching
 archive before applying those local filters.
+
+For `runs get`, project and time options are partition-pruning hints. A bare run ID
+has no project/date information, so a year-scale archive otherwise requires manifest
+discovery across every project and day. Pass the narrowest known `--project` or
+`--project-id` plus `--since`/`--before` or `--last` window.
 
 See `docs/TRACE_ARCHIVE_DESIGN.md` for storage layout, reconciliation,
 deduplication, crash recovery, IAM boundaries, and efficiency decisions.

--- a/skills/langsmith/references/archive.md
+++ b/skills/langsmith/references/archive.md
@@ -65,12 +65,17 @@ Overlapping jobs are safe: immutable data uploads happen before an ETag-conditio
 manifest update. Exactly one writer publishes; stale writers fail and are safe to
 retry. Do not add an external distributed lock around the CronJob.
 
-List manifests:
+Check archive size without downloading every manifest:
 
 ```bash
-langsmith-cli --json archive status --route dev
-langsmith-cli --json archive status --all-routes
+langsmith-cli --json archive status --summary --route dev
+langsmith-cli --json archive status --summary --all-routes
 ```
+
+Omit `--summary` only when you need every validated manifest body. A full status
+audit performs one object read per manifest; the summary derives project/date counts
+from immutable manifest keys using S3 LIST and reports
+`manifest_contents_verified: false` explicitly.
 
 ## Historical backfill
 
@@ -158,22 +163,24 @@ expected day count is `end_date - start_date`. A complete rectangular backfill h
 `selected_projects * expected_days` sealed manifests:
 
 ```bash
-langsmith-cli --json archive status --config archive.yaml --route production \
-  | jq '[.[] | select(
-      .trace_date >= "2025-08-01" and .trace_date < "2026-08-01"
-    )] | {
-      manifests: length,
-      sealed: map(select(.sealed)) | length,
-      projects: map(.project_id) | unique | length
+langsmith-cli --json archive status --summary \
+  --config archive.yaml --route production \
+  | jq '.routes[0] | {
+      manifests: .manifest_count,
+      projects: .project_count,
+      first_date,
+      last_date,
+      invalid_manifest_keys
     }'
 ```
 
 Completion requires all of the following:
 
 1. Every shard exits 0 and emits its final JSON result.
-2. `manifests == sealed == selected_projects * expected_days` for the requested
-   matrix. Use the original selected-project count; deriving it only from manifests
-   could hide a project with zero published days.
+2. Every shard result reports `imported_days + skipped_days == expected_days` for
+   each selected project, and summary `manifests == selected_projects *
+   expected_days` with no invalid keys. Use the original selected-project count;
+   deriving it only from manifests could hide a project with zero published days.
 3. No shard reports a terminal export, validation, DuckDB, S3, or CAS error.
 4. Representative DuckDB archive queries return the expected runs before temporary
    Bulk Export credentials or raw source objects are retired.

--- a/skills/langsmith/references/archive.md
+++ b/skills/langsmith/references/archive.md
@@ -83,18 +83,22 @@ langsmith-cli --json archive backfill \
   --start-date 2025-08-01 \
   --end-date 2026-08-01 \
   --bulk-export-timeout-hours 73 \
+  --import-workers 8 \
   --bulk-export-destination-id <uuid>
 ```
 
 The command submits/adopts every selected project export before waiting, allowing
-LangSmith to apply its workspace concurrency. Completed output is split into sealed
-UTC-day manifests for DuckDB. Re-running the same command adopts the existing range
-export and skips already sealed days.
+LangSmith to apply its workspace concurrency. It harvests projects in completion
+order and compacts independent projects concurrently. Completed output is split into
+sealed UTC-day manifests for DuckDB. Re-running the same command adopts the existing
+range export and skips already sealed days.
 
 Historical exports can remain queued behind other workspace jobs. Backfill waits up
-to 73 hours per project by default, slightly beyond the managed workflow's 72-hour
-terminal timeout. Override `--bulk-export-timeout-hours` for a shorter operator
-window; rerunning adopts the same exact-window jobs.
+to 73 hours without any project completing by default, slightly beyond the managed
+workflow's 72-hour terminal timeout. Each completion resets that idle deadline.
+Override `--bulk-export-timeout-hours` for a shorter operator window and
+`--import-workers` to bound local DuckDB/S3 concurrency; rerunning adopts the same
+exact-window jobs.
 
 Use repeated `--project` options to limit a repair or trial. Keep ranges small enough
 to finish within LangSmith's managed export workflow timeout. Bulk Export cannot

--- a/skills/langsmith/references/fql.md
+++ b/skills/langsmith/references/fql.md
@@ -64,4 +64,3 @@ Examples:
 # Examples with metadata
 --filter 'and(eq(metadata_key, "difficulty"), eq(metadata_value, "hard"))'
 ```
-

--- a/skills/langsmith/references/runs.md
+++ b/skills/langsmith/references/runs.md
@@ -107,6 +107,11 @@ langsmith-cli --json runs get <run-id> [OPTIONS]
 
 **Options:**
 - `--archive` - Read the run and optional children from canonical Parquet
+- `--project TEXT` - Exact project name hint; avoids scanning unrelated archive partitions
+- `--project-id TEXT` - Project UUID hint; avoids scanning unrelated archive partitions
+- `--since TEXT` - Archive partition lower bound (ISO or shorthand)
+- `--before TEXT` - Archive partition upper bound (ISO or shorthand)
+- `--last TEXT` - Archive partition duration ending now or relative to `--since`/`--before`
 - `--fields TEXT` - Comma-separated list of fields to return (critical for context efficiency)
 
 **Available Fields:**
@@ -149,7 +154,14 @@ langsmith-cli --json runs get <id> --fields name,status,start_time,end_time
 
 # Full object (use sparingly, ~20KB)
 langsmith-cli --json runs get <id>
+
+# Fast archived point read when project/day are known
+langsmith-cli --json runs get <id> --archive --project dev/agent \
+  --since 2026-08-18 --before 2026-08-19 --fields name,inputs,outputs
 ```
+
+Archive point reads without project/date hints must discover all sealed manifests.
+For a long-retention archive, pass the narrowest known project and time window.
 
 ### `runs stats`
 

--- a/src/langsmith_cli/archive/backfill.py
+++ b/src/langsmith_cli/archive/backfill.py
@@ -1,0 +1,106 @@
+"""Import completed range exports into the canonical daily archive."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta, timezone
+
+from langsmith_cli.archive.bulk import BulkExportSnapshot
+from langsmith_cli.archive.models import ArchivePhase
+from langsmith_cli.archive.repository import (
+    ManifestSnapshot,
+    manifest_key,
+    read_manifest_snapshot,
+)
+from langsmith_cli.archive.storage import ArchiveStore
+from langsmith_cli.archive.sync import sync_project_day
+
+
+@dataclass(frozen=True)
+class BackfillImportResult:
+    export_id: str
+    imported_days: int
+    skipped_days: int
+    canonical_run_count: int
+
+
+@dataclass(frozen=True)
+class _CompletedDayExporter:
+    project_id: str
+    snapshot: BulkExportSnapshot
+
+    def export_window(
+        self,
+        *,
+        project_id: str,
+        start_time: datetime,
+        end_time: datetime,
+        excluded_export_ids: frozenset[str],
+    ) -> BulkExportSnapshot:
+        if project_id != self.project_id:
+            raise ValueError("Backfill snapshot project identity changed")
+        if start_time != self.snapshot.start_time or end_time != self.snapshot.end_time:
+            raise ValueError("Backfill snapshot window changed")
+        return self.snapshot
+
+
+def import_backfill_snapshot(
+    store: ArchiveStore,
+    *,
+    project_id: str,
+    project_name: str,
+    snapshot: BulkExportSnapshot,
+) -> BackfillImportResult:
+    """Publish one completed range export as sealed canonical project-days."""
+    if snapshot.start_time.time() != time.min or snapshot.end_time.time() != time.min:
+        raise ValueError("Backfill range must align to UTC day boundaries")
+    start_date = snapshot.start_time.date()
+    end_date = snapshot.end_time.date()
+    manifest_keys = set(store.list_keys(f"manifests/project_id={project_id}"))
+    imported_days = 0
+    skipped_days = 0
+    canonical_run_count = 0
+    trace_date = start_date
+    while trace_date < end_date:
+        key = manifest_key(project_id, trace_date.isoformat())
+        existing: ManifestSnapshot | None = (
+            read_manifest_snapshot(store, key, known_exists=True)
+            if key in manifest_keys
+            else None
+        )
+        if existing is not None and existing.manifest.sealed:
+            skipped_days += 1
+            canonical_run_count += existing.manifest.canonical_run_count
+            trace_date += timedelta(days=1)
+            continue
+        day_snapshot = snapshot.for_utc_date(trace_date)
+        manifest = sync_project_day(
+            None,
+            store,
+            project_id=project_id,
+            project_name=project_name,
+            trace_date=trace_date,
+            phase=ArchivePhase.RECONCILIATION,
+            existing_snapshot=existing,
+            manifest_known_absent=existing is None,
+            bulk_exporter=_CompletedDayExporter(project_id, day_snapshot),
+        )
+        imported_days += 1
+        canonical_run_count += manifest.canonical_run_count
+        manifest_keys.add(key)
+        trace_date += timedelta(days=1)
+    return BackfillImportResult(
+        export_id=snapshot.export_id,
+        imported_days=imported_days,
+        skipped_days=skipped_days,
+        canonical_run_count=canonical_run_count,
+    )
+
+
+def backfill_window(start_date: date, end_date: date) -> tuple[datetime, datetime]:
+    if end_date <= start_date:
+        raise ValueError("Backfill end date must be after start date")
+    return (
+        datetime.combine(start_date, time.min, tzinfo=timezone.utc),
+        datetime.combine(end_date, time.min, tzinfo=timezone.utc),
+    )

--- a/src/langsmith_cli/archive/backfill.py
+++ b/src/langsmith_cli/archive/backfill.py
@@ -68,6 +68,13 @@ def import_backfill_snapshot(
             if key in manifest_keys
             else None
         )
+        # INVARIANT: resume may skip work, never identity validation. Otherwise a
+        # rename/route move could make sealed data look successfully backfilled
+        # under a project name that the published manifest does not contain.
+        if existing is not None and existing.manifest.project_name != project_name:
+            raise ValueError(
+                "Archived project name changed; migrate its manifest before backfill"
+            )
         if existing is not None and existing.manifest.sealed:
             skipped_days += 1
             canonical_run_count += existing.manifest.canonical_run_count

--- a/src/langsmith_cli/archive/bulk.py
+++ b/src/langsmith_cli/archive/bulk.py
@@ -82,6 +82,15 @@ BULK_EXPORT_FIELDS = (
     "trace_id",
     "trace_tier",
 )
+BULK_EXPORT_FORMAT_VERSION = "v2_beta"
+BULK_EXPORT_COMPRESSION = "zstandard"
+BULK_EXPORT_TERMINAL_FAILURES = frozenset(
+    {
+        BulkExportStatus.CANCELLED,
+        BulkExportStatus.FAILED,
+        BulkExportStatus.TIMED_OUT,
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -100,6 +109,16 @@ class BulkExportJob:
     export_fields: tuple[str, ...] | None
     all_experiments: bool
 
+    def __post_init__(self) -> None:
+        """Enforce the identity/window contract for every construction path."""
+        # INVARIANT: callers may only hold jobs with canonical managed-resource
+        # identities and a non-empty UTC window. Keeping this on the model avoids
+        # a trusted/untrusted split between API-parsed jobs and direct instances.
+        _require_uuid(self.export_id, "bulk export ID")
+        _require_uuid(self.destination_id, "bulk export destination ID")
+        _require_uuid(self.project_id, "bulk export project ID")
+        _require_utc_range(self.start_time, self.end_time)
+
 
 @dataclass(frozen=True)
 class BulkExportSnapshot:
@@ -109,6 +128,15 @@ class BulkExportSnapshot:
     run_count: int
     file_uris: tuple[str, ...]
     partitions: tuple[BulkExportPartition, ...] = ()
+
+    def __post_init__(self) -> None:
+        """Enforce contracts assumed by daily slicing and publication."""
+        # INVARIANT: snapshot windows are always comparable to UTC archive-day
+        # boundaries; malformed provider implementations fail at model creation.
+        _require_uuid(self.export_id, "bulk export ID")
+        _require_utc_range(self.start_time, self.end_time)
+        if self.run_count < 0:
+            raise ValueError("Bulk export run count must be non-negative")
 
     def for_utc_date(self, trace_date: date) -> BulkExportSnapshot:
         start = datetime.combine(trace_date, datetime_time.min, tzinfo=timezone.utc)
@@ -143,6 +171,12 @@ class BulkExportPartition:
     end_time: datetime
     run_count: int
     file_uris: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        """Enforce contracts assumed by exact partition coverage checks."""
+        _require_utc_range(self.start_time, self.end_time)
+        if self.run_count < 0:
+            raise ValueError("Bulk export partition run count must be non-negative")
 
 
 class BulkWindowExporter(Protocol):
@@ -235,10 +269,6 @@ class LangSmithBulkExporter:
         end_time: datetime,
         excluded_export_ids: frozenset[str],
     ) -> BulkExportSnapshot:
-        _require_uuid(project_id, "bulk export project ID")
-        _require_utc_range(start_time, end_time)
-        for export_id in excluded_export_ids:
-            _require_uuid(export_id, "excluded bulk export ID")
         job = self.begin_window(
             project_id=project_id,
             start_time=start_time,
@@ -265,12 +295,7 @@ class LangSmithBulkExporter:
             for job in self._list_exports()
             if self._matches_window(job, project_id, start_time, end_time)
             and job.export_id not in excluded_export_ids
-            and job.status
-            not in {
-                BulkExportStatus.CANCELLED,
-                BulkExportStatus.FAILED,
-                BulkExportStatus.TIMED_OUT,
-            }
+            and job.status not in BULK_EXPORT_TERMINAL_FAILURES
         ]
         if candidates:
             return max(candidates, key=lambda candidate: candidate.created_at)
@@ -295,11 +320,7 @@ class LangSmithBulkExporter:
             made_progress = False
             terminal_failure: BulkExportJob | None = None
             for export_id, current in tuple(pending.items()):
-                if current.status in {
-                    BulkExportStatus.CANCELLED,
-                    BulkExportStatus.FAILED,
-                    BulkExportStatus.TIMED_OUT,
-                }:
+                if current.status in BULK_EXPORT_TERMINAL_FAILURES:
                     if terminal_failure is None:
                         terminal_failure = current
                     continue
@@ -398,8 +419,8 @@ class LangSmithBulkExporter:
             "session_id": project_id,
             "start_time": start_time.isoformat(),
             "end_time": end_time.isoformat(),
-            "format_version": "v2_beta",
-            "compression": "zstandard",
+            "format_version": BULK_EXPORT_FORMAT_VERSION,
+            "compression": BULK_EXPORT_COMPRESSION,
             "export_fields": list(BULK_EXPORT_FIELDS),
         }
         raw = self._request(
@@ -487,8 +508,8 @@ class LangSmithBulkExporter:
             and job.project_id == project_id
             and job.start_time == start_time
             and job.end_time == end_time
-            and job.format_version == "v2_beta"
-            and job.compression == "zstandard"
+            and job.format_version == BULK_EXPORT_FORMAT_VERSION
+            and job.compression == BULK_EXPORT_COMPRESSION
             and job.interval_hours is None
             and job.filter is None
             and job.export_fields == BULK_EXPORT_FIELDS
@@ -562,10 +583,6 @@ def _parse_job(raw: object) -> BulkExportJob:
         export_fields=fields,
         all_experiments=all_experiments,
     )
-    _require_uuid(job.export_id, "bulk export ID")
-    _require_uuid(job.destination_id, "bulk export destination ID")
-    _require_uuid(job.project_id, "bulk export project ID")
-    _require_utc_range(job.start_time, job.end_time)
     return job
 
 
@@ -574,6 +591,7 @@ def _validate_partition_coverage(
     expected_start: datetime,
     expected_end: datetime,
 ) -> None:
+    """Enforce one contiguous, exact cover of the requested export window."""
     if not intervals:
         raise ValueError("Completed bulk export has no partition runs")
     ordered = sorted(intervals)

--- a/src/langsmith_cli/archive/bulk.py
+++ b/src/langsmith_cli/archive/bulk.py
@@ -206,6 +206,7 @@ class LangSmithBulkExporter:
         *,
         destination_id: str,
         archive_uri: str,
+        timeout_seconds: float = 5 * 60 * 60,
     ) -> LangSmithBulkExporter:
         # These are public LangSmith Client properties. Direct access is
         # deliberate so SDK contract changes fail instead of silently degrading.
@@ -223,6 +224,7 @@ class LangSmithBulkExporter:
             or os.environ.get("LANGSMITH_WORKSPACE_ID"),
             destination_id=destination_id,
             archive_uri=archive_uri,
+            timeout_seconds=timeout_seconds,
         )
 
     def export_window(

--- a/src/langsmith_cli/archive/bulk.py
+++ b/src/langsmith_cli/archive/bulk.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
 from datetime import date, datetime, time as datetime_time, timedelta, timezone
 from enum import Enum
@@ -277,9 +277,71 @@ class LangSmithBulkExporter:
         return self._create_export(project_id, start_time, end_time)
 
     def complete_export(self, job: BulkExportJob) -> BulkExportSnapshot:
+        return next(self.complete_exports((job,)))
+
+    def complete_exports(
+        self, jobs: Iterable[BulkExportJob]
+    ) -> Iterator[BulkExportSnapshot]:
+        """Yield snapshots as jobs complete, independent of submission order."""
+        job_list = tuple(jobs)
+        pending = {job.export_id: job for job in job_list}
+        if len(pending) != len(job_list):
+            raise ValueError("Duplicate bulk export ID in completion batch")
         destination = self._get_validated_destination()
-        completed = self._wait_until_completed(job)
-        return self._read_snapshot(completed, destination)
+        if len(pending) == 0:
+            return
+        deadline = self._monotonic() + self._timeout_seconds
+        while pending:
+            made_progress = False
+            terminal_failure: BulkExportJob | None = None
+            for export_id, current in tuple(pending.items()):
+                if current.status in {
+                    BulkExportStatus.CANCELLED,
+                    BulkExportStatus.FAILED,
+                    BulkExportStatus.TIMED_OUT,
+                }:
+                    if terminal_failure is None:
+                        terminal_failure = current
+                    continue
+                if current.status is not BulkExportStatus.COMPLETED:
+                    continue
+
+                # INVARIANT: completion order never controls harvest order. A
+                # ready job is removed and yielded immediately, even when an
+                # earlier submission remains queued.
+                del pending[export_id]
+                made_progress = True
+                yield self._read_snapshot(current, destination)
+
+            # Ready peers have already been yielded to the caller for durable
+            # import; only then does a terminal peer fail the batch.
+            if terminal_failure is not None:
+                raise BulkExportFailedError(
+                    f"LangSmith bulk export {terminal_failure.export_id} ended as "
+                    f"{terminal_failure.status.value}"
+                )
+            if not pending:
+                return
+            if made_progress:
+                deadline = self._monotonic() + self._timeout_seconds
+            if self._monotonic() >= deadline:
+                raise BulkExportTimeoutError(
+                    f"{len(pending)} LangSmith bulk export(s) did not finish in time"
+                )
+            self._sleep(self._poll_interval_seconds)
+            for export_id, previous in tuple(pending.items()):
+                raw = self._request(
+                    "GET", f"/api/v1/bulk-exports/{export_id}", None, None
+                )
+                current = _parse_job(raw)
+                if current.export_id != export_id or not self._matches_window(
+                    current,
+                    previous.project_id,
+                    previous.start_time,
+                    previous.end_time,
+                ):
+                    raise ValueError("Polled bulk export changed request identity")
+                pending[export_id] = current
 
     def _get_validated_destination(self) -> _S3Destination:
         if self._validated_destination is not None:
@@ -297,6 +359,9 @@ class LangSmithBulkExporter:
         destination = _S3Destination(
             bucket=_require_string(config, "bucket_name"),
             prefix=_require_string(config, "prefix").strip("/"),
+        )
+        _require_normalized_s3_path(
+            destination.prefix, "Bulk export destination prefix"
         )
         archive = self._archive_destination
         if destination.bucket != archive.bucket:
@@ -349,30 +414,6 @@ class LangSmithBulkExporter:
         if self._known_jobs is not None:
             self._known_jobs.append(job)
         return job
-
-    def _wait_until_completed(self, job: BulkExportJob) -> BulkExportJob:
-        deadline = self._monotonic() + self._timeout_seconds
-        current = job
-        while current.status is not BulkExportStatus.COMPLETED:
-            if current.status in {
-                BulkExportStatus.CANCELLED,
-                BulkExportStatus.FAILED,
-                BulkExportStatus.TIMED_OUT,
-            }:
-                raise BulkExportFailedError(
-                    f"LangSmith bulk export {current.export_id} ended as "
-                    f"{current.status.value}"
-                )
-            if self._monotonic() >= deadline:
-                raise BulkExportTimeoutError(
-                    f"LangSmith bulk export {current.export_id} did not finish in time"
-                )
-            self._sleep(self._poll_interval_seconds)
-            raw = self._request(
-                "GET", f"/api/v1/bulk-exports/{current.export_id}", None, None
-            )
-            current = _parse_job(raw)
-        return current
 
     def _read_snapshot(
         self, job: BulkExportJob, destination: _S3Destination
@@ -549,8 +590,7 @@ def _exported_file_uri(path: str, destination: _S3Destination) -> str:
     expected_prefix = f"{destination.bucket}/{destination.prefix.rstrip('/')}/"
     if not path.startswith(expected_prefix) or not path.endswith(".parquet"):
         raise ValueError("Bulk export file is outside the configured destination")
-    if "/../" in path or "\\" in path:
-        raise ValueError("Bulk export file path is not normalized")
+    _require_normalized_s3_path(path, "Bulk export file path")
     return "s3://" + path
 
 
@@ -570,7 +610,20 @@ def _parse_s3_uri(uri: str) -> _S3Destination:
     prefix = parsed.path.strip("/")
     if not prefix:
         raise ValueError("Bulk Export archive URI requires a bucket prefix")
+    _require_normalized_s3_path(prefix, "Bulk Export archive prefix")
     return _S3Destination(bucket=parsed.netloc, prefix=prefix)
+
+
+def _require_normalized_s3_path(value: str, context: str) -> None:
+    # These strings become DuckDB S3 URIs. Reject both traversal segments and
+    # URI metacharacters instead of relying on every HTTP layer to preserve a
+    # literal S3 key in exactly the same way.
+    if (
+        "\\" in value
+        or any(character in value for character in ("%", "?", "#"))
+        or any(part in ("", ".", "..") for part in value.split("/"))
+    ):
+        raise ValueError(f"{context} must be normalized")
 
 
 def _parse_datetime(value: str) -> datetime:

--- a/src/langsmith_cli/archive/bulk.py
+++ b/src/langsmith_cli/archive/bulk.py
@@ -287,9 +287,9 @@ class LangSmithBulkExporter:
         pending = {job.export_id: job for job in job_list}
         if len(pending) != len(job_list):
             raise ValueError("Duplicate bulk export ID in completion batch")
-        destination = self._get_validated_destination()
         if len(pending) == 0:
             return
+        destination = self._get_validated_destination()
         deadline = self._monotonic() + self._timeout_seconds
         while pending:
             made_progress = False

--- a/src/langsmith_cli/archive/bulk.py
+++ b/src/langsmith_cli/archive/bulk.py
@@ -1,0 +1,631 @@
+"""LangSmith-managed Bulk Export orchestration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import date, datetime, time as datetime_time, timedelta, timezone
+from enum import Enum
+import os
+import time
+from typing import Protocol, TypedDict, cast
+from urllib.parse import urlparse
+from uuid import UUID
+
+
+class BulkExportStatus(str, Enum):
+    CANCELLED = "Cancelled"
+    COMPLETED = "Completed"
+    CREATED = "Created"
+    FAILED = "Failed"
+    INTERVAL_SCHEDULED = "IntervalScheduled"
+    RUNNING = "Running"
+    TIMED_OUT = "TimedOut"
+
+
+class BulkExportFailedError(RuntimeError):
+    """A managed export reached a terminal state without completing."""
+
+
+class BulkExportTimeoutError(TimeoutError):
+    """A managed export did not finish within the operator's wait budget."""
+
+
+class BulkExportCreateDict(TypedDict):
+    bulk_export_destination_id: str
+    session_id: str
+    start_time: str
+    end_time: str
+    format_version: str
+    compression: str
+    export_fields: list[str]
+
+
+class BulkExportListParams(TypedDict):
+    limit: int
+    offset: int
+
+
+JsonRequest = Callable[
+    [str, str, dict[str, object] | None, dict[str, object] | None], object
+]
+
+
+BULK_EXPORT_FIELDS = (
+    "completion_cost",
+    "completion_tokens",
+    "dotted_order",
+    "end_time",
+    "error",
+    "events",
+    "extra",
+    "feedback_stats",
+    "first_token_time",
+    "id",
+    "inputs",
+    "is_root",
+    "name",
+    "outputs",
+    "parent_run_id",
+    "parent_run_ids",
+    "prompt_cost",
+    "prompt_tokens",
+    "reference_example_id",
+    "run_type",
+    "session_id",
+    "start_time",
+    "status",
+    "tags",
+    "tenant_id",
+    "total_cost",
+    "total_tokens",
+    "trace_id",
+    "trace_tier",
+)
+
+
+@dataclass(frozen=True)
+class BulkExportJob:
+    export_id: str
+    destination_id: str
+    project_id: str
+    start_time: datetime
+    end_time: datetime
+    status: BulkExportStatus
+    created_at: datetime
+    format_version: str
+    compression: str
+    interval_hours: int | None
+    filter: str | None
+    export_fields: tuple[str, ...] | None
+    all_experiments: bool
+
+
+@dataclass(frozen=True)
+class BulkExportSnapshot:
+    export_id: str
+    start_time: datetime
+    end_time: datetime
+    run_count: int
+    file_uris: tuple[str, ...]
+    partitions: tuple[BulkExportPartition, ...] = ()
+
+    def for_utc_date(self, trace_date: date) -> BulkExportSnapshot:
+        start = datetime.combine(trace_date, datetime_time.min, tzinfo=timezone.utc)
+        end = start + timedelta(days=1)
+        if start < self.start_time or end > self.end_time:
+            raise ValueError("Bulk export snapshot does not cover requested UTC date")
+        partitions = tuple(
+            partition
+            for partition in self.partitions
+            if partition.start_time >= start and partition.end_time <= end
+        )
+        _validate_partition_coverage(
+            [(partition.start_time, partition.end_time) for partition in partitions],
+            start,
+            end,
+        )
+        return BulkExportSnapshot(
+            export_id=self.export_id,
+            start_time=start,
+            end_time=end,
+            run_count=sum(partition.run_count for partition in partitions),
+            file_uris=tuple(
+                sorted(uri for partition in partitions for uri in partition.file_uris)
+            ),
+            partitions=partitions,
+        )
+
+
+@dataclass(frozen=True)
+class BulkExportPartition:
+    start_time: datetime
+    end_time: datetime
+    run_count: int
+    file_uris: tuple[str, ...]
+
+
+class BulkWindowExporter(Protocol):
+    def export_window(
+        self,
+        *,
+        project_id: str,
+        start_time: datetime,
+        end_time: datetime,
+        excluded_export_ids: frozenset[str],
+    ) -> BulkExportSnapshot: ...
+
+
+@dataclass(frozen=True)
+class _S3Destination:
+    bucket: str
+    prefix: str
+
+
+class LangSmithBulkExporter:
+    """Create/adopt exact-window exports and validate their S3 artifacts."""
+
+    def __init__(
+        self,
+        *,
+        api_url: str,
+        api_key: str,
+        workspace_id: str | None,
+        destination_id: str,
+        archive_uri: str,
+        request_json: JsonRequest | None = None,
+        poll_interval_seconds: float = 10,
+        timeout_seconds: float = 5 * 60 * 60,
+        sleep: Callable[[float], None] = time.sleep,
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> None:
+        _require_uuid(destination_id, "bulk export destination ID")
+        if not api_key:
+            raise ValueError("LangSmith API key must not be empty")
+        if poll_interval_seconds < 0:
+            raise ValueError("Bulk export poll interval must be non-negative")
+        if timeout_seconds <= 0:
+            raise ValueError("Bulk export timeout must be positive")
+        self._api_root = _api_root(api_url)
+        self._api_key = api_key
+        self._workspace_id = workspace_id
+        self._destination_id = destination_id
+        self._archive_destination = _parse_s3_uri(archive_uri)
+        self._request_override = request_json
+        self._poll_interval_seconds = poll_interval_seconds
+        self._timeout_seconds = timeout_seconds
+        self._sleep = sleep
+        self._monotonic = monotonic
+        self._validated_destination: _S3Destination | None = None
+        self._known_jobs: list[BulkExportJob] | None = None
+
+    @classmethod
+    def from_langsmith_client(
+        cls,
+        client: object,
+        *,
+        destination_id: str,
+        archive_uri: str,
+    ) -> LangSmithBulkExporter:
+        # These are public LangSmith Client properties. Direct access is
+        # deliberate so SDK contract changes fail instead of silently degrading.
+        from langsmith import Client
+
+        if not isinstance(client, Client):
+            raise TypeError("Bulk Export requires a LangSmith Client")
+        api_key = client.api_key
+        if api_key is None:
+            raise ValueError("Bulk Export requires a LangSmith API key")
+        return cls(
+            api_url=client.api_url,
+            api_key=api_key,
+            workspace_id=client.workspace_id
+            or os.environ.get("LANGSMITH_WORKSPACE_ID"),
+            destination_id=destination_id,
+            archive_uri=archive_uri,
+        )
+
+    def export_window(
+        self,
+        *,
+        project_id: str,
+        start_time: datetime,
+        end_time: datetime,
+        excluded_export_ids: frozenset[str],
+    ) -> BulkExportSnapshot:
+        _require_uuid(project_id, "bulk export project ID")
+        _require_utc_range(start_time, end_time)
+        for export_id in excluded_export_ids:
+            _require_uuid(export_id, "excluded bulk export ID")
+        job = self.begin_window(
+            project_id=project_id,
+            start_time=start_time,
+            end_time=end_time,
+            excluded_export_ids=excluded_export_ids,
+        )
+        return self.complete_export(job)
+
+    def begin_window(
+        self,
+        *,
+        project_id: str,
+        start_time: datetime,
+        end_time: datetime,
+        excluded_export_ids: frozenset[str],
+    ) -> BulkExportJob:
+        _require_uuid(project_id, "bulk export project ID")
+        _require_utc_range(start_time, end_time)
+        for export_id in excluded_export_ids:
+            _require_uuid(export_id, "excluded bulk export ID")
+        self._get_validated_destination()
+        candidates = [
+            job
+            for job in self._list_exports()
+            if self._matches_window(job, project_id, start_time, end_time)
+            and job.export_id not in excluded_export_ids
+            and job.status
+            not in {
+                BulkExportStatus.CANCELLED,
+                BulkExportStatus.FAILED,
+                BulkExportStatus.TIMED_OUT,
+            }
+        ]
+        if candidates:
+            return max(candidates, key=lambda candidate: candidate.created_at)
+        return self._create_export(project_id, start_time, end_time)
+
+    def complete_export(self, job: BulkExportJob) -> BulkExportSnapshot:
+        destination = self._get_validated_destination()
+        completed = self._wait_until_completed(job)
+        return self._read_snapshot(completed, destination)
+
+    def _get_validated_destination(self) -> _S3Destination:
+        if self._validated_destination is not None:
+            return self._validated_destination
+        raw = self._request(
+            "GET",
+            f"/api/v1/bulk-exports/destinations/{self._destination_id}",
+            None,
+            None,
+        )
+        payload = _require_dict(raw, "bulk export destination")
+        if _require_string(payload, "id") != self._destination_id:
+            raise ValueError("Bulk export destination response changed identity")
+        config = _require_dict(payload["config"], "bulk export destination config")
+        destination = _S3Destination(
+            bucket=_require_string(config, "bucket_name"),
+            prefix=_require_string(config, "prefix").strip("/"),
+        )
+        archive = self._archive_destination
+        if destination.bucket != archive.bucket:
+            raise ValueError("Bulk export destination bucket does not match archive")
+        if destination.prefix != archive.prefix and not destination.prefix.startswith(
+            archive.prefix.rstrip("/") + "/"
+        ):
+            raise ValueError("Bulk export destination prefix is outside archive URI")
+        self._validated_destination = destination
+        return destination
+
+    def _list_exports(self) -> tuple[BulkExportJob, ...]:
+        if self._known_jobs is not None:
+            return tuple(self._known_jobs)
+        jobs: list[BulkExportJob] = []
+        offset = 0
+        while True:
+            params: BulkExportListParams = {"limit": 1000, "offset": offset}
+            raw = self._request(
+                "GET", "/api/v1/bulk-exports", cast(dict[str, object], params), None
+            )
+            items = _require_list(raw, "bulk export list")
+            jobs.extend(_parse_job(item) for item in items)
+            if len(items) < 1000:
+                self._known_jobs = jobs
+                return tuple(self._known_jobs)
+            offset += len(items)
+
+    def _create_export(
+        self, project_id: str, start_time: datetime, end_time: datetime
+    ) -> BulkExportJob:
+        payload: BulkExportCreateDict = {
+            "bulk_export_destination_id": self._destination_id,
+            "session_id": project_id,
+            "start_time": start_time.isoformat(),
+            "end_time": end_time.isoformat(),
+            "format_version": "v2_beta",
+            "compression": "zstandard",
+            "export_fields": list(BULK_EXPORT_FIELDS),
+        }
+        raw = self._request(
+            "POST",
+            "/api/v1/bulk-exports",
+            None,
+            cast(dict[str, object], payload),
+        )
+        job = _parse_job(raw)
+        if not self._matches_window(job, project_id, start_time, end_time):
+            raise ValueError("Created bulk export does not match requested window")
+        if self._known_jobs is not None:
+            self._known_jobs.append(job)
+        return job
+
+    def _wait_until_completed(self, job: BulkExportJob) -> BulkExportJob:
+        deadline = self._monotonic() + self._timeout_seconds
+        current = job
+        while current.status is not BulkExportStatus.COMPLETED:
+            if current.status in {
+                BulkExportStatus.CANCELLED,
+                BulkExportStatus.FAILED,
+                BulkExportStatus.TIMED_OUT,
+            }:
+                raise BulkExportFailedError(
+                    f"LangSmith bulk export {current.export_id} ended as "
+                    f"{current.status.value}"
+                )
+            if self._monotonic() >= deadline:
+                raise BulkExportTimeoutError(
+                    f"LangSmith bulk export {current.export_id} did not finish in time"
+                )
+            self._sleep(self._poll_interval_seconds)
+            raw = self._request(
+                "GET", f"/api/v1/bulk-exports/{current.export_id}", None, None
+            )
+            current = _parse_job(raw)
+        return current
+
+    def _read_snapshot(
+        self, job: BulkExportJob, destination: _S3Destination
+    ) -> BulkExportSnapshot:
+        raw = self._request(
+            "GET", f"/api/v1/bulk-exports/{job.export_id}/runs", None, None
+        )
+        run_payloads = _require_list(raw, "bulk export run list")
+        intervals: list[tuple[datetime, datetime]] = []
+        partitions: list[BulkExportPartition] = []
+        run_count = 0
+        file_uris: list[str] = []
+        for raw_run in run_payloads:
+            run = _require_dict(raw_run, "bulk export run")
+            status = BulkExportStatus(_require_string(run, "status"))
+            if status is not BulkExportStatus.COMPLETED:
+                raise BulkExportFailedError(
+                    f"Bulk export partition {_require_string(run, 'id')} is "
+                    f"{status.value}"
+                )
+            metadata = _require_dict(run["metadata"], "bulk export run metadata")
+            start = _parse_datetime(_require_string(metadata, "start_time"))
+            end = _parse_datetime(_require_string(metadata, "end_time"))
+            intervals.append((start, end))
+            result_raw = metadata["result"]
+            if result_raw is None:
+                raise ValueError("Completed bulk export partition has no result")
+            result = _require_dict(result_raw, "bulk export run result")
+            rows_written = _require_integer(result, "rows_written")
+            if rows_written < 0:
+                raise ValueError("Bulk export rows_written must be non-negative")
+            run_count += rows_written
+            partition_uris: list[str] = []
+            for exported_file in _require_list(
+                result["exported_files"], "bulk export file list"
+            ):
+                if not isinstance(exported_file, str):
+                    raise ValueError("Bulk export file path must be a string")
+                uri = _exported_file_uri(exported_file, destination)
+                file_uris.append(uri)
+                partition_uris.append(uri)
+            partitions.append(
+                BulkExportPartition(
+                    start_time=start,
+                    end_time=end,
+                    run_count=rows_written,
+                    file_uris=tuple(sorted(partition_uris)),
+                )
+            )
+        _validate_partition_coverage(intervals, job.start_time, job.end_time)
+        if run_count and not file_uris:
+            raise ValueError("Non-empty bulk export did not publish Parquet files")
+        return BulkExportSnapshot(
+            export_id=job.export_id,
+            start_time=job.start_time,
+            end_time=job.end_time,
+            run_count=run_count,
+            file_uris=tuple(sorted(file_uris)),
+            partitions=tuple(sorted(partitions, key=lambda item: item.start_time)),
+        )
+
+    def _matches_window(
+        self,
+        job: BulkExportJob,
+        project_id: str,
+        start_time: datetime,
+        end_time: datetime,
+    ) -> bool:
+        return (
+            job.destination_id == self._destination_id
+            and job.project_id == project_id
+            and job.start_time == start_time
+            and job.end_time == end_time
+            and job.format_version == "v2_beta"
+            and job.compression == "zstandard"
+            and job.interval_hours is None
+            and job.filter is None
+            and job.export_fields == BULK_EXPORT_FIELDS
+            and not job.all_experiments
+        )
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        params: dict[str, object] | None,
+        payload: dict[str, object] | None,
+    ) -> object:
+        if self._request_override is not None:
+            return self._request_override(method, path, params, payload)
+        import httpx
+
+        headers = {"X-API-Key": self._api_key}
+        if self._workspace_id is not None:
+            headers["X-Tenant-Id"] = self._workspace_id
+        request_params = (
+            {key: str(value) for key, value in params.items()}
+            if params is not None
+            else None
+        )
+        response = httpx.request(
+            method,
+            self._api_root + path,
+            headers=headers,
+            params=request_params,
+            json=payload,
+            timeout=60,
+        )
+        response.raise_for_status()
+        raw: object = response.json()
+        return raw
+
+
+def _parse_job(raw: object) -> BulkExportJob:
+    payload = _require_dict(raw, "bulk export")
+    end_time_raw = payload["end_time"]
+    if not isinstance(end_time_raw, str):
+        raise ValueError("One-off bulk export end_time must be a string")
+    interval_raw = payload["interval_hours"]
+    if interval_raw is not None and type(interval_raw) is not int:
+        raise ValueError("Bulk export interval_hours must be an integer or null")
+    filter_raw = payload["filter"]
+    if filter_raw is not None and not isinstance(filter_raw, str):
+        raise ValueError("Bulk export filter must be a string or null")
+    fields_raw = payload["export_fields"]
+    fields: tuple[str, ...] | None
+    if fields_raw is None:
+        fields = None
+    else:
+        fields = tuple(_require_string_list(fields_raw, "bulk export fields"))
+    all_experiments = payload["all_experiments"]
+    if type(all_experiments) is not bool:
+        raise ValueError("Bulk export all_experiments must be a boolean")
+    job = BulkExportJob(
+        export_id=_require_string(payload, "id"),
+        destination_id=_require_string(payload, "bulk_export_destination_id"),
+        project_id=_require_string(payload, "session_id"),
+        start_time=_parse_datetime(_require_string(payload, "start_time")),
+        end_time=_parse_datetime(end_time_raw),
+        status=BulkExportStatus(_require_string(payload, "status")),
+        created_at=_parse_datetime(_require_string(payload, "created_at")),
+        format_version=_require_string(payload, "format_version"),
+        compression=_require_string(payload, "compression"),
+        interval_hours=interval_raw,
+        filter=filter_raw,
+        export_fields=fields,
+        all_experiments=all_experiments,
+    )
+    _require_uuid(job.export_id, "bulk export ID")
+    _require_uuid(job.destination_id, "bulk export destination ID")
+    _require_uuid(job.project_id, "bulk export project ID")
+    _require_utc_range(job.start_time, job.end_time)
+    return job
+
+
+def _validate_partition_coverage(
+    intervals: list[tuple[datetime, datetime]],
+    expected_start: datetime,
+    expected_end: datetime,
+) -> None:
+    if not intervals:
+        raise ValueError("Completed bulk export has no partition runs")
+    ordered = sorted(intervals)
+    cursor = expected_start
+    for start, end in ordered:
+        if start != cursor or end <= start:
+            raise ValueError("Bulk export partitions do not exactly cover the window")
+        cursor = end
+    if cursor != expected_end:
+        raise ValueError("Bulk export partitions do not exactly cover the window")
+
+
+def _exported_file_uri(path: str, destination: _S3Destination) -> str:
+    expected_prefix = f"{destination.bucket}/{destination.prefix.rstrip('/')}/"
+    if not path.startswith(expected_prefix) or not path.endswith(".parquet"):
+        raise ValueError("Bulk export file is outside the configured destination")
+    if "/../" in path or "\\" in path:
+        raise ValueError("Bulk export file path is not normalized")
+    return "s3://" + path
+
+
+def _api_root(api_url: str) -> str:
+    root = api_url.rstrip("/")
+    if not root.startswith(("https://", "http://")):
+        raise ValueError("LangSmith API URL must use HTTP or HTTPS")
+    if root.endswith("/api"):
+        root = root.removesuffix("/api")
+    return root
+
+
+def _parse_s3_uri(uri: str) -> _S3Destination:
+    parsed = urlparse(uri)
+    if parsed.scheme != "s3" or not parsed.netloc:
+        raise ValueError("Bulk Export requires an s3:// archive URI")
+    prefix = parsed.path.strip("/")
+    if not prefix:
+        raise ValueError("Bulk Export archive URI requires a bucket prefix")
+    return _S3Destination(bucket=parsed.netloc, prefix=prefix)
+
+
+def _parse_datetime(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError("Bulk export datetime must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
+
+
+def _require_utc_range(start: datetime, end: datetime) -> None:
+    if (
+        start.tzinfo is None
+        or end.tzinfo is None
+        or start.utcoffset() != timedelta(0)
+        or end.utcoffset() != timedelta(0)
+        or end <= start
+    ):
+        raise ValueError("Bulk export window must be a non-empty UTC range")
+
+
+def _require_uuid(value: str, field: str) -> None:
+    try:
+        parsed = UUID(value)
+    except ValueError as exc:
+        raise ValueError(f"{field} must be a UUID") from exc
+    if str(parsed) != value.lower():
+        raise ValueError(f"{field} must use canonical UUID format")
+
+
+def _require_dict(raw: object, context: str) -> dict[str, object]:
+    if not isinstance(raw, dict) or not all(isinstance(key, str) for key in raw):
+        raise ValueError(f"{context} must be an object")
+    return cast(dict[str, object], raw)
+
+
+def _require_list(raw: object, context: str) -> list[object]:
+    if not isinstance(raw, list):
+        raise ValueError(f"{context} must be a list")
+    return cast(list[object], raw)
+
+
+def _require_string(payload: dict[str, object], field: str) -> str:
+    value = payload[field]
+    if not isinstance(value, str):
+        raise ValueError(f"Bulk export field must be a string: {field}")
+    return value
+
+
+def _require_integer(payload: dict[str, object], field: str) -> int:
+    value = payload[field]
+    if type(value) is not int:
+        raise ValueError(f"Bulk export field must be an integer: {field}")
+    return value
+
+
+def _require_string_list(raw: object, context: str) -> list[str]:
+    values = _require_list(raw, context)
+    if not all(isinstance(value, str) for value in values):
+        raise ValueError(f"{context} must contain only strings")
+    return cast(list[str], values)

--- a/src/langsmith_cli/archive/duckdb.py
+++ b/src/langsmith_cli/archive/duckdb.py
@@ -9,16 +9,23 @@ import tempfile
 from typing import Any, Protocol
 
 
+# This is deliberately per connection. Bulk backfill opens several independent
+# in-memory databases, and DuckDB's host-relative default lets each one claim most
+# of the same host memory before spilling.
+DUCKDB_MEMORY_LIMIT = "1.0 GiB"
+
+
 class DuckConnection(Protocol):
     def execute(self, query: str, parameters: object | None = None) -> Any: ...
 
 
-def configure_duckdb_temp_directory(
+def configure_duckdb_resources(
     connection: DuckConnection, staging_directory: Path
 ) -> None:
-    """Keep DuckDB spill files inside one process/project staging boundary."""
+    """Bound memory and isolate spill files inside one connection boundary."""
     spill_directory = staging_directory / "duckdb-spill"
     spill_directory.mkdir(parents=True, exist_ok=True)
+    connection.execute("SET memory_limit = ?", [DUCKDB_MEMORY_LIMIT])
     connection.execute("SET temp_directory = ?", [str(spill_directory)])
 
 
@@ -34,7 +41,7 @@ def archive_duckdb_connection(
     ) as connection_staging:
         connection = duckdb.connect()
         try:
-            configure_duckdb_temp_directory(connection, Path(connection_staging))
+            configure_duckdb_resources(connection, Path(connection_staging))
             yield connection
         finally:
             connection.close()

--- a/src/langsmith_cli/archive/duckdb.py
+++ b/src/langsmith_cli/archive/duckdb.py
@@ -2,11 +2,42 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+import tempfile
 from typing import Any, Protocol
 
 
 class DuckConnection(Protocol):
     def execute(self, query: str, parameters: object | None = None) -> Any: ...
+
+
+def configure_duckdb_temp_directory(
+    connection: DuckConnection, staging_directory: Path
+) -> None:
+    """Keep DuckDB spill files inside one process/project staging boundary."""
+    spill_directory = staging_directory / "duckdb-spill"
+    spill_directory.mkdir(parents=True, exist_ok=True)
+    connection.execute("SET temp_directory = ?", [str(spill_directory)])
+
+
+@contextmanager
+def archive_duckdb_connection(
+    staging_directory: Path | None = None,
+) -> Iterator[DuckConnection]:
+    """Open DuckDB with a unique spill directory and deterministic cleanup."""
+    import duckdb
+
+    with tempfile.TemporaryDirectory(
+        prefix="langsmith-duckdb-", dir=staging_directory
+    ) as connection_staging:
+        connection = duckdb.connect()
+        try:
+            configure_duckdb_temp_directory(connection, Path(connection_staging))
+            yield connection
+        finally:
+            connection.close()
 
 
 def configure_duckdb_s3(connection: DuckConnection, uris: list[str]) -> None:

--- a/src/langsmith_cli/archive/query.py
+++ b/src/langsmith_cli/archive/query.py
@@ -214,6 +214,29 @@ def _normalize_run_payload(payload: dict[str, Any]) -> dict[str, Any]:
         if decoded is not None and not isinstance(decoded, expected_type):
             raise ValueError(f"Archived JSON field has an invalid type: {field}")
         payload[field] = decoded
+    # Bulk v2 preserves LangChain's reserved ``inputs.input`` value with one
+    # extra JSON layer. Decode that provider representation without stripping
+    # nulls: explicit nested nulls are part of the live CLI output contract.
+    inputs = payload.get("inputs")
+    if isinstance(inputs, dict) and isinstance(inputs.get("input"), str):
+        try:
+            inputs["input"] = json.loads(inputs["input"])
+        except json.JSONDecodeError:
+            pass
+    events = payload.get("events")
+    if isinstance(events, list):
+        for event in events:
+            if not isinstance(event, dict) or not isinstance(event.get("time"), str):
+                continue
+            try:
+                event_time = datetime.fromisoformat(
+                    event["time"].replace("Z", "+00:00")
+                )
+            except ValueError:
+                continue
+            if event_time.tzinfo is None:
+                event_time = event_time.replace(tzinfo=timezone.utc)
+            event["time"] = event_time.astimezone(timezone.utc).isoformat()
     for details_field in (
         "prompt_token_details",
         "completion_token_details",
@@ -228,6 +251,28 @@ def _normalize_run_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 key: value for key, value in details.items() if value is not None
             }
     return payload
+
+
+def _validated_archive_run(payload: dict[str, Any]) -> Run:
+    """Validate an archive row and restore UTC on untyped SDK event datetimes."""
+    from langsmith.schemas import Run
+
+    run = Run.model_validate(_normalize_run_payload(payload))
+    normalized_events: list[dict[str, Any]] = []
+    for event in run.events or []:
+        normalized_event = dict(event)
+        event_time = normalized_event.get("time")
+        if isinstance(event_time, str):
+            try:
+                event_time = datetime.fromisoformat(event_time.replace("Z", "+00:00"))
+            except ValueError:
+                event_time = None
+        if isinstance(event_time, datetime):
+            if event_time.tzinfo is None:
+                event_time = event_time.replace(tzinfo=timezone.utc)
+            normalized_event["time"] = event_time.astimezone(timezone.utc).isoformat()
+        normalized_events.append(normalized_event)
+    return run.model_copy(update={"events": normalized_events or run.events})
 
 
 def _where_clause(query: ArchiveRunQuery) -> tuple[str, list[object]]:
@@ -282,7 +327,6 @@ def query_archive_runs(
 ) -> list[Run]:
     """Return LangSmith Run contracts populated from canonical Parquet."""
     import duckdb
-    from langsmith.schemas import Run
 
     uris = _canonical_uris(query, config_path)
     if not uris:
@@ -305,8 +349,8 @@ def query_archive_runs(
         columns = [description[0] for description in cursor.description]
         runs: list[Run] = []
         for row in cursor.fetchall():
-            payload = _normalize_run_payload(dict(zip(columns, row, strict=True)))
-            runs.append(Run.model_validate(payload))
+            payload = dict(zip(columns, row, strict=True))
+            runs.append(_validated_archive_run(payload))
         return runs
     finally:
         connection.close()
@@ -347,7 +391,6 @@ def read_archived_run(
     config_path: str | None = None,
 ) -> tuple[Run, list[Run]]:
     import duckdb
-    from langsmith.schemas import Run
 
     uris = _canonical_uris(
         ArchiveRunQuery(
@@ -373,9 +416,7 @@ def read_archived_run(
         if row is None:
             raise LookupError(f"Archived run not found: {run_id}")
         columns = [description[0] for description in cursor.description]
-        run = Run.model_validate(
-            _normalize_run_payload(dict(zip(columns, row, strict=True)))
-        )
+        run = _validated_archive_run(dict(zip(columns, row, strict=True)))
         children: list[Run] = []
         if follow_children:
             child_cursor = connection.execute(
@@ -386,11 +427,15 @@ def read_archived_run(
             )
             child_columns = [description[0] for description in child_cursor.description]
             children = [
-                Run.model_validate(
-                    _normalize_run_payload(dict(zip(child_columns, child, strict=True)))
-                )
+                _validated_archive_run(dict(zip(child_columns, child, strict=True)))
                 for child in child_cursor.fetchall()
             ]
+            # Bulk Export does not include the API's derived child_run_ids field.
+            # The trace query above is authoritative, ordered identically to the
+            # live CLI path, and restores full-trace output parity.
+            run = run.model_copy(
+                update={"child_run_ids": [child.id for child in children]}
+            )
         return run, children
     finally:
         connection.close()

--- a/src/langsmith_cli/archive/query.py
+++ b/src/langsmith_cli/archive/query.py
@@ -11,7 +11,11 @@ from typing import TYPE_CHECKING, Any
 
 from langsmith_cli.archive.config import load_archive_config
 from langsmith_cli.archive.duckdb import configure_duckdb_s3
-from langsmith_cli.archive.repository import list_project_records, read_manifest
+from langsmith_cli.archive.repository import (
+    list_project_records,
+    manifest_identity_from_key as _manifest_identity_from_key,
+    read_manifests,
+)
 from langsmith_cli.archive.storage import create_store
 from langsmith_cli.archive.sync import (
     ARCHIVE_JSON_LIST_COLUMNS,
@@ -130,15 +134,16 @@ def _canonical_uris(query: ArchiveRunQuery, config_path: str | None) -> list[str
                     )
                 ]
                 manifest_keys.extend(legacy_keys)
-        for key in manifest_keys:
-            identity = _manifest_identity_from_key(key)
-            key_date = identity[1] if identity is not None else None
-            if key_date is not None and not _date_partition_overlaps(
-                key_date, since, before
-            ):
-                continue
-            manifest = read_manifest(store, key, known_exists=True)
-            if manifest is None or manifest.canonical_key is None:
+        manifest_keys = [
+            key
+            for key in manifest_keys
+            if (
+                (identity := _manifest_identity_from_key(key)) is None
+                or _date_partition_overlaps(identity[1], since, before)
+            )
+        ]
+        for manifest in read_manifests(store, manifest_keys):
+            if manifest.canonical_key is None:
                 continue
             configured_route = config.route_project(manifest.project_name)
             if configured_route.name != route.name:
@@ -159,20 +164,6 @@ def _canonical_uris(query: ArchiveRunQuery, config_path: str | None) -> list[str
                 continue
             uris.append(store.object_uri(manifest.canonical_key))
     return sorted(set(uris))
-
-
-_MANIFEST_KEY_RE = re.compile(
-    r"^manifests/project_id=([^/]+)/date=(\d{4}-\d{2}-\d{2})\.json$"
-)
-
-
-def _manifest_identity_from_key(key: str) -> tuple[str, date] | None:
-    match = _MANIFEST_KEY_RE.fullmatch(key)
-    return (
-        (match.group(1), date.fromisoformat(match.group(2)))
-        if match is not None
-        else None
-    )
 
 
 def _date_partition_overlaps(

--- a/src/langsmith_cli/archive/query.py
+++ b/src/langsmith_cli/archive/query.py
@@ -13,6 +13,10 @@ from langsmith_cli.archive.config import load_archive_config
 from langsmith_cli.archive.duckdb import configure_duckdb_s3
 from langsmith_cli.archive.repository import list_project_records, read_manifest
 from langsmith_cli.archive.storage import create_store
+from langsmith_cli.archive.sync import (
+    ARCHIVE_JSON_LIST_COLUMNS,
+    ARCHIVE_JSON_OBJECT_COLUMNS,
+)
 from langsmith_cli.time_parsing import ensure_aware_datetime
 
 if TYPE_CHECKING:
@@ -181,6 +185,21 @@ def _date_partition_overlaps(
     )
 
 
+def _normalize_event_time(value: object) -> object:
+    """Return one event time as zoned UTC, preserving unparseable values."""
+    event_time = value
+    if isinstance(event_time, str):
+        try:
+            event_time = datetime.fromisoformat(event_time.replace("Z", "+00:00"))
+        except ValueError:
+            return value
+    if not isinstance(event_time, datetime):
+        return value
+    if event_time.tzinfo is None:
+        event_time = event_time.replace(tzinfo=timezone.utc)
+    return event_time.astimezone(timezone.utc).isoformat()
+
+
 def _normalize_run_payload(payload: dict[str, Any]) -> dict[str, Any]:
     """Normalize provider-specific Parquet values to the LangSmith Run contract."""
     for field in (
@@ -198,15 +217,11 @@ def _normalize_run_payload(payload: dict[str, Any]) -> dict[str, Any]:
             if not isinstance(decoded, str):
                 raise ValueError(f"Archived UUID field is not a string: {field}")
             payload[field] = decoded
-    for field, expected_type in (
-        ("extra", dict),
-        ("inputs", dict),
-        ("outputs", dict),
-        ("feedback_stats", dict),
-        ("events", list),
-        ("tags", list),
-        ("parent_run_ids", list),
-    ):
+    expected_json_types = {
+        **dict.fromkeys(ARCHIVE_JSON_OBJECT_COLUMNS, dict),
+        **dict.fromkeys(ARCHIVE_JSON_LIST_COLUMNS, list),
+    }
+    for field, expected_type in expected_json_types.items():
         value = payload[field] if field in payload else None
         if not isinstance(value, str):
             continue
@@ -226,17 +241,9 @@ def _normalize_run_payload(payload: dict[str, Any]) -> dict[str, Any]:
     events = payload.get("events")
     if isinstance(events, list):
         for event in events:
-            if not isinstance(event, dict) or not isinstance(event.get("time"), str):
+            if not isinstance(event, dict) or "time" not in event:
                 continue
-            try:
-                event_time = datetime.fromisoformat(
-                    event["time"].replace("Z", "+00:00")
-                )
-            except ValueError:
-                continue
-            if event_time.tzinfo is None:
-                event_time = event_time.replace(tzinfo=timezone.utc)
-            event["time"] = event_time.astimezone(timezone.utc).isoformat()
+            event["time"] = _normalize_event_time(event["time"])
     for details_field in (
         "prompt_token_details",
         "completion_token_details",
@@ -261,16 +268,8 @@ def _validated_archive_run(payload: dict[str, Any]) -> Run:
     normalized_events: list[dict[str, Any]] = []
     for event in run.events or []:
         normalized_event = dict(event)
-        event_time = normalized_event.get("time")
-        if isinstance(event_time, str):
-            try:
-                event_time = datetime.fromisoformat(event_time.replace("Z", "+00:00"))
-            except ValueError:
-                event_time = None
-        if isinstance(event_time, datetime):
-            if event_time.tzinfo is None:
-                event_time = event_time.replace(tzinfo=timezone.utc)
-            normalized_event["time"] = event_time.astimezone(timezone.utc).isoformat()
+        if "time" in normalized_event:
+            normalized_event["time"] = _normalize_event_time(normalized_event["time"])
         normalized_events.append(normalized_event)
     return run.model_copy(update={"events": normalized_events or run.events})
 

--- a/src/langsmith_cli/archive/query.py
+++ b/src/langsmith_cli/archive/query.py
@@ -10,7 +10,10 @@ import re
 from typing import TYPE_CHECKING, Any
 
 from langsmith_cli.archive.config import load_archive_config
-from langsmith_cli.archive.duckdb import configure_duckdb_s3
+from langsmith_cli.archive.duckdb import (
+    archive_duckdb_connection,
+    configure_duckdb_s3,
+)
 from langsmith_cli.archive.repository import (
     list_project_records,
     manifest_identity_from_key as _manifest_identity_from_key,
@@ -316,8 +319,6 @@ def query_archive_runs(
     query: ArchiveRunQuery, *, config_path: str | None = None
 ) -> list[Run]:
     """Return LangSmith Run contracts populated from canonical Parquet."""
-    import duckdb
-
     uris = _canonical_uris(query, config_path)
     if not uris:
         return []
@@ -332,8 +333,7 @@ def query_archive_runs(
         f"{where} ORDER BY start_time DESC{limit}"
     )
 
-    connection = duckdb.connect()
-    try:
+    with archive_duckdb_connection() as connection:
         configure_duckdb_s3(connection, uris)
         cursor = connection.execute(sql, parameters)
         columns = [description[0] for description in cursor.description]
@@ -342,22 +342,17 @@ def query_archive_runs(
             payload = dict(zip(columns, row, strict=True))
             runs.append(_validated_archive_run(payload))
         return runs
-    finally:
-        connection.close()
 
 
 def count_archive_runs(
     query: ArchiveRunQuery, *, config_path: str | None = None
 ) -> int:
     """Count matching runs using Parquet metadata/predicate pushdown only."""
-    import duckdb
-
     uris = _canonical_uris(query, config_path)
     if not uris:
         return 0
     where, parameters = _where_clause(query)
-    connection = duckdb.connect()
-    try:
+    with archive_duckdb_connection() as connection:
         configure_duckdb_s3(connection, uris)
         row = connection.execute(
             f"SELECT count(*) FROM read_parquet(?, union_by_name=true){where}",
@@ -366,8 +361,6 @@ def count_archive_runs(
         if row is None:
             raise ValueError("DuckDB did not return an archive count")
         return int(row[0])
-    finally:
-        connection.close()
 
 
 def read_archived_run(
@@ -380,8 +373,6 @@ def read_archived_run(
     before: datetime | None = None,
     config_path: str | None = None,
 ) -> tuple[Run, list[Run]]:
-    import duckdb
-
     uris = _canonical_uris(
         ArchiveRunQuery(
             project=project,
@@ -394,8 +385,7 @@ def read_archived_run(
     )
     if not uris:
         raise LookupError(f"Archived run not found: {run_id}")
-    connection = duckdb.connect()
-    try:
+    with archive_duckdb_connection() as connection:
         configure_duckdb_s3(connection, uris)
         cursor = connection.execute(
             "SELECT * FROM read_parquet(?, union_by_name=true) "
@@ -427,5 +417,3 @@ def read_archived_run(
                 update={"child_run_ids": [child.id for child in children]}
             )
         return run, children
-    finally:
-        connection.close()

--- a/src/langsmith_cli/archive/query.py
+++ b/src/langsmith_cli/archive/query.py
@@ -182,7 +182,7 @@ def _date_partition_overlaps(
 
 
 def _normalize_run_payload(payload: dict[str, Any]) -> dict[str, Any]:
-    """Normalize UUID columns promoted to DuckDB JSON by all-null snapshots."""
+    """Normalize provider-specific Parquet values to the LangSmith Run contract."""
     for field in (
         "id",
         "trace_id",
@@ -198,6 +198,22 @@ def _normalize_run_payload(payload: dict[str, Any]) -> dict[str, Any]:
             if not isinstance(decoded, str):
                 raise ValueError(f"Archived UUID field is not a string: {field}")
             payload[field] = decoded
+    for field, expected_type in (
+        ("extra", dict),
+        ("inputs", dict),
+        ("outputs", dict),
+        ("feedback_stats", dict),
+        ("events", list),
+        ("tags", list),
+        ("parent_run_ids", list),
+    ):
+        value = payload[field] if field in payload else None
+        if not isinstance(value, str):
+            continue
+        decoded = json.loads(value)
+        if decoded is not None and not isinstance(decoded, expected_type):
+            raise ValueError(f"Archived JSON field has an invalid type: {field}")
+        payload[field] = decoded
     for details_field in (
         "prompt_token_details",
         "completion_token_details",
@@ -238,7 +254,10 @@ def _where_clause(query: ArchiveRunQuery) -> tuple[str, list[object]]:
             "parent_run_id IS NULL" if query.is_root else "parent_run_id IS NOT NULL"
         )
     for tag in query.tags:
-        clauses.append("list_contains(tags, ?)")
+        # Runs API snapshots expose a native VARCHAR[] while managed Bulk Export
+        # writes the same field as JSON text. Casting either representation to
+        # JSON keeps mixed-provider archives queryable.
+        clauses.append("json_contains(CAST(tags AS JSON), to_json(?))")
         parameters.append(tag)
     if query.text is not None:
         text_sql = " || ' ' || ".join(
@@ -318,12 +337,28 @@ def count_archive_runs(
 
 
 def read_archived_run(
-    run_id: str, *, follow_children: bool, config_path: str | None = None
+    run_id: str,
+    *,
+    follow_children: bool,
+    project: str | None = None,
+    project_id: str | None = None,
+    since: datetime | None = None,
+    before: datetime | None = None,
+    config_path: str | None = None,
 ) -> tuple[Run, list[Run]]:
     import duckdb
     from langsmith.schemas import Run
 
-    uris = _canonical_uris(ArchiveRunQuery(limit=0), config_path)
+    uris = _canonical_uris(
+        ArchiveRunQuery(
+            project=project,
+            project_id=project_id,
+            since=since,
+            before=before,
+            limit=0,
+        ),
+        config_path,
+    )
     if not uris:
         raise LookupError(f"Archived run not found: {run_id}")
     connection = duckdb.connect()

--- a/src/langsmith_cli/archive/repository.py
+++ b/src/langsmith_cli/archive/repository.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import date
 import json
-from typing import cast
+import re
+from typing import Callable, TypeVar, cast
 
 from langsmith_cli.archive.models import (
     ArchiveManifest,
@@ -24,8 +26,25 @@ class ManifestSnapshot:
     version: str
 
 
+MetadataRecord = TypeVar("MetadataRecord")
+MAX_METADATA_READ_WORKERS = 16
+_MANIFEST_KEY_RE = re.compile(
+    r"^manifests/project_id=([^/]+)/date=(\d{4}-\d{2}-\d{2})\.json$"
+)
+
+
 def manifest_key(project_id: str, trace_date: str) -> str:
     return f"manifests/project_id={project_id}/date={trace_date}.json"
+
+
+def manifest_identity_from_key(key: str) -> tuple[str, date] | None:
+    """Parse the immutable project/date identity encoded in a manifest key."""
+    match = _MANIFEST_KEY_RE.fullmatch(key)
+    return (
+        (match.group(1), date.fromisoformat(match.group(2)))
+        if match is not None
+        else None
+    )
 
 
 def project_key(project_id: str) -> str:
@@ -63,15 +82,21 @@ def ensure_project_record(
 
 def list_project_records(store: ArchiveStore) -> tuple[ArchiveProject, ...]:
     keys = store.list_keys("projects")
-    if len(keys) < 2:
-        return tuple(_read_project_record(store, key) for key in keys)
+    return _read_independent_metadata(
+        keys, lambda key: _read_project_record(store, key)
+    )
 
-    # Catalog records are independent, tiny objects. Parallel GETs keep CLI query
-    # and idempotent sync latency bounded as organizations add projects.
-    from concurrent.futures import ThreadPoolExecutor
 
-    with ThreadPoolExecutor(max_workers=min(16, len(keys))) as executor:
-        return tuple(executor.map(lambda key: _read_project_record(store, key), keys))
+def read_manifests(store: ArchiveStore, keys: list[str]) -> tuple[ArchiveManifest, ...]:
+    """Read independent manifests with bounded remote I/O concurrency."""
+
+    def read_known_manifest(key: str) -> ArchiveManifest:
+        manifest = read_manifest(store, key, known_exists=True)
+        if manifest is None:
+            raise RuntimeError(f"Listed archive manifest disappeared: {key}")
+        return manifest
+
+    return _read_independent_metadata(keys, read_known_manifest)
 
 
 def read_manifest(
@@ -134,6 +159,23 @@ def _read_project_record(store: ArchiveStore, key: str) -> ArchiveProject:
     if key != project_key(project.project_id):
         raise ValueError("Archive project object key does not match its project_id")
     return project
+
+
+def _read_independent_metadata(
+    keys: list[str], reader: Callable[[str], MetadataRecord]
+) -> tuple[MetadataRecord, ...]:
+    if len(keys) < 2:
+        return tuple(reader(key) for key in keys)
+
+    # Metadata objects are immutable, tiny, and independent. One bounded reader
+    # serves project catalogs, status, and archived queries so those paths cannot
+    # drift back to one S3 round trip at a time as the archive grows.
+    from concurrent.futures import ThreadPoolExecutor
+
+    with ThreadPoolExecutor(
+        max_workers=min(MAX_METADATA_READ_WORKERS, len(keys))
+    ) as executor:
+        return tuple(executor.map(reader, keys))
 
 
 def _validate_manifest_payload(raw: object, key: str) -> ArchiveManifestDict:

--- a/src/langsmith_cli/archive/sync.py
+++ b/src/langsmith_cli/archive/sync.py
@@ -34,6 +34,21 @@ from langsmith_cli.archive.storage import ArchiveStore
 
 if TYPE_CHECKING:
     from langsmith.schemas import Run
+    from langsmith_cli.archive.bulk import BulkWindowExporter
+
+
+# Canonical Parquet stores nested provider fields as JSON text. Runs API JSONL is
+# inferred as STRUCT/LIST while Bulk Export v2 emits VARCHAR for the same fields;
+# normalizing here keeps reconciliation and cross-day union schema-stable.
+ARCHIVE_JSON_COLUMNS = (
+    "extra",
+    "inputs",
+    "outputs",
+    "feedback_stats",
+    "events",
+    "tags",
+    "parent_run_ids",
+)
 
 
 class RunsExportClient(Protocol):
@@ -145,6 +160,57 @@ def _write_runs_parquet(
     return run_count
 
 
+def _write_bulk_parquet(
+    exporter: BulkWindowExporter,
+    manifest: ArchiveManifest,
+    target: Path,
+    excluded_export_ids: frozenset[str],
+) -> tuple[str, int]:
+    import duckdb
+
+    snapshot = exporter.export_window(
+        project_id=manifest.project_id,
+        start_time=manifest.window_start,
+        end_time=manifest.window_end,
+        excluded_export_ids=excluded_export_ids,
+    )
+    connection = duckdb.connect()
+    try:
+        if snapshot.run_count:
+            if not snapshot.file_uris:
+                raise ValueError("Non-empty bulk export has no Parquet files")
+            configure_duckdb_s3(connection, list(snapshot.file_uris))
+            source_list = (
+                "[" + ", ".join(_sql_string(uri) for uri in snapshot.file_uris) + "]"
+            )
+            source = (
+                f"read_parquet({source_list}, union_by_name=true, "
+                "hive_partitioning=false)"
+            )
+            counts = connection.execute(
+                f"SELECT count(*), count(DISTINCT id) FROM {source}"
+            ).fetchone()
+            if counts is None or counts[0] != snapshot.run_count:
+                raise ValueError("Bulk export row count does not match Parquet")
+            if counts[0] != counts[1]:
+                raise ValueError("Bulk export contains duplicate run IDs")
+            connection.execute(
+                f"COPY (SELECT * FROM {source}) TO {_sql_string(str(target))} "
+                "(FORMAT PARQUET, COMPRESSION ZSTD)"
+            )
+        else:
+            if snapshot.file_uris:
+                raise ValueError("Empty bulk export unexpectedly published files")
+            connection.execute(
+                "COPY (SELECT CAST(NULL AS VARCHAR) AS id WHERE false) "
+                f"TO {_sql_string(str(target))} "
+                "(FORMAT PARQUET, COMPRESSION ZSTD)"
+            )
+    finally:
+        connection.close()
+    return snapshot.export_id, snapshot.run_count
+
+
 def _canonicalize(store: ArchiveStore, manifest: ArchiveManifest, target: Path) -> int:
     import duckdb
 
@@ -171,7 +237,26 @@ def _canonicalize(store: ArchiveStore, manifest: ArchiveManifest, target: Path) 
             ).fetchone()
             if counts is None or counts[0] != counts[1]:
                 raise ValueError(f"Snapshot contains duplicate run IDs: {uri}")
-            selects.append(f"SELECT * FROM {view}")
+            columns = {
+                str(row[1])
+                for row in connection.execute(f"PRAGMA table_info('{view}')").fetchall()
+            }
+            json_columns = tuple(
+                column for column in ARCHIVE_JSON_COLUMNS if column in columns
+            )
+            if json_columns:
+                excluded = ", ".join(json_columns)
+                normalized = ", ".join(
+                    f"CASE WHEN typeof({column}) = 'VARCHAR' "
+                    f"THEN CAST({column} AS VARCHAR) "
+                    f"ELSE CAST(to_json({column}) AS VARCHAR) END AS {column}"
+                    for column in json_columns
+                )
+                selects.append(
+                    f"SELECT * EXCLUDE ({excluded}), {normalized} FROM {view}"
+                )
+            else:
+                selects.append(f"SELECT * FROM {view}")
 
         union_sql = " UNION ALL BY NAME ".join(selects)
         query = (
@@ -201,7 +286,7 @@ def _canonicalize(store: ArchiveStore, manifest: ArchiveManifest, target: Path) 
 
 
 def sync_project_day(
-    client: RunsExportClient,
+    client: RunsExportClient | None,
     store: ArchiveStore,
     *,
     project_id: str,
@@ -212,6 +297,7 @@ def sync_project_day(
     manifest_known_absent: bool = False,
     existing_project: ArchiveProject | None = None,
     project_record_checked: bool = False,
+    bulk_exporter: BulkWindowExporter | None = None,
 ) -> ArchiveManifest:
     """Export one phase and conditionally publish a canonical generation.
 
@@ -247,6 +333,11 @@ def sync_project_day(
         return manifest
     if manifest.sealed:
         raise ValueError("A sealed archive day is immutable")
+    excluded_export_ids = frozenset(
+        record.generation_id
+        for record in (manifest.primary, manifest.reconciliation)
+        if record is not None
+    )
     generation_id = str(uuid4())
     raw_key = (
         f"raw/project_id={project_id}/date={trace_date.isoformat()}/"
@@ -256,7 +347,21 @@ def sync_project_day(
     with tempfile.TemporaryDirectory(prefix="langsmith-archive-") as directory:
         staging = Path(directory)
         raw_file = staging / "raw.parquet"
-        run_count = _write_runs_parquet(client, manifest, raw_file)
+        if bulk_exporter is not None:
+            generation_id, run_count = _write_bulk_parquet(
+                bulk_exporter,
+                manifest,
+                raw_file,
+                excluded_export_ids,
+            )
+            raw_key = (
+                f"raw/project_id={project_id}/date={trace_date.isoformat()}/"
+                f"phase={phase.value}/generation={generation_id}/runs.parquet"
+            )
+        else:
+            if client is None:
+                raise ValueError("Runs API archive sync requires a LangSmith client")
+            run_count = _write_runs_parquet(client, manifest, raw_file)
         store.put_file(raw_key, raw_file)
 
         record = PhaseRecord(

--- a/src/langsmith_cli/archive/sync.py
+++ b/src/langsmith_cli/archive/sync.py
@@ -22,7 +22,10 @@ from langsmith_cli.archive.models import (
     PhaseRecord,
     PhaseStatus,
 )
-from langsmith_cli.archive.duckdb import configure_duckdb_s3
+from langsmith_cli.archive.duckdb import (
+    archive_duckdb_connection,
+    configure_duckdb_s3,
+)
 from langsmith_cli.archive.repository import (
     ManifestSnapshot,
     ensure_project_record,
@@ -118,8 +121,6 @@ def _new_manifest(
 def _write_runs_parquet(
     client: RunsExportClient, manifest: ArchiveManifest, target: Path
 ) -> int:
-    import duckdb
-
     filter_ = f'lt(start_time, "{manifest.window_end.isoformat()}")'
     # Close the JSONL before DuckDB opens it. Windows does not guarantee that a
     # named temporary file can be reopened while Python still holds its handle.
@@ -142,25 +143,24 @@ def _write_runs_parquet(
             rows.write("\n")
             run_count += 1
 
-    connection = duckdb.connect()
     try:
-        if run_count:
-            connection.execute(
-                "COPY (SELECT * FROM read_json_auto("
-                f"{_sql_string(str(rows_path))}, maximum_object_size=104857600)) "
-                f"TO {_sql_string(str(target))} "
-                "(FORMAT PARQUET, COMPRESSION ZSTD)"
-            )
-        else:
-            connection.execute(
-                "COPY (SELECT CAST(NULL AS VARCHAR) AS id WHERE false) "
-                f"TO {_sql_string(str(target))} "
-                "(FORMAT PARQUET, COMPRESSION ZSTD)"
-            )
+        with archive_duckdb_connection(target.parent) as connection:
+            if run_count:
+                connection.execute(
+                    "COPY (SELECT * FROM read_json_auto("
+                    f"{_sql_string(str(rows_path))}, maximum_object_size=104857600)) "
+                    f"TO {_sql_string(str(target))} "
+                    "(FORMAT PARQUET, COMPRESSION ZSTD)"
+                )
+            else:
+                connection.execute(
+                    "COPY (SELECT CAST(NULL AS VARCHAR) AS id WHERE false) "
+                    f"TO {_sql_string(str(target))} "
+                    "(FORMAT PARQUET, COMPRESSION ZSTD)"
+                )
+        return run_count
     finally:
-        connection.close()
         rows_path.unlink(missing_ok=True)
-    return run_count
 
 
 def _write_bulk_parquet(
@@ -169,16 +169,13 @@ def _write_bulk_parquet(
     target: Path,
     excluded_export_ids: frozenset[str],
 ) -> tuple[str, int]:
-    import duckdb
-
     snapshot = exporter.export_window(
         project_id=manifest.project_id,
         start_time=manifest.window_start,
         end_time=manifest.window_end,
         excluded_export_ids=excluded_export_ids,
     )
-    connection = duckdb.connect()
-    try:
+    with archive_duckdb_connection(target.parent) as connection:
         if snapshot.run_count:
             if not snapshot.file_uris:
                 raise ValueError("Non-empty bulk export has no Parquet files")
@@ -209,14 +206,10 @@ def _write_bulk_parquet(
                 f"TO {_sql_string(str(target))} "
                 "(FORMAT PARQUET, COMPRESSION ZSTD)"
             )
-    finally:
-        connection.close()
     return snapshot.export_id, snapshot.run_count
 
 
 def _canonicalize(store: ArchiveStore, manifest: ArchiveManifest, target: Path) -> int:
-    import duckdb
-
     sources: list[tuple[str, int]] = []
     if manifest.primary is not None:
         sources.append((store.object_uri(manifest.primary.raw_key), 1))
@@ -225,8 +218,7 @@ def _canonicalize(store: ArchiveStore, manifest: ArchiveManifest, target: Path) 
     if not sources:
         raise ValueError("Cannot canonicalize a manifest without snapshots")
 
-    connection = duckdb.connect()
-    try:
+    with archive_duckdb_connection(target.parent) as connection:
         configure_duckdb_s3(connection, [uri for uri, _ in sources])
         selects: list[str] = []
         for index, (uri, rank) in enumerate(sources):
@@ -284,8 +276,6 @@ def _canonicalize(store: ArchiveStore, manifest: ArchiveManifest, target: Path) 
         if count_row[0] != count_row[1]:
             raise ValueError("Canonical snapshot contains duplicate run IDs")
         return int(count_row[0])
-    finally:
-        connection.close()
 
 
 def sync_project_day(

--- a/src/langsmith_cli/archive/sync.py
+++ b/src/langsmith_cli/archive/sync.py
@@ -40,15 +40,18 @@ if TYPE_CHECKING:
 # Canonical Parquet stores nested provider fields as JSON text. Runs API JSONL is
 # inferred as STRUCT/LIST while Bulk Export v2 emits VARCHAR for the same fields;
 # normalizing here keeps reconciliation and cross-day union schema-stable.
-ARCHIVE_JSON_COLUMNS = (
+ARCHIVE_JSON_OBJECT_COLUMNS = (
     "extra",
     "inputs",
     "outputs",
     "feedback_stats",
+)
+ARCHIVE_JSON_LIST_COLUMNS = (
     "events",
     "tags",
     "parent_run_ids",
 )
+ARCHIVE_JSON_COLUMNS = ARCHIVE_JSON_OBJECT_COLUMNS + ARCHIVE_JSON_LIST_COLUMNS
 
 
 class RunsExportClient(Protocol):

--- a/src/langsmith_cli/commands/archive.py
+++ b/src/langsmith_cli/commands/archive.py
@@ -13,6 +13,8 @@ from langsmith_cli.archive.config import (
     UnknownRouteError,
     load_archive_config,
 )
+from langsmith_cli.archive.backfill import backfill_window, import_backfill_snapshot
+from langsmith_cli.archive.bulk import BulkExportJob, LangSmithBulkExporter
 from langsmith_cli.archive.models import (
     ArchiveManifestDict,
     ArchivePhase,
@@ -36,9 +38,19 @@ class SyncResultDict(TypedDict):
     project_id: str
     trace_date: str
     phase: str
+    provider: str
     skipped: bool
     canonical_run_count: int
     sealed: bool
+
+
+class BackfillProjectResultDict(TypedDict):
+    project_name: str
+    project_id: str
+    export_id: str
+    imported_days: int
+    skipped_days: int
+    canonical_run_count: int
 
 
 @click.group()
@@ -71,6 +83,11 @@ def _selected_routes(
 @click.option("--project", "projects", multiple=True, help="Exact project to sync.")
 @click.option("--retention-days", default=14, show_default=True, type=int)
 @click.option(
+    "--bulk-export-destination-id",
+    envvar="LANGSMITH_BULK_EXPORT_DESTINATION_ID",
+    help="Use a LangSmith-managed Bulk Export destination UUID.",
+)
+@click.option(
     "--date",
     "trace_date_text",
     help="Export one exact UTC trace date (YYYY-MM-DD); requires --phase.",
@@ -94,6 +111,7 @@ def sync_archive(
     all_routes: bool,
     projects: tuple[str, ...],
     retention_days: int,
+    bulk_export_destination_id: str | None,
     trace_date_text: str | None,
     phase_text: str | None,
     today_text: str | None,
@@ -113,6 +131,19 @@ def sync_archive(
         else due_trace_dates(today, retention_days)
     )
     client = get_or_create_client(ctx)
+    if bulk_export_destination_id is not None and len(routes) != 1:
+        raise click.ClickException(
+            "Bulk Export requires exactly one selected archive route"
+        )
+    bulk_exporter = (
+        LangSmithBulkExporter.from_langsmith_client(
+            client,
+            destination_id=bulk_export_destination_id,
+            archive_uri=routes[0].archive_uri,
+        )
+        if bulk_export_destination_id is not None
+        else None
+    )
 
     if projects:
         project_models = [client.read_project(project_name=name) for name in projects]
@@ -178,6 +209,7 @@ def sync_archive(
                         str(project.id)
                     ),
                     project_record_checked=True,
+                    bulk_exporter=bulk_exporter,
                 )
             except ConcurrentArchiveWriteError as exc:
                 raise click.ClickException(
@@ -197,6 +229,9 @@ def sync_archive(
                     "project_id": str(project.id),
                     "trace_date": trace_date.isoformat(),
                     "phase": phase.value,
+                    "provider": (
+                        "bulk_export" if bulk_exporter is not None else "runs_api"
+                    ),
                     "skipped": skipped,
                     "canonical_run_count": manifest.canonical_run_count,
                     "sealed": manifest.sealed,
@@ -219,6 +254,114 @@ def sync_archive(
         logger.warning(
             f"Skipped {len(unmatched_projects)} project(s) without an archive route"
         )
+
+
+@archive.command("backfill")
+@click.option("--config", "config_path", type=click.Path(exists=True, dir_okay=False))
+@click.option("--route", "route_name", required=True, help="Backfill one route.")
+@click.option("--project", "projects", multiple=True, help="Exact project to backfill.")
+@click.option("--start-date", required=True, help="Inclusive UTC date (YYYY-MM-DD).")
+@click.option("--end-date", required=True, help="Exclusive UTC date (YYYY-MM-DD).")
+@click.option(
+    "--bulk-export-destination-id",
+    envvar="LANGSMITH_BULK_EXPORT_DESTINATION_ID",
+    required=True,
+    help="LangSmith-managed Bulk Export destination UUID.",
+)
+@click.pass_context
+def backfill_archive(
+    ctx: click.Context,
+    config_path: str | None,
+    route_name: str,
+    projects: tuple[str, ...],
+    start_date: str,
+    end_date: str,
+    bulk_export_destination_id: str,
+) -> None:
+    """Export a historical range once and publish sealed daily partitions."""
+    routes = _selected_routes(config_path, route_name, False)
+    route = routes[0]
+    window_start, window_end = backfill_window(
+        date.fromisoformat(start_date), date.fromisoformat(end_date)
+    )
+    client = get_or_create_client(ctx)
+    exporter = LangSmithBulkExporter.from_langsmith_client(
+        client,
+        destination_id=bulk_export_destination_id,
+        archive_uri=route.archive_uri,
+    )
+    if projects:
+        project_models = [client.read_project(project_name=name) for name in projects]
+    else:
+        project_models = list(client.list_projects(limit=None))
+    config = load_archive_config(config_path)
+    selected_projects: list[tuple[str, str]] = []
+    unmatched_projects: list[str] = []
+    for project in project_models:
+        try:
+            matched_route = config.route_project(project.name)
+        except UnmatchedProjectError as exc:
+            if projects:
+                raise click.ClickException(str(exc)) from exc
+            unmatched_projects.append(project.name)
+            continue
+        if matched_route.name != route.name:
+            if projects:
+                raise click.ClickException(
+                    f"Project {project.name} belongs to route {matched_route.name}, "
+                    f"not the selected route"
+                )
+            continue
+        if project.name is None:
+            raise click.ClickException("LangSmith project is missing its name")
+        selected_projects.append((str(project.id), project.name))
+
+    pending: list[tuple[str, str, BulkExportJob]] = []
+    for project_id, project_name in selected_projects:
+        job = exporter.begin_window(
+            project_id=project_id,
+            start_time=window_start,
+            end_time=window_end,
+            excluded_export_ids=frozenset(),
+        )
+        pending.append((project_id, project_name, job))
+
+    store = create_store(route.archive_uri)
+    results: list[BackfillProjectResultDict] = []
+    for project_id, project_name, job in pending:
+        snapshot = exporter.complete_export(job)
+        imported = import_backfill_snapshot(
+            store,
+            project_id=project_id,
+            project_name=project_name,
+            snapshot=snapshot,
+        )
+        results.append(
+            {
+                "project_name": project_name,
+                "project_id": project_id,
+                "export_id": imported.export_id,
+                "imported_days": imported.imported_days,
+                "skipped_days": imported.skipped_days,
+                "canonical_run_count": imported.canonical_run_count,
+            }
+        )
+
+    payload = {
+        "route": route.name,
+        "archive_uri": route.archive_uri,
+        "start_date": start_date,
+        "end_date": end_date,
+        "projects": results,
+        "unmatched_projects": sorted(unmatched_projects),
+    }
+    if is_json_context(ctx):
+        click.echo(json_dumps(payload))
+        return
+    logger = ctx.obj["logger"]
+    logger.success(
+        f"Backfilled {len(results)} project(s) from {start_date} to {end_date}"
+    )
 
 
 @archive.command("status")

--- a/src/langsmith_cli/commands/archive.py
+++ b/src/langsmith_cli/commands/archive.py
@@ -9,6 +9,7 @@ from typing import TypedDict
 
 import click
 from langsmith import Client
+from pydantic import BaseModel, ConfigDict
 
 from langsmith_cli.archive.config import (
     ArchiveConfig,
@@ -30,7 +31,8 @@ from langsmith_cli.archive.models import (
 )
 from langsmith_cli.archive.repository import (
     list_project_records,
-    read_manifest,
+    manifest_identity_from_key,
+    read_manifests,
     read_manifest_snapshot,
 )
 from langsmith_cli.archive.storage import ConcurrentArchiveWriteError, create_store
@@ -59,6 +61,29 @@ class BackfillProjectResultDict(TypedDict):
     imported_days: int
     skipped_days: int
     canonical_run_count: int
+
+
+class ArchiveStatusRoute(BaseModel):
+    """Fast key-derived status for one configured archive route."""
+
+    model_config = ConfigDict(frozen=True)
+
+    route: str
+    archive_uri: str
+    manifest_count: int
+    project_count: int
+    first_date: date | None
+    last_date: date | None
+    invalid_manifest_keys: tuple[str, ...]
+
+
+class ArchiveStatusSummary(BaseModel):
+    """Status summary that deliberately avoids per-manifest object reads."""
+
+    model_config = ConfigDict(frozen=True)
+
+    manifest_contents_verified: bool = False
+    routes: tuple[ArchiveStatusRoute, ...]
 
 
 @dataclass(frozen=True)
@@ -455,25 +480,65 @@ def backfill_archive(
 @click.option("--config", "config_path", type=click.Path(exists=True, dir_okay=False))
 @click.option("--route", "route_name")
 @click.option("--all-routes", is_flag=True)
+@click.option(
+    "--summary",
+    is_flag=True,
+    help="List key-derived counts without downloading every manifest.",
+)
 @click.pass_context
 def archive_status(
     ctx: click.Context,
     config_path: str | None,
     route_name: str | None,
     all_routes: bool,
+    summary: bool,
 ) -> None:
     """List published archive manifests."""
     config = load_archive_config(config_path)
     routes = _selected_routes(config, route_name, all_routes)
-    manifests: list[ArchiveManifestDict] = []
+    route_keys = []
     for route in routes:
         store = create_store(route.archive_uri)
-        for key in store.list_keys("manifests"):
-            manifest = read_manifest(store, key, known_exists=True)
-            if manifest is not None:
-                manifests.append(manifest.to_dict())
-    if is_json_context(ctx):
-        click.echo(json_dumps(manifests))
+        route_keys.append((route, store, store.list_keys("manifests")))
+
+    if summary or not is_json_context(ctx):
+        status = ArchiveStatusSummary(
+            routes=tuple(
+                _archive_status_route(route, keys) for route, _, keys in route_keys
+            )
+        )
+        if is_json_context(ctx):
+            click.echo(json_dumps(status.model_dump(mode="json")))
+            return
+        logger = ctx.obj["logger"]
+        for route_status in status.routes:
+            logger.info(
+                f"{route_status.route}: {route_status.manifest_count} manifest(s), "
+                f"{route_status.project_count} project(s)"
+            )
         return
-    logger = ctx.obj["logger"]
-    logger.info(f"Found {len(manifests)} archive manifest(s)")
+
+    manifests: list[ArchiveManifestDict] = []
+    for _, store, keys in route_keys:
+        manifests.extend(manifest.to_dict() for manifest in read_manifests(store, keys))
+    click.echo(json_dumps(manifests))
+
+
+def _archive_status_route(route: ArchiveRoute, keys: list[str]) -> ArchiveStatusRoute:
+    identities = [
+        identity
+        for key in keys
+        if (identity := manifest_identity_from_key(key)) is not None
+    ]
+    dates = [trace_date for _, trace_date in identities]
+    return ArchiveStatusRoute(
+        route=route.name,
+        archive_uri=route.archive_uri,
+        manifest_count=len(identities),
+        project_count=len({project_id for project_id, _ in identities}),
+        first_date=min(dates, default=None),
+        last_date=max(dates, default=None),
+        invalid_manifest_keys=tuple(
+            key for key in keys if manifest_identity_from_key(key) is None
+        ),
+    )

--- a/src/langsmith_cli/commands/archive.py
+++ b/src/langsmith_cli/commands/archive.py
@@ -268,6 +268,13 @@ def sync_archive(
     required=True,
     help="LangSmith-managed Bulk Export destination UUID.",
 )
+@click.option(
+    "--bulk-export-timeout-hours",
+    default=73.0,
+    show_default=True,
+    type=click.FloatRange(min=0, min_open=True),
+    help="Maximum wait per historical project export.",
+)
 @click.pass_context
 def backfill_archive(
     ctx: click.Context,
@@ -277,6 +284,7 @@ def backfill_archive(
     start_date: str,
     end_date: str,
     bulk_export_destination_id: str,
+    bulk_export_timeout_hours: float,
 ) -> None:
     """Export a historical range once and publish sealed daily partitions."""
     routes = _selected_routes(config_path, route_name, False)
@@ -289,6 +297,7 @@ def backfill_archive(
         client,
         destination_id=bulk_export_destination_id,
         archive_uri=route.archive_uri,
+        timeout_seconds=bulk_export_timeout_hours * 60 * 60,
     )
     if projects:
         project_models = [client.read_project(project_name=name) for name in projects]

--- a/src/langsmith_cli/commands/archive.py
+++ b/src/langsmith_cli/commands/archive.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from typing import TypedDict
 
 import click
+from langsmith import Client
 
 from langsmith_cli.archive.config import (
+    ArchiveConfig,
     ArchiveRoute,
     UnmatchedProjectError,
     UnknownRouteError,
@@ -58,15 +61,21 @@ class BackfillProjectResultDict(TypedDict):
     canonical_run_count: int
 
 
+@dataclass(frozen=True)
+class _RoutedProject:
+    project_id: str
+    project_name: str
+    route: ArchiveRoute
+
+
 @click.group()
 def archive() -> None:
     """Export traces to organization-owned Parquet archives."""
 
 
 def _selected_routes(
-    config_path: str | None, route_name: str | None, all_routes: bool
+    config: ArchiveConfig, route_name: str | None, all_routes: bool
 ) -> tuple[ArchiveRoute, ...]:
-    config = load_archive_config(config_path)
     if route_name is not None and all_routes:
         raise click.ClickException("Use either --route or --all-routes, not both")
     if route_name is not None:
@@ -79,6 +88,57 @@ def _selected_routes(
     raise click.ClickException(
         "Config has multiple archive routes; select --route NAME or --all-routes"
     )
+
+
+def _routed_projects(
+    client: Client,
+    config: ArchiveConfig,
+    requested_names: tuple[str, ...],
+    selected_route_names: set[str],
+) -> tuple[list[_RoutedProject], list[str]]:
+    """Resolve one stable, unique project selection for archive commands."""
+    projects = (
+        [client.read_project(project_name=name) for name in requested_names]
+        if requested_names
+        else list(client.list_projects(limit=None))
+    )
+    routed: list[_RoutedProject] = []
+    unmatched: list[str] = []
+    seen_project_ids: set[str] = set()
+    for project in projects:
+        if project.name is None:
+            raise click.ClickException("LangSmith project is missing its name")
+        project_id = str(project.id)
+        # INVARIANT: one command invocation processes each project identity once.
+        # This is especially load-bearing for backfill, where routed projects are
+        # submitted to concurrent import workers after this check.
+        if project_id in seen_project_ids:
+            raise click.ClickException(
+                f"Duplicate LangSmith project ID in selection: {project_id}"
+            )
+        seen_project_ids.add(project_id)
+        try:
+            route = config.route_project(project.name)
+        except UnmatchedProjectError as exc:
+            if requested_names:
+                raise click.ClickException(str(exc)) from exc
+            unmatched.append(project.name)
+            continue
+        if route.name not in selected_route_names:
+            if requested_names:
+                raise click.ClickException(
+                    f"Project {project.name} belongs to route {route.name}, "
+                    "not the selected route"
+                )
+            continue
+        routed.append(
+            _RoutedProject(
+                project_id=project_id,
+                project_name=project.name,
+                route=route,
+            )
+        )
+    return routed, unmatched
 
 
 @archive.command("sync")
@@ -122,7 +182,8 @@ def sync_archive(
     today_text: str | None,
 ) -> None:
     """Run due D+2 primary and D+(retention-2) reconciliation exports."""
-    routes = _selected_routes(config_path, route_name, all_routes)
+    config = load_archive_config(config_path)
+    routes = _selected_routes(config, route_name, all_routes)
     today = (
         date.fromisoformat(today_text)
         if today_text is not None
@@ -150,15 +211,11 @@ def sync_archive(
         else None
     )
 
-    if projects:
-        project_models = [client.read_project(project_name=name) for name in projects]
-    else:
-        project_models = list(client.list_projects(limit=None))
-
     results: list[SyncResultDict] = []
-    unmatched_projects: list[str] = []
-    config = load_archive_config(config_path)
     selected_names = {route.name for route in routes}
+    routed_projects, unmatched_projects = _routed_projects(
+        client, config, projects, selected_names
+    )
     stores = {route.name: create_store(route.archive_uri) for route in routes}
     manifest_keys = {
         route.name: set(stores[route.name].list_keys("manifests")) for route in routes
@@ -170,26 +227,14 @@ def sync_archive(
         }
         for route in routes
     }
-    for project in project_models:
-        try:
-            matched_route = config.route_project(project.name)
-        except UnmatchedProjectError as exc:
-            if projects:
-                raise click.ClickException(str(exc)) from exc
-            unmatched_projects.append(project.name)
-            continue
-        if matched_route.name not in selected_names:
-            if projects:
-                raise click.ClickException(
-                    f"Project {project.name} belongs to route {matched_route.name}, "
-                    f"not the selected route"
-                )
-            continue
-
+    for routed_project in routed_projects:
+        project_id = routed_project.project_id
+        project_name = routed_project.project_name
+        matched_route = routed_project.route
         store = stores[matched_route.name]
         for trace_date, phase in due:
             before_key = (
-                f"manifests/project_id={project.id}/date={trace_date.isoformat()}.json"
+                f"manifests/project_id={project_id}/date={trace_date.isoformat()}.json"
             )
             before_snapshot = (
                 read_manifest_snapshot(store, before_key, known_exists=True)
@@ -204,14 +249,14 @@ def sync_archive(
                 manifest = sync_project_day(
                     client,
                     store,
-                    project_id=str(project.id),
-                    project_name=project.name,
+                    project_id=project_id,
+                    project_name=project_name,
                     trace_date=trace_date,
                     phase=phase,
                     existing_snapshot=before_snapshot,
                     manifest_known_absent=before_snapshot is None,
                     existing_project=project_records[matched_route.name].get(
-                        str(project.id)
+                        project_id
                     ),
                     project_record_checked=True,
                     bulk_exporter=bulk_exporter,
@@ -221,17 +266,17 @@ def sync_archive(
                     "Archive manifest changed concurrently; rerun the sync safely"
                 ) from exc
             manifest_keys[matched_route.name].add(before_key)
-            project_records[matched_route.name][str(project.id)] = ArchiveProject(
+            project_records[matched_route.name][project_id] = ArchiveProject(
                 schema_version=1,
-                project_id=str(project.id),
-                project_name=project.name,
+                project_id=project_id,
+                project_name=project_name,
             )
             results.append(
                 {
                     "route": matched_route.name,
                     "archive_uri": matched_route.archive_uri,
-                    "project_name": project.name,
-                    "project_id": str(project.id),
+                    "project_name": project_name,
+                    "project_id": project_id,
                     "trace_date": trace_date.isoformat(),
                     "phase": phase.value,
                     "provider": (
@@ -300,7 +345,8 @@ def backfill_archive(
     import_workers: int,
 ) -> None:
     """Export a historical range once and publish sealed daily partitions."""
-    routes = _selected_routes(config_path, route_name, False)
+    config = load_archive_config(config_path)
+    routes = _selected_routes(config, route_name, False)
     route = routes[0]
     window_start, window_end = backfill_window(
         date.fromisoformat(start_date), date.fromisoformat(end_date)
@@ -312,31 +358,12 @@ def backfill_archive(
         archive_uri=route.archive_uri,
         timeout_seconds=bulk_export_timeout_hours * 60 * 60,
     )
-    if projects:
-        project_models = [client.read_project(project_name=name) for name in projects]
-    else:
-        project_models = list(client.list_projects(limit=None))
-    config = load_archive_config(config_path)
-    selected_projects: list[tuple[str, str]] = []
-    unmatched_projects: list[str] = []
-    for project in project_models:
-        try:
-            matched_route = config.route_project(project.name)
-        except UnmatchedProjectError as exc:
-            if projects:
-                raise click.ClickException(str(exc)) from exc
-            unmatched_projects.append(project.name)
-            continue
-        if matched_route.name != route.name:
-            if projects:
-                raise click.ClickException(
-                    f"Project {project.name} belongs to route {matched_route.name}, "
-                    f"not the selected route"
-                )
-            continue
-        if project.name is None:
-            raise click.ClickException("LangSmith project is missing its name")
-        selected_projects.append((str(project.id), project.name))
+    routed_projects, unmatched_projects = _routed_projects(
+        client, config, projects, {route.name}
+    )
+    selected_projects = [
+        (item.project_id, item.project_name) for item in routed_projects
+    ]
 
     jobs: list[BulkExportJob] = []
     project_by_export_id: dict[str, tuple[str, str]] = {}
@@ -384,8 +411,8 @@ def backfill_archive(
     with ThreadPoolExecutor(max_workers=import_workers) as executor:
         for snapshot in exporter.complete_exports(jobs):
             project_id, project_name = project_by_export_id[snapshot.export_id]
-            # INVARIANT: export IDs are unique above, so at most one worker can
-            # publish a given project's daily manifests in this invocation.
+            # Project identities and export IDs are both unique before any worker
+            # starts, so this invocation has at most one publisher per project-day.
             future = executor.submit(
                 import_backfill_snapshot,
                 create_store(route.archive_uri),
@@ -436,7 +463,8 @@ def archive_status(
     all_routes: bool,
 ) -> None:
     """List published archive manifests."""
-    routes = _selected_routes(config_path, route_name, all_routes)
+    config = load_archive_config(config_path)
+    routes = _selected_routes(config, route_name, all_routes)
     manifests: list[ArchiveManifestDict] = []
     for route in routes:
         store = create_store(route.archive_uri)

--- a/src/langsmith_cli/commands/archive.py
+++ b/src/langsmith_cli/commands/archive.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from datetime import date, datetime, timezone
 from typing import TypedDict
 
@@ -13,7 +14,11 @@ from langsmith_cli.archive.config import (
     UnknownRouteError,
     load_archive_config,
 )
-from langsmith_cli.archive.backfill import backfill_window, import_backfill_snapshot
+from langsmith_cli.archive.backfill import (
+    BackfillImportResult,
+    backfill_window,
+    import_backfill_snapshot,
+)
 from langsmith_cli.archive.bulk import BulkExportJob, LangSmithBulkExporter
 from langsmith_cli.archive.models import (
     ArchiveManifestDict,
@@ -273,7 +278,14 @@ def sync_archive(
     default=73.0,
     show_default=True,
     type=click.FloatRange(min=0, min_open=True),
-    help="Maximum wait per historical project export.",
+    help="Maximum time without any historical export completing.",
+)
+@click.option(
+    "--import-workers",
+    default=8,
+    show_default=True,
+    type=click.IntRange(min=1, max=32),
+    help="Projects compacted concurrently after their exports complete.",
 )
 @click.pass_context
 def backfill_archive(
@@ -285,6 +297,7 @@ def backfill_archive(
     end_date: str,
     bulk_export_destination_id: str,
     bulk_export_timeout_hours: float,
+    import_workers: int,
 ) -> None:
     """Export a historical range once and publish sealed daily partitions."""
     routes = _selected_routes(config_path, route_name, False)
@@ -325,7 +338,9 @@ def backfill_archive(
             raise click.ClickException("LangSmith project is missing its name")
         selected_projects.append((str(project.id), project.name))
 
-    pending: list[tuple[str, str, BulkExportJob]] = []
+    jobs: list[BulkExportJob] = []
+    project_by_export_id: dict[str, tuple[str, str]] = {}
+    logger = ctx.obj["logger"]
     for project_id, project_name in selected_projects:
         job = exporter.begin_window(
             project_id=project_id,
@@ -333,18 +348,24 @@ def backfill_archive(
             end_time=window_end,
             excluded_export_ids=frozenset(),
         )
-        pending.append((project_id, project_name, job))
+        if job.export_id in project_by_export_id:
+            raise click.ClickException(
+                f"Bulk export {job.export_id} was selected for multiple projects"
+            )
+        jobs.append(job)
+        project_by_export_id[job.export_id] = (project_id, project_name)
+    logger.info(
+        f"Submitted or adopted {len(jobs)} project export(s); "
+        f"compacting with {import_workers} worker(s) as they complete"
+    )
 
-    store = create_store(route.archive_uri)
     results: list[BackfillProjectResultDict] = []
-    for project_id, project_name, job in pending:
-        snapshot = exporter.complete_export(job)
-        imported = import_backfill_snapshot(
-            store,
-            project_id=project_id,
-            project_name=project_name,
-            snapshot=snapshot,
-        )
+    futures: dict[Future[BackfillImportResult], tuple[str, str]] = {}
+
+    def record_result(
+        future: Future[BackfillImportResult], project_id: str, project_name: str
+    ) -> None:
+        imported = future.result()
         results.append(
             {
                 "project_name": project_name,
@@ -355,6 +376,36 @@ def backfill_archive(
                 "canonical_run_count": imported.canonical_run_count,
             }
         )
+        logger.info(
+            f"Imported {project_name}: {imported.imported_days} new day(s), "
+            f"{imported.skipped_days} already sealed"
+        )
+
+    with ThreadPoolExecutor(max_workers=import_workers) as executor:
+        for snapshot in exporter.complete_exports(jobs):
+            project_id, project_name = project_by_export_id[snapshot.export_id]
+            # INVARIANT: export IDs are unique above, so at most one worker can
+            # publish a given project's daily manifests in this invocation.
+            future = executor.submit(
+                import_backfill_snapshot,
+                create_store(route.archive_uri),
+                project_id=project_id,
+                project_name=project_name,
+                snapshot=snapshot,
+            )
+            futures[future] = (project_id, project_name)
+            logger.info(f"Export ready; importing {project_name}")
+            for completed in tuple(futures):
+                if not completed.done():
+                    continue
+                completed_project_id, completed_project_name = futures.pop(completed)
+                record_result(completed, completed_project_id, completed_project_name)
+
+        for completed in as_completed(tuple(futures)):
+            project_id, project_name = futures[completed]
+            record_result(completed, project_id, project_name)
+
+    results.sort(key=lambda result: result["project_name"])
 
     payload = {
         "route": route.name,

--- a/src/langsmith_cli/commands/archive.py
+++ b/src/langsmith_cli/commands/archive.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
-from typing import TypedDict
+from typing import Literal, TypedDict
 
 import click
 from langsmith import Client
@@ -82,7 +82,7 @@ class ArchiveStatusSummary(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    manifest_contents_verified: bool = False
+    manifest_contents_verified: Literal[False] = False
     routes: tuple[ArchiveStatusRoute, ...]
 
 

--- a/src/langsmith_cli/commands/runs/get_cmd.py
+++ b/src/langsmith_cli/commands/runs/get_cmd.py
@@ -37,6 +37,26 @@ if TYPE_CHECKING:
     is_flag=True,
     help="Read canonical Parquet from the configured archive.",
 )
+@click.option(
+    "--project",
+    help="Exact project name used to prune archive partitions.",
+)
+@click.option(
+    "--project-id",
+    help="Project UUID used to prune archive partitions.",
+)
+@click.option(
+    "--since",
+    help="Archive partition lower bound (ISO or shorthand: '7d', '24h').",
+)
+@click.option(
+    "--before",
+    help="Archive partition upper bound (ISO or shorthand: '7d', '24h').",
+)
+@click.option(
+    "--last",
+    help="Archive partition duration (e.g. '24h', '7d').",
+)
 @fields_option(
     "Comma-separated field names to include (e.g., 'id,name,inputs,error'). Reduces context usage."
 )
@@ -51,7 +71,19 @@ if TYPE_CHECKING:
     ),
 )
 @click.pass_context
-def get_run(ctx, run_id, archive, fields, output, follow_children):
+def get_run(
+    ctx,
+    run_id,
+    archive,
+    project,
+    project_id,
+    since,
+    before,
+    last,
+    fields,
+    output,
+    follow_children,
+):
     """Fetch details of a single run.
 
     Use --follow-children when the run is a parent chain (e.g. RunnableSequence)
@@ -64,9 +96,18 @@ def get_run(ctx, run_id, archive, fields, output, follow_children):
     """
     if archive:
         from langsmith_cli.archive.query import read_archived_run
+        from langsmith_cli.time_parsing import parse_time_range
 
+        since_dt, before_dt = parse_time_range(since=since, before=before, last=last)
         try:
-            run, children = read_archived_run(run_id, follow_children=follow_children)
+            run, children = read_archived_run(
+                run_id,
+                follow_children=follow_children,
+                project=project,
+                project_id=project_id,
+                since=since_dt,
+                before=before_dt,
+            )
         except LookupError as exc:
             raise click.ClickException(str(exc)) from exc
         data = filter_fields(run, fields)
@@ -76,6 +117,12 @@ def get_run(ctx, run_id, archive, fields, output, follow_children):
             ctx, data, console, output=output, render_fn=render_run_details
         )
         return
+
+    if project or project_id or since or before or last:
+        raise click.ClickException(
+            "--project, --project-id, --since, --before, and --last are archive "
+            "partition hints and require --archive"
+        )
 
     client = get_or_create_client(ctx)
     run = client.read_run(run_id)

--- a/tests/test_archive_commands.py
+++ b/tests/test_archive_commands.py
@@ -107,6 +107,10 @@ def test_bulk_backfill_submits_all_projects_before_importing(
             name="stg/not-selected",
             project_id="32345678-1234-5678-1234-567812345678",
         ),
+        create_project(
+            name="qa/unrouted",
+            project_id="52345678-1234-5678-1234-567812345678",
+        ),
     ]
     client = FakeArchiveClient(projects, [])
     monkeypatch.setattr(archive_commands, "get_or_create_client", lambda ctx: client)
@@ -179,6 +183,55 @@ def test_bulk_backfill_submits_all_projects_before_importing(
         "dev/agent",
         "dev/other",
     ]
+    assert payload["unmatched_projects"] == ["qa/unrouted"]
+
+
+@pytest.mark.parametrize(
+    ("project_name", "message"),
+    (
+        ("stg/not-selected", "belongs to route staging"),
+        ("qa/unrouted", "No archive route matches project"),
+    ),
+)
+def test_bulk_backfill_rejects_explicit_project_outside_route(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner,
+    project_name: str,
+    message: str,
+) -> None:
+    from langsmith_cli.commands import archive as archive_commands
+
+    client = FakeArchiveClient([create_project(name=project_name)], [])
+    monkeypatch.setattr(archive_commands, "get_or_create_client", lambda ctx: client)
+    monkeypatch.setattr(
+        archive_commands.LangSmithBulkExporter,
+        "from_langsmith_client",
+        staticmethod(lambda client, **kwargs: object()),
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "archive",
+            "backfill",
+            "--config",
+            str(_write_config(tmp_path)),
+            "--route",
+            "dev",
+            "--project",
+            project_name,
+            "--start-date",
+            "2026-08-18",
+            "--end-date",
+            "2026-08-20",
+            "--bulk-export-destination-id",
+            "42345678-1234-5678-1234-567812345678",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert message in parse_json_output(result.output)["message"]
 
 
 def test_sync_command_rejects_project_from_another_selected_route(

--- a/tests/test_archive_commands.py
+++ b/tests/test_archive_commands.py
@@ -356,6 +356,55 @@ def test_bulk_backfill_rejects_one_export_selected_for_multiple_projects(
     assert "was selected for multiple projects" in result.output
 
 
+def test_bulk_backfill_rejects_duplicate_project_identity_before_export(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner,
+) -> None:
+    """INVARIANT: one backfill invocation submits at most one job per project ID."""
+    from langsmith_cli.commands import archive as archive_commands
+
+    duplicate_id = "22345678-1234-5678-1234-567812345678"
+    client = FakeArchiveClient(
+        [
+            create_project(name="dev/agent", project_id=duplicate_id),
+            create_project(name="dev/renamed-agent", project_id=duplicate_id),
+        ],
+        [],
+    )
+    monkeypatch.setattr(archive_commands, "get_or_create_client", lambda ctx: client)
+
+    class ExportMustNotStart:
+        def begin_window(self, **kwargs: object) -> None:
+            raise AssertionError("duplicate project identity reached export submission")
+
+    monkeypatch.setattr(
+        archive_commands.LangSmithBulkExporter,
+        "from_langsmith_client",
+        staticmethod(lambda client, **kwargs: ExportMustNotStart()),
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "archive",
+            "backfill",
+            "--config",
+            str(_write_config(tmp_path)),
+            "--route",
+            "dev",
+            "--start-date",
+            "2026-08-18",
+            "--end-date",
+            "2026-08-20",
+            "--bulk-export-destination-id",
+            "42345678-1234-5678-1234-567812345678",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Duplicate LangSmith project ID" in result.output
+
+
 @pytest.mark.parametrize(
     ("project_name", "message"),
     (

--- a/tests/test_archive_commands.py
+++ b/tests/test_archive_commands.py
@@ -89,6 +89,98 @@ def test_sync_command_routes_projects_and_reports_unmatched(
     assert all(item["route"] == "dev" for item in payload["processed"])
 
 
+def test_bulk_backfill_submits_all_projects_before_importing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner,
+) -> None:
+    from langsmith_cli.archive.backfill import BackfillImportResult
+    from langsmith_cli.commands import archive as archive_commands
+
+    projects = [
+        create_project(name="dev/agent"),
+        create_project(
+            name="dev/other",
+            project_id="22345678-1234-5678-1234-567812345678",
+        ),
+        create_project(
+            name="stg/not-selected",
+            project_id="32345678-1234-5678-1234-567812345678",
+        ),
+    ]
+    client = FakeArchiveClient(projects, [])
+    monkeypatch.setattr(archive_commands, "get_or_create_client", lambda ctx: client)
+    events: list[str] = []
+
+    class FakeManagedExporter:
+        def begin_window(self, **kwargs: object) -> str:
+            project_id = str(kwargs["project_id"])
+            events.append(f"begin:{project_id}")
+            return project_id
+
+        def complete_export(self, job: str) -> str:
+            events.append(f"complete:{job}")
+            return job
+
+    exporter = FakeManagedExporter()
+    monkeypatch.setattr(
+        archive_commands.LangSmithBulkExporter,
+        "from_langsmith_client",
+        staticmethod(lambda client, **kwargs: exporter),
+    )
+
+    def import_snapshot(
+        store: object,
+        *,
+        project_id: str,
+        project_name: str,
+        snapshot: str,
+    ) -> BackfillImportResult:
+        assert snapshot == project_id
+        events.append(f"import:{project_id}")
+        return BackfillImportResult(
+            export_id=f"export-{project_name}",
+            imported_days=2,
+            skipped_days=0,
+            canonical_run_count=7,
+        )
+
+    monkeypatch.setattr(archive_commands, "import_backfill_snapshot", import_snapshot)
+    result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "archive",
+            "backfill",
+            "--config",
+            str(_write_config(tmp_path)),
+            "--route",
+            "dev",
+            "--start-date",
+            "2026-08-18",
+            "--end-date",
+            "2026-08-20",
+            "--bulk-export-destination-id",
+            "42345678-1234-5678-1234-567812345678",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert events == [
+        f"begin:{projects[0].id}",
+        f"begin:{projects[1].id}",
+        f"complete:{projects[0].id}",
+        f"import:{projects[0].id}",
+        f"complete:{projects[1].id}",
+        f"import:{projects[1].id}",
+    ]
+    payload = parse_json_output(result.output)
+    assert [item["project_name"] for item in payload["projects"]] == [
+        "dev/agent",
+        "dev/other",
+    ]
+
+
 def test_sync_command_rejects_project_from_another_selected_route(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_archive_commands.py
+++ b/tests/test_archive_commands.py
@@ -127,10 +127,16 @@ def test_bulk_backfill_submits_all_projects_before_importing(
             return job
 
     exporter = FakeManagedExporter()
+    factory_options: dict[str, object] = {}
+
+    def build_exporter(client: object, **kwargs: object) -> FakeManagedExporter:
+        factory_options.update(kwargs)
+        return exporter
+
     monkeypatch.setattr(
         archive_commands.LangSmithBulkExporter,
         "from_langsmith_client",
-        staticmethod(lambda client, **kwargs: exporter),
+        staticmethod(build_exporter),
     )
 
     def import_snapshot(
@@ -184,6 +190,7 @@ def test_bulk_backfill_submits_all_projects_before_importing(
         "dev/other",
     ]
     assert payload["unmatched_projects"] == ["qa/unrouted"]
+    assert factory_options["timeout_seconds"] == 73 * 60 * 60
 
 
 @pytest.mark.parametrize(

--- a/tests/test_archive_commands.py
+++ b/tests/test_archive_commands.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from pathlib import Path
 from threading import Barrier, Lock
+import time
 from typing import Any, Iterator
 
 import pytest
@@ -533,6 +534,128 @@ def test_status_command_lists_published_manifests(
     assert len(manifests) == 1
     assert manifests[0]["project_name"] == "dev/agent"
     assert manifests[0]["canonical_run_count"] == 1
+
+
+def test_status_reads_independent_manifests_concurrently(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner,
+) -> None:
+    """
+    Archive size must not turn status into one network round trip per manifest.
+
+    Falsifies: a status implementation that lists keys quickly but then performs
+    every independent S3 manifest GET serially.
+    """
+    from langsmith_cli.archive.models import ArchivePhase
+    from langsmith_cli.archive.storage import create_store
+    from langsmith_cli.archive.sync import sync_project_day
+    from langsmith_cli.commands import archive as archive_commands
+
+    store = create_store(str(tmp_path / "dev-archive"))
+    for index in range(4):
+        sync_project_day(
+            FakeArchiveClient([], [create_run()]),
+            store,
+            project_id=f"{index + 1}2345678-1234-5678-1234-567812345678",
+            project_name=f"dev/agent-{index}",
+            trace_date=datetime(2026, 8, 19, tzinfo=timezone.utc).date(),
+            phase=ArchivePhase.PRIMARY,
+        )
+
+    class TrackingStore:
+        def __init__(self) -> None:
+            self.active = 0
+            self.max_active = 0
+            self.lock = Lock()
+
+        def list_keys(self, prefix: str) -> list[str]:
+            return store.list_keys(prefix)
+
+        def get_text_with_version(self, key: str):
+            with self.lock:
+                self.active += 1
+                self.max_active = max(self.max_active, self.active)
+            try:
+                time.sleep(0.02)
+                return store.get_text_with_version(key)
+            finally:
+                with self.lock:
+                    self.active -= 1
+
+    tracking_store = TrackingStore()
+    monkeypatch.setattr(archive_commands, "create_store", lambda uri: tracking_store)
+
+    result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "archive",
+            "status",
+            "--config",
+            str(_write_config(tmp_path)),
+            "--route",
+            "dev",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(parse_json_output(result.output)) == 4
+    assert tracking_store.max_active >= 2
+
+
+def test_status_summary_is_key_derived_and_never_downloads_manifests(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner,
+) -> None:
+    """A completion count stays one S3 LIST operation regardless of matrix size."""
+    from langsmith_cli.commands import archive as archive_commands
+
+    class SummaryOnlyStore:
+        def list_keys(self, prefix: str) -> list[str]:
+            assert prefix == "manifests"
+            return [
+                "manifests/project_id=12345678-1234-5678-1234-567812345678/date=2026-08-18.json",
+                "manifests/project_id=12345678-1234-5678-1234-567812345678/date=2026-08-19.json",
+                "manifests/project_id=22345678-1234-5678-1234-567812345678/date=2026-08-19.json",
+                "manifests/not-a-partition.json",
+            ]
+
+        def get_text_with_version(self, key: str) -> None:
+            raise AssertionError(f"summary downloaded manifest {key}")
+
+    monkeypatch.setattr(
+        archive_commands, "create_store", lambda uri: SummaryOnlyStore()
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "archive",
+            "status",
+            "--summary",
+            "--config",
+            str(_write_config(tmp_path)),
+            "--route",
+            "dev",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = parse_json_output(result.output)
+    assert payload["manifest_contents_verified"] is False
+    assert payload["routes"] == [
+        {
+            "route": "dev",
+            "archive_uri": str(tmp_path / "dev-archive"),
+            "manifest_count": 3,
+            "project_count": 2,
+            "first_date": "2026-08-18",
+            "last_date": "2026-08-19",
+            "invalid_manifest_keys": ["manifests/not-a-partition.json"],
+        }
+    ]
 
 
 def test_sync_command_surfaces_safe_retry_on_concurrent_publication(

--- a/tests/test_archive_commands.py
+++ b/tests/test_archive_commands.py
@@ -299,6 +299,63 @@ def test_bulk_backfill_submits_all_projects_before_importing(
     assert factory_options["timeout_seconds"] == 73 * 60 * 60
 
 
+def test_bulk_backfill_rejects_one_export_selected_for_multiple_projects(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner,
+) -> None:
+    from langsmith_cli.commands import archive as archive_commands
+
+    client = FakeArchiveClient(
+        [
+            create_project(name="dev/agent"),
+            create_project(
+                name="dev/other",
+                project_id="22345678-1234-5678-1234-567812345678",
+            ),
+        ],
+        [],
+    )
+    monkeypatch.setattr(archive_commands, "get_or_create_client", lambda ctx: client)
+    duplicate = BulkExportSnapshot(
+        export_id="42345678-1234-5678-1234-567812345678",
+        start_time=datetime(2026, 8, 18, tzinfo=timezone.utc),
+        end_time=datetime(2026, 8, 20, tzinfo=timezone.utc),
+        run_count=0,
+        file_uris=(),
+    )
+
+    class DuplicateExporter:
+        def begin_window(self, **kwargs: object) -> BulkExportSnapshot:
+            return duplicate
+
+    monkeypatch.setattr(
+        archive_commands.LangSmithBulkExporter,
+        "from_langsmith_client",
+        staticmethod(lambda client, **kwargs: DuplicateExporter()),
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "archive",
+            "backfill",
+            "--config",
+            str(_write_config(tmp_path)),
+            "--route",
+            "dev",
+            "--start-date",
+            "2026-08-18",
+            "--end-date",
+            "2026-08-20",
+            "--bulk-export-destination-id",
+            "42345678-1234-5678-1234-567812345678",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "was selected for multiple projects" in result.output
+
+
 @pytest.mark.parametrize(
     ("project_name", "message"),
     (

--- a/tests/test_archive_commands.py
+++ b/tests/test_archive_commands.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
+from threading import Barrier, Lock
 from typing import Any, Iterator
 
 import pytest
 from langsmith.schemas import Run, TracerSessionResult
 
 from conftest import create_project, create_run, parse_json_output
+from langsmith_cli.archive.bulk import BulkExportSnapshot
 from langsmith_cli.main import cli
 
 
@@ -89,6 +92,77 @@ def test_sync_command_routes_projects_and_reports_unmatched(
     assert all(item["route"] == "dev" for item in payload["processed"])
 
 
+def test_sync_command_threads_managed_bulk_provider_into_each_due_window(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner,
+) -> None:
+    from langsmith_cli.commands import archive as archive_commands
+
+    client = FakeArchiveClient([create_project(name="dev/agent")], [])
+    monkeypatch.setattr(archive_commands, "get_or_create_client", lambda ctx: client)
+    windows: list[tuple[datetime, datetime]] = []
+    factory_options: dict[str, object] = {}
+
+    class FakeManagedExporter:
+        def export_window(
+            self,
+            *,
+            project_id: str,
+            start_time: datetime,
+            end_time: datetime,
+            excluded_export_ids: frozenset[str],
+        ) -> BulkExportSnapshot:
+            windows.append((start_time, end_time))
+            export_id = (
+                "62345678-1234-5678-1234-567812345678"
+                if len(windows) == 1
+                else "72345678-1234-5678-1234-567812345678"
+            )
+            return BulkExportSnapshot(
+                export_id=export_id,
+                start_time=start_time,
+                end_time=end_time,
+                run_count=0,
+                file_uris=(),
+            )
+
+    def build_exporter(client: object, **kwargs: object) -> FakeManagedExporter:
+        factory_options.update(kwargs)
+        return FakeManagedExporter()
+
+    monkeypatch.setattr(
+        archive_commands.LangSmithBulkExporter,
+        "from_langsmith_client",
+        staticmethod(build_exporter),
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "archive",
+            "sync",
+            "--config",
+            str(_write_config(tmp_path)),
+            "--route",
+            "dev",
+            "--today",
+            "2026-08-21",
+            "--bulk-export-destination-id",
+            "42345678-1234-5678-1234-567812345678",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = parse_json_output(result.output)
+    assert len(windows) == 2
+    assert {item["provider"] for item in payload["processed"]} == {"bulk_export"}
+    assert factory_options == {
+        "destination_id": "42345678-1234-5678-1234-567812345678",
+        "archive_uri": str(tmp_path / "dev-archive"),
+    }
+
+
 def test_bulk_backfill_submits_all_projects_before_importing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -115,16 +189,27 @@ def test_bulk_backfill_submits_all_projects_before_importing(
     client = FakeArchiveClient(projects, [])
     monkeypatch.setattr(archive_commands, "get_or_create_client", lambda ctx: client)
     events: list[str] = []
+    event_lock = Lock()
+    import_barrier = Barrier(2, timeout=2)
 
     class FakeManagedExporter:
-        def begin_window(self, **kwargs: object) -> str:
+        def begin_window(self, **kwargs: object) -> BulkExportSnapshot:
             project_id = str(kwargs["project_id"])
             events.append(f"begin:{project_id}")
-            return project_id
+            return BulkExportSnapshot(
+                export_id=project_id,
+                start_time=datetime(2026, 8, 18, tzinfo=timezone.utc),
+                end_time=datetime(2026, 8, 20, tzinfo=timezone.utc),
+                run_count=0,
+                file_uris=(),
+            )
 
-        def complete_export(self, job: str) -> str:
-            events.append(f"complete:{job}")
-            return job
+        def complete_exports(
+            self, jobs: list[BulkExportSnapshot]
+        ) -> Iterator[BulkExportSnapshot]:
+            for job in reversed(jobs):
+                events.append(f"complete:{job.export_id}")
+                yield job
 
     exporter = FakeManagedExporter()
     factory_options: dict[str, object] = {}
@@ -144,10 +229,14 @@ def test_bulk_backfill_submits_all_projects_before_importing(
         *,
         project_id: str,
         project_name: str,
-        snapshot: str,
+        snapshot: BulkExportSnapshot,
     ) -> BackfillImportResult:
-        assert snapshot == project_id
-        events.append(f"import:{project_id}")
+        assert snapshot.export_id == project_id
+        with event_lock:
+            events.append(f"import-start:{project_id}")
+        import_barrier.wait()
+        with event_lock:
+            events.append(f"import-end:{project_id}")
         return BackfillImportResult(
             export_id=f"export-{project_name}",
             imported_days=2,
@@ -172,18 +261,35 @@ def test_bulk_backfill_submits_all_projects_before_importing(
             "2026-08-20",
             "--bulk-export-destination-id",
             "42345678-1234-5678-1234-567812345678",
+            "--import-workers",
+            "2",
         ],
     )
 
     assert result.exit_code == 0, result.output
-    assert events == [
+    assert events[:2] == [
         f"begin:{projects[0].id}",
         f"begin:{projects[1].id}",
-        f"complete:{projects[0].id}",
-        f"import:{projects[0].id}",
-        f"complete:{projects[1].id}",
-        f"import:{projects[1].id}",
     ]
+    assert events.index(f"complete:{projects[1].id}") < events.index(
+        f"import-start:{projects[1].id}"
+    )
+    assert events.index(f"complete:{projects[0].id}") < events.index(
+        f"import-start:{projects[0].id}"
+    )
+    start_events = {event for event in events if event.startswith("import-start:")}
+    end_events = {event for event in events if event.startswith("import-end:")}
+    assert start_events == {
+        f"import-start:{projects[0].id}",
+        f"import-start:{projects[1].id}",
+    }
+    assert end_events == {
+        f"import-end:{projects[0].id}",
+        f"import-end:{projects[1].id}",
+    }
+    assert max(events.index(event) for event in start_events) < min(
+        events.index(event) for event in end_events
+    )
     payload = parse_json_output(result.output)
     assert [item["project_name"] for item in payload["projects"]] == [
         "dev/agent",

--- a/tests/test_archive_commands.py
+++ b/tests/test_archive_commands.py
@@ -658,6 +658,18 @@ def test_status_summary_is_key_derived_and_never_downloads_manifests(
     ]
 
 
+def test_status_summary_cannot_claim_manifest_body_verification() -> None:
+    """Key-derived evidence must never be mislabeled as a full body audit."""
+    from pydantic import ValidationError
+
+    from langsmith_cli.commands.archive import ArchiveStatusSummary
+
+    with pytest.raises(ValidationError):
+        ArchiveStatusSummary.model_validate(
+            {"manifest_contents_verified": True, "routes": []}
+        )
+
+
 def test_sync_command_surfaces_safe_retry_on_concurrent_publication(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_archive_commands.py
+++ b/tests/test_archive_commands.py
@@ -245,7 +245,9 @@ def test_archive_get_reports_missing_run(
 ) -> None:
     from langsmith_cli.archive import query as archive_query
 
-    def missing_run(run_id: str, *, follow_children: bool) -> tuple[Run, list[Run]]:
+    def missing_run(
+        run_id: str, *, follow_children: bool, **kwargs: object
+    ) -> tuple[Run, list[Run]]:
         raise LookupError(f"Archived run not found: {run_id}")
 
     monkeypatch.setattr(archive_query, "read_archived_run", missing_run)
@@ -256,6 +258,61 @@ def test_archive_get_reports_missing_run(
 
     assert result.exit_code != 0
     assert "Archived run not found" in parse_json_output(result.output)["message"]
+
+
+def test_archive_get_forwards_partition_pruning_hints(
+    monkeypatch: pytest.MonkeyPatch,
+    runner,
+) -> None:
+    from langsmith_cli.archive import query as archive_query
+
+    observed: dict[str, object] = {}
+
+    def read_run(
+        run_id: str,
+        *,
+        follow_children: bool,
+        project: str | None,
+        project_id: str | None,
+        since: object,
+        before: object,
+    ) -> tuple[Run, list[Run]]:
+        observed.update(
+            run_id=run_id,
+            follow_children=follow_children,
+            project=project,
+            project_id=project_id,
+            since=since,
+            before=before,
+        )
+        return create_run(id_str=run_id), []
+
+    monkeypatch.setattr(archive_query, "read_archived_run", read_run)
+    run_id = "12345678-1234-5678-1234-567812345678"
+    result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "runs",
+            "get",
+            run_id,
+            "--archive",
+            "--project",
+            "dev/agent",
+            "--project-id",
+            "22345678-1234-5678-1234-567812345678",
+            "--since",
+            "2026-08-18",
+            "--before",
+            "2026-08-20",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert observed["project"] == "dev/agent"
+    assert observed["project_id"] == "22345678-1234-5678-1234-567812345678"
+    assert str(observed["since"]) == "2026-08-18 00:00:00"
+    assert str(observed["before"]) == "2026-08-20 00:00:00"
 
 
 def test_archive_get_latest_maps_filters_and_fields(

--- a/tests/test_archive_invariants.py
+++ b/tests/test_archive_invariants.py
@@ -223,6 +223,22 @@ def test_empty_archive_is_queryable_as_zero_rows(
     assert count_archive_runs(query) == 0
 
 
+def test_queries_ignore_unpublished_raw_and_canonical_objects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """INVARIANT: manifests are the only publication pointers visible to readers."""
+    archive_uri = str(tmp_path / "archive")
+    monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
+    store, manifest = _sync_primary(tmp_path, [create_run()])
+    assert manifest.canonical_key is not None
+    store.put_text("raw/orphan/runs.parquet", "not parquet")
+    store.put_text("canonical/orphan/runs.parquet", "not parquet")
+
+    runs = query_archive_runs(ArchiveRunQuery(project="dev/agent", limit=0))
+
+    assert len(runs) == 1
+
+
 def test_project_catalog_prunes_unrelated_manifest_reads(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_archive_invariants.py
+++ b/tests/test_archive_invariants.py
@@ -14,7 +14,10 @@ import pytest
 from langsmith.schemas import Run
 
 from conftest import create_run
-from langsmith_cli.archive.duckdb import configure_duckdb_temp_directory
+from langsmith_cli.archive.duckdb import (
+    DUCKDB_MEMORY_LIMIT,
+    configure_duckdb_resources,
+)
 from langsmith_cli.archive.models import ArchivePhase
 from langsmith_cli.archive.query import (
     ArchiveRunQuery,
@@ -676,17 +679,17 @@ def test_store_factory_supports_s3_and_file_uris(tmp_path: Path) -> None:
     assert create_store(tmp_path.as_uri()).base_uri == str(tmp_path.resolve())
 
 
-def test_duckdb_spill_directory_is_unique_to_each_project_staging_area(
+def test_duckdb_resources_are_bounded_and_unique_to_each_project_staging_area(
     tmp_path: Path,
 ) -> None:
-    """Concurrent processes must never share DuckDB's default relative `.tmp`."""
+    """Concurrent workers must neither share spill files nor claim host memory."""
     import duckdb
 
     first = duckdb.connect()
     second = duckdb.connect()
     try:
-        configure_duckdb_temp_directory(first, tmp_path / "project-a")
-        configure_duckdb_temp_directory(second, tmp_path / "project-b")
+        configure_duckdb_resources(first, tmp_path / "project-a")
+        configure_duckdb_resources(second, tmp_path / "project-b")
 
         first_path = first.execute(
             "SELECT current_setting('temp_directory')"
@@ -697,6 +700,12 @@ def test_duckdb_spill_directory_is_unique_to_each_project_staging_area(
         assert first_path == (str(tmp_path / "project-a" / "duckdb-spill"),)
         assert second_path == (str(tmp_path / "project-b" / "duckdb-spill"),)
         assert first_path != second_path
+        assert first.execute("SELECT current_setting('memory_limit')").fetchone() == (
+            DUCKDB_MEMORY_LIMIT,
+        )
+        assert second.execute("SELECT current_setting('memory_limit')").fetchone() == (
+            DUCKDB_MEMORY_LIMIT,
+        )
     finally:
         first.close()
         second.close()

--- a/tests/test_archive_invariants.py
+++ b/tests/test_archive_invariants.py
@@ -14,6 +14,7 @@ import pytest
 from langsmith.schemas import Run
 
 from conftest import create_run
+from langsmith_cli.archive.duckdb import configure_duckdb_temp_directory
 from langsmith_cli.archive.models import ArchivePhase
 from langsmith_cli.archive.query import (
     ArchiveRunQuery,
@@ -673,6 +674,32 @@ def test_store_rejects_invalid_or_unsupported_uris(uri: str) -> None:
 def test_store_factory_supports_s3_and_file_uris(tmp_path: Path) -> None:
     assert isinstance(create_store("s3://archive-bucket/prefix"), S3ArchiveStore)
     assert create_store(tmp_path.as_uri()).base_uri == str(tmp_path.resolve())
+
+
+def test_duckdb_spill_directory_is_unique_to_each_project_staging_area(
+    tmp_path: Path,
+) -> None:
+    """Concurrent processes must never share DuckDB's default relative `.tmp`."""
+    import duckdb
+
+    first = duckdb.connect()
+    second = duckdb.connect()
+    try:
+        configure_duckdb_temp_directory(first, tmp_path / "project-a")
+        configure_duckdb_temp_directory(second, tmp_path / "project-b")
+
+        first_path = first.execute(
+            "SELECT current_setting('temp_directory')"
+        ).fetchone()
+        second_path = second.execute(
+            "SELECT current_setting('temp_directory')"
+        ).fetchone()
+        assert first_path == (str(tmp_path / "project-a" / "duckdb-spill"),)
+        assert second_path == (str(tmp_path / "project-b" / "duckdb-spill"),)
+        assert first_path != second_path
+    finally:
+        first.close()
+        second.close()
 
 
 def test_s3_store_propagates_non_concurrency_service_errors(

--- a/tests/test_bulk_export.py
+++ b/tests/test_bulk_export.py
@@ -290,7 +290,23 @@ def test_bulk_export_batch_rejects_polled_request_identity_drift() -> None:
         list(_exporter(request_json=request).complete_exports((queued,)))
 
 
-def test_bulk_export_rejects_destination_outside_archive() -> None:
+@pytest.mark.parametrize(
+    ("destination_override", "expected_error"),
+    [
+        ({"id": "62345678-1234-5678-1234-567812345678"}, "changed identity"),
+        (
+            {"config": {"bucket_name": "traces-dev", "prefix": "elsewhere/bulk"}},
+            "prefix is outside archive URI",
+        ),
+        (
+            {"config": {"bucket_name": "traces-prd", "prefix": "langsmith/bulk"}},
+            "bucket does not match",
+        ),
+    ],
+)
+def test_bulk_export_rejects_destination_outside_archive(
+    destination_override: dict[str, object], expected_error: str
+) -> None:
     def wrong_destination(
         method: str,
         path: str,
@@ -300,13 +316,10 @@ def test_bulk_export_rejects_destination_outside_archive() -> None:
         response = cast(
             dict[str, object], _destination_request(method, path, params, payload)
         )
-        response["config"] = {
-            "bucket_name": "traces-prd",
-            "prefix": "langsmith/bulk",
-        }
+        response.update(destination_override)
         return response
 
-    with pytest.raises(ValueError, match="bucket does not match"):
+    with pytest.raises(ValueError, match=expected_error):
         _exporter(request_json=wrong_destination).begin_window(
             project_id=PROJECT_ID,
             start_time=TRACE_START,

--- a/tests/test_bulk_export.py
+++ b/tests/test_bulk_export.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import date, datetime, timezone
 import json
 from pathlib import Path
@@ -181,6 +182,100 @@ def test_bulk_export_wait_is_bounded() -> None:
     exporter = _exporter(timeout_seconds=1, monotonic=lambda: next(clock))
     with pytest.raises(BulkExportTimeoutError, match="did not finish in time"):
         exporter.complete_export(_job(BulkExportStatus.CREATED))
+
+
+def test_bulk_export_batch_harvests_completed_jobs_without_head_of_line_blocking() -> (
+    None
+):
+    queued_export_id = "82345678-1234-5678-1234-567812345678"
+    ready_export_id = "92345678-1234-5678-1234-567812345678"
+    queued_polls = 0
+
+    def request(
+        method: str,
+        path: str,
+        params: dict[str, object] | None,
+        payload: dict[str, object] | None,
+    ) -> object:
+        nonlocal queued_polls
+        if path.startswith("/api/v1/bulk-exports/destinations/"):
+            return _destination_request(method, path, params, payload)
+        if path == f"/api/v1/bulk-exports/{queued_export_id}":
+            queued_polls += 1
+            status = "Created" if queued_polls == 1 else "Completed"
+            return _job_payload(queued_export_id, status, TRACE_START.isoformat())
+        if path == f"/api/v1/bulk-exports/{ready_export_id}/runs":
+            return [_partition_payload(rows_written=0, exported_files=[])]
+        if path == f"/api/v1/bulk-exports/{queued_export_id}/runs":
+            return [_partition_payload(rows_written=0, exported_files=[])]
+        raise AssertionError((method, path))
+
+    queued = replace(_job(BulkExportStatus.CREATED), export_id=queued_export_id)
+    ready = replace(_job(BulkExportStatus.COMPLETED), export_id=ready_export_id)
+
+    completed = list(_exporter(request_json=request).complete_exports((queued, ready)))
+
+    assert [snapshot.export_id for snapshot in completed] == [
+        ready_export_id,
+        queued_export_id,
+    ]
+
+
+def test_bulk_export_batch_harvests_ready_peer_before_reporting_failure() -> None:
+    failed = replace(
+        _job(BulkExportStatus.FAILED),
+        export_id="a2345678-1234-5678-1234-567812345678",
+    )
+    ready = replace(
+        _job(BulkExportStatus.COMPLETED),
+        export_id="b2345678-1234-5678-1234-567812345678",
+    )
+
+    def request(
+        method: str,
+        path: str,
+        params: dict[str, object] | None,
+        payload: dict[str, object] | None,
+    ) -> object:
+        if path.startswith("/api/v1/bulk-exports/destinations/"):
+            return _destination_request(method, path, params, payload)
+        if path == f"/api/v1/bulk-exports/{ready.export_id}/runs":
+            return [_partition_payload(rows_written=0, exported_files=[])]
+        raise AssertionError((method, path))
+
+    snapshots = _exporter(request_json=request).complete_exports((failed, ready))
+
+    assert next(snapshots).export_id == ready.export_id
+    with pytest.raises(
+        BulkExportFailedError, match=f"{failed.export_id} ended as Failed"
+    ):
+        next(snapshots)
+
+
+def test_bulk_export_batch_rejects_duplicate_export_ids() -> None:
+    duplicate = _job(BulkExportStatus.COMPLETED)
+
+    with pytest.raises(ValueError, match="Duplicate bulk export ID"):
+        list(_exporter().complete_exports((duplicate, duplicate)))
+
+
+def test_bulk_export_batch_rejects_polled_request_identity_drift() -> None:
+    queued = _job(BulkExportStatus.CREATED)
+
+    def request(
+        method: str,
+        path: str,
+        params: dict[str, object] | None,
+        payload: dict[str, object] | None,
+    ) -> object:
+        if path.startswith("/api/v1/bulk-exports/destinations/"):
+            return _destination_request(method, path, params, payload)
+        changed = _job_payload(queued.export_id, "Running", TRACE_START.isoformat())
+        changed["session_id"] = "c2345678-1234-5678-1234-567812345678"
+        return changed
+
+    with pytest.raises(ValueError, match="changed request identity"):
+        list(_exporter(request_json=request).complete_exports((queued,)))
 
 
 def test_bulk_export_rejects_destination_outside_archive() -> None:
@@ -380,6 +475,12 @@ def test_bulk_export_builds_from_langsmith_client() -> None:
             "s3://traces-dev",
             "requires a bucket prefix",
         ),
+        (
+            "https://api.smith.langchain.com",
+            DESTINATION_ID,
+            "s3://traces-dev/langsmith/../private",
+            "prefix must be normalized",
+        ),
     ),
 )
 def test_bulk_export_rejects_unsafe_identity_and_storage_configuration(
@@ -487,6 +588,13 @@ def test_bulk_export_polls_then_accepts_complete_empty_partition() -> None:
                 exported_files=["traces-prd/langsmith/bulk/out.parquet"],
             ),
             "outside the configured destination",
+        ),
+        (
+            _partition_payload(
+                rows_written=1,
+                exported_files=["traces-dev/langsmith/bulk/./out.parquet"],
+            ),
+            "path must be normalized",
         ),
         (
             _partition_payload(rows_written=0, exported_files=[], status="Failed"),

--- a/tests/test_bulk_export.py
+++ b/tests/test_bulk_export.py
@@ -259,6 +259,18 @@ def test_bulk_export_batch_rejects_duplicate_export_ids() -> None:
         list(_exporter().complete_exports((duplicate, duplicate)))
 
 
+def test_bulk_export_empty_batch_performs_no_destination_request() -> None:
+    def unexpected_request(
+        method: str,
+        path: str,
+        params: dict[str, object] | None,
+        payload: dict[str, object] | None,
+    ) -> object:
+        raise AssertionError((method, path))
+
+    assert list(_exporter(request_json=unexpected_request).complete_exports(())) == []
+
+
 def test_bulk_export_batch_rejects_polled_request_identity_drift() -> None:
     queued = _job(BulkExportStatus.CREATED)
 

--- a/tests/test_bulk_export.py
+++ b/tests/test_bulk_export.py
@@ -10,7 +10,7 @@ import time
 from typing import Any, Callable, Iterator, cast
 
 import pytest
-from conftest import create_run
+from conftest import create_run, parse_json_output
 from langsmith import Client
 from langsmith.schemas import Run
 from langsmith_cli.archive.backfill import import_backfill_snapshot
@@ -26,10 +26,15 @@ from langsmith_cli.archive.bulk import (
     LangSmithBulkExporter,
 )
 from langsmith_cli.archive.models import ArchivePhase
-from langsmith_cli.archive.query import ArchiveRunQuery, query_archive_runs
+from langsmith_cli.archive.query import (
+    ArchiveRunQuery,
+    query_archive_runs,
+    read_archived_run,
+)
 from langsmith_cli.archive.query import _normalize_run_payload
 from langsmith_cli.archive.storage import create_store
 from langsmith_cli.archive.sync import sync_project_day
+from langsmith_cli.main import cli
 
 
 PROJECT_ID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
@@ -57,6 +62,44 @@ def test_bulk_json_strings_normalize_to_run_contracts() -> None:
     assert payload["events"] == [{"name": "start"}]
     assert payload["tags"] == ["production"]
     assert payload["error"] == "plain error string"
+
+
+def test_bulk_json_normalization_matches_live_run_shape() -> None:
+    """INVARIANT: provider representation does not change CLI run JSON."""
+    payload = _normalize_run_payload(
+        {
+            "inputs": json.dumps(
+                {
+                    "input": json.dumps({"question": "hello"}),
+                    "schema_padding": None,
+                }
+            ),
+            "outputs": json.dumps({"answer": "world", "schema_padding": None}),
+            "extra": json.dumps({"metadata": {"model": "gpt", "schema_padding": None}}),
+            "events": json.dumps(
+                [
+                    {
+                        "name": "start",
+                        "time": "2026-08-19T21:59:53.948395",
+                        "schema_padding": None,
+                    }
+                ]
+            ),
+        }
+    )
+
+    assert payload == {
+        "inputs": {"input": {"question": "hello"}, "schema_padding": None},
+        "outputs": {"answer": "world", "schema_padding": None},
+        "extra": {"metadata": {"model": "gpt", "schema_padding": None}},
+        "events": [
+            {
+                "name": "start",
+                "time": "2026-08-19T21:59:53.948395+00:00",
+                "schema_padding": None,
+            }
+        ],
+    }
 
 
 class FakeBulkExporter:
@@ -847,7 +890,7 @@ def test_bulk_snapshot_integrates_with_canonical_reconciliation(
 
 
 def test_bulk_reconciliation_unifies_runs_api_and_v2_json_column_types(
-    tmp_path: Path, monkeypatch
+    tmp_path: Path, monkeypatch, runner
 ) -> None:
     """A Bulk v2 reconciliation must replace native Runs API rows by run ID."""
     import duckdb
@@ -861,11 +904,18 @@ def test_bulk_reconciliation_unifies_runs_api_and_v2_json_column_types(
         parent_run_id=str(primary_run.id),
         trace_id=str(primary_run.id),
         outputs={"late": True},
+    ).model_copy(
+        update={
+            "events": [{"name": "start", "time": "2026-08-19T21:59:53.948395+00:00"}]
+        }
     )
     json_rows = tmp_path / "bulk-mixed.json"
     payloads: list[dict[str, object]] = []
     for run in (reconciled_run, late_child):
         payload = run.model_dump(mode="json")
+        if run.id == late_child.id:
+            events = cast(list[dict[str, object]], payload["events"])
+            events[0]["time"] = "2026-08-19T21:59:53.948395"
         for field in (
             "extra",
             "inputs",
@@ -925,6 +975,40 @@ def test_bulk_reconciliation_unifies_runs_api_and_v2_json_column_types(
     root = next(run for run in archived if run.id == primary_run.id)
     assert root.outputs == {"version": "bulk-v2"}
     assert root.tags == ["reconciled"]
+    archived_root, archived_children = read_archived_run(
+        str(primary_run.id),
+        follow_children=True,
+        project="dev/agent",
+    )
+    assert [child.id for child in archived_children] == [late_child.id]
+    assert archived_root.child_run_ids == [late_child.id]
+    assert archived_children[0].model_dump(mode="json")["events"] == [
+        {"name": "start", "time": "2026-08-19T21:59:53.948395+00:00"}
+    ]
+
+    class FullTraceClient:
+        def read_run(self, run_id: str) -> Run:
+            assert run_id == str(primary_run.id)
+            return reconciled_run.model_copy(update={"child_run_ids": [late_child.id]})
+
+        def list_runs(self, **kwargs: object) -> Iterator[Run]:
+            assert kwargs == {"trace_id": str(primary_run.id)}
+            return iter((reconciled_run, late_child))
+
+    from langsmith_cli.commands.runs import get_cmd
+
+    monkeypatch.setattr(get_cmd, "get_or_create_client", lambda ctx: FullTraceClient())
+    command = ["--json", "runs", "get", str(primary_run.id), "--follow-children"]
+    api_result = runner.invoke(cli, command)
+    archive_result = runner.invoke(
+        cli, [*command, "--archive", "--project", "dev/agent"]
+    )
+
+    assert api_result.exit_code == 0, api_result.output
+    assert archive_result.exit_code == 0, archive_result.output
+    assert parse_json_output(api_result.output) == parse_json_output(
+        archive_result.output
+    )
 
 
 def test_range_backfill_publishes_daily_partitions_and_resumes(

--- a/tests/test_bulk_export.py
+++ b/tests/test_bulk_export.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 import json
 from pathlib import Path
 import time
@@ -34,7 +34,7 @@ from langsmith_cli.archive.query import (
 )
 from langsmith_cli.archive.query import _normalize_run_payload
 from langsmith_cli.archive.storage import create_store
-from langsmith_cli.archive.sync import sync_project_day
+from langsmith_cli.archive.sync import ARCHIVE_JSON_COLUMNS, sync_project_day
 from langsmith_cli.main import cli
 
 
@@ -44,6 +44,50 @@ PRIMARY_EXPORT_ID = "32345678-1234-5678-1234-567812345678"
 NEW_EXPORT_ID = "42345678-1234-5678-1234-567812345678"
 TRACE_START = datetime(2026, 8, 19, tzinfo=timezone.utc)
 TRACE_END = datetime(2026, 8, 20, tzinfo=timezone.utc)
+
+
+def test_archive_json_columns_are_one_explicit_provider_schema_contract() -> None:
+    """INVARIANT: writer, reader, and fixtures share the complete JSON schema."""
+    assert ARCHIVE_JSON_COLUMNS == (
+        "extra",
+        "inputs",
+        "outputs",
+        "feedback_stats",
+        "events",
+        "tags",
+        "parent_run_ids",
+    )
+
+
+def _bulk_v2_payload(run: Run) -> dict[str, object]:
+    """Encode a Run like Bulk Export v2's JSON-valued Parquet columns."""
+    payload = cast(dict[str, object], run.model_dump(mode="json"))
+    for field in ARCHIVE_JSON_COLUMNS:
+        if field in payload and payload[field] is not None:
+            payload[field] = json.dumps(payload[field])
+    return payload
+
+
+def _write_json_rows_as_parquet(
+    rows_path: Path, parquet_path: Path, payloads: list[dict[str, object]]
+) -> None:
+    """Write JSON fixture rows through DuckDB's production-compatible reader."""
+    import duckdb
+
+    rows_path.write_text(
+        "".join(json.dumps(payload) + "\n" for payload in payloads),
+        encoding="utf-8",
+    )
+    connection = duckdb.connect()
+    try:
+        parquet_sql = str(parquet_path).replace("'", "''")
+        connection.execute(
+            f"COPY (SELECT * FROM read_json_auto(?)) TO '{parquet_sql}' "
+            "(FORMAT PARQUET)",
+            [str(rows_path)],
+        )
+    finally:
+        connection.close()
 
 
 def test_bulk_json_strings_normalize_to_run_contracts() -> None:
@@ -203,6 +247,47 @@ def _job(status: BulkExportStatus) -> BulkExportJob:
         export_fields=BULK_EXPORT_FIELDS,
         all_experiments=False,
     )
+
+
+@pytest.mark.parametrize(
+    ("job_update", "message"),
+    (
+        ({"export_id": "not-a-uuid"}, "bulk export ID must be a UUID"),
+        (
+            {"start_time": TRACE_START.replace(tzinfo=None)},
+            "window must be a non-empty UTC range",
+        ),
+    ),
+    ids=("canonical-export-id", "utc-window"),
+)
+def test_bulk_export_job_model_enforces_identity_and_window_invariants(
+    job_update: dict[str, object], message: str
+) -> None:
+    """INVARIANT: every job instance has canonical IDs and a non-empty UTC window."""
+    with pytest.raises(ValueError, match=message):
+        replace(_job(BulkExportStatus.CREATED), **job_update)
+
+
+@pytest.mark.parametrize(
+    "start_time",
+    (
+        TRACE_START.replace(tzinfo=None),
+        TRACE_START.astimezone(timezone(timedelta(hours=2))),
+    ),
+    ids=("naive", "non-utc"),
+)
+def test_bulk_export_snapshot_model_enforces_utc_window_invariant(
+    start_time: datetime,
+) -> None:
+    """INVARIANT: snapshots are expressed as non-empty UTC ranges."""
+    with pytest.raises(ValueError, match="window must be a non-empty UTC range"):
+        BulkExportSnapshot(
+            export_id=NEW_EXPORT_ID,
+            start_time=start_time,
+            end_time=start_time + timedelta(days=1),
+            run_count=0,
+            file_uris=(),
+        )
 
 
 def _destination_request(
@@ -770,6 +855,48 @@ def test_bulk_export_rejects_missing_partition_coverage() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    "intervals",
+    (
+        (
+            (TRACE_START, TRACE_START + timedelta(hours=12)),
+            (TRACE_START + timedelta(hours=13), TRACE_END),
+        ),
+        (
+            (TRACE_START, TRACE_START + timedelta(hours=13)),
+            (TRACE_START + timedelta(hours=12), TRACE_END),
+        ),
+    ),
+    ids=("gap", "overlap"),
+)
+def test_bulk_export_partitions_exactly_cover_requested_window(
+    intervals: tuple[tuple[datetime, datetime], ...],
+) -> None:
+    """INVARIANT: completed partitions have neither gaps nor overlaps."""
+    partitions: list[dict[str, object]] = []
+    for start_time, end_time in intervals:
+        partition = _partition_payload(rows_written=0, exported_files=[])
+        metadata = cast(dict[str, object], partition["metadata"])
+        metadata["start_time"] = start_time.isoformat()
+        metadata["end_time"] = end_time.isoformat()
+        partitions.append(partition)
+
+    def request(
+        method: str,
+        path: str,
+        params: dict[str, object] | None,
+        payload: dict[str, object] | None,
+    ) -> object:
+        if path.startswith("/api/v1/bulk-exports/destinations/"):
+            return _destination_request(method, path, params, payload)
+        return partitions
+
+    with pytest.raises(ValueError, match="exactly cover the window"):
+        _exporter(request_json=request).complete_export(
+            _job(BulkExportStatus.COMPLETED)
+        )
+
+
 def test_bulk_export_adopts_latest_matching_job_and_excludes_prior_phase() -> None:
     requests: list[tuple[str, str]] = []
 
@@ -862,34 +989,10 @@ def test_bulk_export_adopts_latest_matching_job_and_excludes_prior_phase() -> No
 def test_bulk_snapshot_integrates_with_canonical_reconciliation(
     tmp_path: Path, monkeypatch
 ) -> None:
-    import duckdb
-
     run = create_run(outputs={"source": "bulk"}, tags=["bulk-provider"])
     source = tmp_path / "bulk.parquet"
     rows = tmp_path / "bulk.json"
-    payload = run.model_dump(mode="json")
-    for field in (
-        "extra",
-        "inputs",
-        "outputs",
-        "feedback_stats",
-        "events",
-        "tags",
-        "parent_run_ids",
-    ):
-        if field in payload and payload[field] is not None:
-            payload[field] = json.dumps(payload[field])
-    rows.write_text(json.dumps(payload) + "\n", encoding="utf-8")
-    connection = duckdb.connect()
-    try:
-        source_sql = str(source).replace("'", "''")
-        connection.execute(
-            f"COPY (SELECT * FROM read_json_auto(?)) TO '{source_sql}' "
-            "(FORMAT PARQUET)",
-            [str(rows)],
-        )
-    finally:
-        connection.close()
+    _write_json_rows_as_parquet(rows, source, [_bulk_v2_payload(run)])
 
     archive_uri = str(tmp_path / "archive")
     monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
@@ -920,8 +1023,6 @@ def test_bulk_reconciliation_unifies_runs_api_and_v2_json_column_types(
     tmp_path: Path, monkeypatch, runner
 ) -> None:
     """A Bulk v2 reconciliation must replace native Runs API rows by run ID."""
-    import duckdb
-
     primary_run = create_run(outputs={"version": "runs-api"}, tags=["primary"])
     reconciled_run = primary_run.model_copy(
         update={"outputs": {"version": "bulk-v2"}, "tags": ["reconciled"]}
@@ -937,39 +1038,17 @@ def test_bulk_reconciliation_unifies_runs_api_and_v2_json_column_types(
         }
     )
     json_rows = tmp_path / "bulk-mixed.json"
-    payloads: list[dict[str, object]] = []
-    for run in (reconciled_run, late_child):
-        payload = run.model_dump(mode="json")
-        if run.id == late_child.id:
-            events = cast(list[dict[str, object]], payload["events"])
-            events[0]["time"] = "2026-08-19T21:59:53.948395"
-        for field in (
-            "extra",
-            "inputs",
-            "outputs",
-            "feedback_stats",
-            "events",
-            "tags",
-            "parent_run_ids",
-        ):
-            if field in payload and payload[field] is not None:
-                payload[field] = json.dumps(payload[field])
-        payloads.append(payload)
-    json_rows.write_text(
-        "".join(json.dumps(payload) + "\n" for payload in payloads),
-        encoding="utf-8",
+    reconciled_payload = _bulk_v2_payload(reconciled_run)
+    late_child_payload = cast(dict[str, object], late_child.model_dump(mode="json"))
+    events = cast(list[dict[str, object]], late_child_payload["events"])
+    events[0]["time"] = "2026-08-19T21:59:53.948395"
+    late_child_payload = _bulk_v2_payload(
+        late_child.model_copy(update={"events": events})
     )
     bulk_parquet = tmp_path / "bulk-mixed.parquet"
-    connection = duckdb.connect()
-    try:
-        bulk_parquet_sql = str(bulk_parquet).replace("'", "''")
-        connection.execute(
-            f"COPY (SELECT * FROM read_json_auto(?)) TO '{bulk_parquet_sql}' "
-            "(FORMAT PARQUET)",
-            [str(json_rows)],
-        )
-    finally:
-        connection.close()
+    _write_json_rows_as_parquet(
+        json_rows, bulk_parquet, [reconciled_payload, late_child_payload]
+    )
 
     archive_uri = str(tmp_path / "archive")
     monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
@@ -1041,8 +1120,6 @@ def test_bulk_reconciliation_unifies_runs_api_and_v2_json_column_types(
 def test_range_backfill_publishes_daily_partitions_and_resumes(
     tmp_path: Path, monkeypatch
 ) -> None:
-    import duckdb
-
     files: list[Path] = []
     partitions: list[BulkExportPartition] = []
     for offset, day in enumerate((19, 20)):
@@ -1052,17 +1129,11 @@ def test_range_backfill_publishes_daily_partitions_and_resumes(
         )
         rows = tmp_path / f"day-{day}.json"
         parquet = tmp_path / f"day-{day}.parquet"
-        rows.write_text(run.model_dump_json() + "\n", encoding="utf-8")
-        connection = duckdb.connect()
-        try:
-            parquet_sql = str(parquet).replace("'", "''")
-            connection.execute(
-                f"COPY (SELECT * FROM read_json_auto(?)) TO '{parquet_sql}' "
-                "(FORMAT PARQUET)",
-                [str(rows)],
-            )
-        finally:
-            connection.close()
+        _write_json_rows_as_parquet(
+            rows,
+            parquet,
+            [cast(dict[str, object], run.model_dump(mode="json"))],
+        )
         files.append(parquet)
         start = datetime(2026, 8, day, tzinfo=timezone.utc)
         partitions.append(
@@ -1098,6 +1169,13 @@ def test_range_backfill_publishes_daily_partitions_and_resumes(
         project_name="dev/agent",
         snapshot=snapshot,
     )
+    with pytest.raises(ValueError, match="project name changed"):
+        import_backfill_snapshot(
+            store,
+            project_id=PROJECT_ID,
+            project_name="dev/renamed-agent",
+            snapshot=snapshot,
+        )
 
     assert first.imported_days == 2
     assert first.skipped_days == 0

--- a/tests/test_bulk_export.py
+++ b/tests/test_bulk_export.py
@@ -28,6 +28,7 @@ from langsmith_cli.archive.bulk import (
 from langsmith_cli.archive.models import ArchivePhase
 from langsmith_cli.archive.query import (
     ArchiveRunQuery,
+    _validated_archive_run,
     query_archive_runs,
     read_archived_run,
 )
@@ -100,6 +101,32 @@ def test_bulk_json_normalization_matches_live_run_shape() -> None:
             }
         ],
     }
+
+
+def test_bulk_json_normalization_preserves_non_json_values_and_normalizes_datetimes() -> (
+    None
+):
+    payload = _normalize_run_payload(
+        {
+            "inputs": json.dumps({"input": "plain text"}),
+            "events": json.dumps([{"name": "custom", "time": "not-an-iso-time"}]),
+        }
+    )
+    assert payload == {
+        "inputs": {"input": "plain text"},
+        "events": [{"name": "custom", "time": "not-an-iso-time"}],
+    }
+
+    run_payload = create_run().model_dump(mode="python")
+    run_payload["events"] = [
+        {"name": "start", "time": datetime(2026, 8, 19, 21, 59, 53, 948395)},
+        {"name": "custom", "time": "not-an-iso-time"},
+    ]
+    run = _validated_archive_run(run_payload)
+    assert run.model_dump(mode="json")["events"] == [
+        {"name": "start", "time": "2026-08-19T21:59:53.948395+00:00"},
+        {"name": "custom", "time": "not-an-iso-time"},
+    ]
 
 
 class FakeBulkExporter:

--- a/tests/test_bulk_export.py
+++ b/tests/test_bulk_export.py
@@ -5,15 +5,22 @@ from __future__ import annotations
 from datetime import date, datetime, timezone
 import json
 from pathlib import Path
-from typing import Any, Iterator, cast
+import time
+from typing import Any, Callable, Iterator, cast
 
+import pytest
 from conftest import create_run
 from langsmith.schemas import Run
 from langsmith_cli.archive.backfill import import_backfill_snapshot
 from langsmith_cli.archive.bulk import (
     BULK_EXPORT_FIELDS,
+    BulkExportFailedError,
+    BulkExportJob,
     BulkExportPartition,
     BulkExportSnapshot,
+    BulkExportStatus,
+    BulkExportTimeoutError,
+    JsonRequest,
     LangSmithBulkExporter,
 )
 from langsmith_cli.archive.models import ArchivePhase
@@ -106,6 +113,98 @@ def _job_payload(export_id: str, status: str, created_at: str) -> dict[str, obje
         "finished_at": created_at if status == "Completed" else None,
         "source_bulk_export_id": None,
     }
+
+
+def _job(status: BulkExportStatus) -> BulkExportJob:
+    return BulkExportJob(
+        export_id=NEW_EXPORT_ID,
+        destination_id=DESTINATION_ID,
+        project_id=PROJECT_ID,
+        start_time=TRACE_START,
+        end_time=TRACE_END,
+        status=status,
+        created_at=TRACE_START,
+        format_version="v2_beta",
+        compression="zstandard",
+        interval_hours=None,
+        filter=None,
+        export_fields=BULK_EXPORT_FIELDS,
+        all_experiments=False,
+    )
+
+
+def _destination_request(
+    method: str,
+    path: str,
+    params: dict[str, object] | None,
+    payload: dict[str, object] | None,
+) -> object:
+    assert method == "GET"
+    assert path == f"/api/v1/bulk-exports/destinations/{DESTINATION_ID}"
+    return {
+        "id": DESTINATION_ID,
+        "config": {
+            "bucket_name": "traces-dev",
+            "prefix": "langsmith/bulk",
+            "region": "us-east-1",
+        },
+    }
+
+
+def _exporter(
+    *,
+    request_json: JsonRequest = _destination_request,
+    timeout_seconds: float = 5 * 60 * 60,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> LangSmithBulkExporter:
+    return LangSmithBulkExporter(
+        api_url="https://api.smith.langchain.com",
+        api_key="test-key",
+        workspace_id=None,
+        destination_id=DESTINATION_ID,
+        archive_uri="s3://traces-dev/langsmith",
+        request_json=request_json,
+        poll_interval_seconds=0,
+        timeout_seconds=timeout_seconds,
+        monotonic=monotonic,
+    )
+
+
+def test_bulk_export_fails_fast_on_terminal_failure() -> None:
+    with pytest.raises(BulkExportFailedError, match="ended as Failed"):
+        _exporter().complete_export(_job(BulkExportStatus.FAILED))
+
+
+def test_bulk_export_wait_is_bounded() -> None:
+    clock = iter((0.0, 2.0))
+    exporter = _exporter(timeout_seconds=1, monotonic=lambda: next(clock))
+    with pytest.raises(BulkExportTimeoutError, match="did not finish in time"):
+        exporter.complete_export(_job(BulkExportStatus.CREATED))
+
+
+def test_bulk_export_rejects_destination_outside_archive() -> None:
+    def wrong_destination(
+        method: str,
+        path: str,
+        params: dict[str, object] | None,
+        payload: dict[str, object] | None,
+    ) -> object:
+        response = cast(
+            dict[str, object], _destination_request(method, path, params, payload)
+        )
+        response["config"] = {
+            "bucket_name": "traces-prd",
+            "prefix": "langsmith/bulk",
+        }
+        return response
+
+    with pytest.raises(ValueError, match="bucket does not match"):
+        _exporter(request_json=wrong_destination).begin_window(
+            project_id=PROJECT_ID,
+            start_time=TRACE_START,
+            end_time=TRACE_END,
+            excluded_export_ids=frozenset(),
+        )
 
 
 def test_bulk_export_adopts_latest_matching_job_and_excludes_prior_phase() -> None:

--- a/tests/test_bulk_export.py
+++ b/tests/test_bulk_export.py
@@ -1,0 +1,405 @@
+"""Managed LangSmith Bulk Export contracts and archive integration."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+import json
+from pathlib import Path
+from typing import Any, Iterator, cast
+
+from conftest import create_run
+from langsmith.schemas import Run
+from langsmith_cli.archive.backfill import import_backfill_snapshot
+from langsmith_cli.archive.bulk import (
+    BULK_EXPORT_FIELDS,
+    BulkExportPartition,
+    BulkExportSnapshot,
+    LangSmithBulkExporter,
+)
+from langsmith_cli.archive.models import ArchivePhase
+from langsmith_cli.archive.query import ArchiveRunQuery, query_archive_runs
+from langsmith_cli.archive.query import _normalize_run_payload
+from langsmith_cli.archive.storage import create_store
+from langsmith_cli.archive.sync import sync_project_day
+
+
+PROJECT_ID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+DESTINATION_ID = "22345678-1234-5678-1234-567812345678"
+PRIMARY_EXPORT_ID = "32345678-1234-5678-1234-567812345678"
+NEW_EXPORT_ID = "42345678-1234-5678-1234-567812345678"
+TRACE_START = datetime(2026, 8, 19, tzinfo=timezone.utc)
+TRACE_END = datetime(2026, 8, 20, tzinfo=timezone.utc)
+
+
+def test_bulk_json_strings_normalize_to_run_contracts() -> None:
+    payload = _normalize_run_payload(
+        {
+            "inputs": '{"prompt":"hello"}',
+            "outputs": '{"answer":"world"}',
+            "extra": '{"metadata":{"model":"gpt"}}',
+            "events": '[{"name":"start"}]',
+            "tags": '["production"]',
+            "parent_run_ids": "[]",
+            "feedback_stats": '{"quality":{"avg":1}}',
+            "error": "plain error string",
+        }
+    )
+    assert payload["inputs"] == {"prompt": "hello"}
+    assert payload["events"] == [{"name": "start"}]
+    assert payload["tags"] == ["production"]
+    assert payload["error"] == "plain error string"
+
+
+class FakeBulkExporter:
+    def __init__(
+        self, source: Path, export_id: str = NEW_EXPORT_ID, run_count: int = 1
+    ) -> None:
+        self.source = source
+        self.export_id = export_id
+        self.run_count = run_count
+        self.excluded_export_ids: frozenset[str] | None = None
+
+    def export_window(
+        self,
+        *,
+        project_id: str,
+        start_time: datetime,
+        end_time: datetime,
+        excluded_export_ids: frozenset[str],
+    ) -> BulkExportSnapshot:
+        self.excluded_export_ids = excluded_export_ids
+        return BulkExportSnapshot(
+            export_id=self.export_id,
+            start_time=start_time,
+            end_time=end_time,
+            run_count=self.run_count,
+            file_uris=(str(self.source),),
+        )
+
+
+class SingleRunClient:
+    def __init__(self, run: Run) -> None:
+        self.run = run
+
+    def list_runs(self, **kwargs: Any) -> Iterator[Run]:
+        return iter([self.run])
+
+
+def _job_payload(export_id: str, status: str, created_at: str) -> dict[str, object]:
+    return {
+        "bulk_export_destination_id": DESTINATION_ID,
+        "session_id": PROJECT_ID,
+        "all_experiments": False,
+        "start_time": TRACE_START.isoformat(),
+        "end_time": TRACE_END.isoformat(),
+        "filter": None,
+        "format": "Parquet",
+        "format_version": "v2_beta",
+        "compression": "zstandard",
+        "interval_hours": None,
+        "export_fields": list(BULK_EXPORT_FIELDS),
+        "id": export_id,
+        "tenant_id": "52345678-1234-5678-1234-567812345678",
+        "status": status,
+        "created_at": created_at,
+        "updated_at": created_at,
+        "finished_at": created_at if status == "Completed" else None,
+        "source_bulk_export_id": None,
+    }
+
+
+def test_bulk_export_adopts_latest_matching_job_and_excludes_prior_phase() -> None:
+    requests: list[tuple[str, str]] = []
+
+    def request(
+        method: str,
+        path: str,
+        params: dict[str, object] | None,
+        payload: dict[str, object] | None,
+    ) -> object:
+        requests.append((method, path))
+        if path == f"/api/v1/bulk-exports/destinations/{DESTINATION_ID}":
+            return {
+                "id": DESTINATION_ID,
+                "config": {
+                    "bucket_name": "traces-dev",
+                    "prefix": "langsmith/bulk",
+                    "region": "us-east-1",
+                },
+            }
+        if path == "/api/v1/bulk-exports":
+            return [
+                _job_payload(
+                    PRIMARY_EXPORT_ID, "Completed", "2026-08-20T01:00:00+00:00"
+                ),
+                _job_payload(NEW_EXPORT_ID, "Completed", "2026-08-21T01:00:00+00:00"),
+            ]
+        if path == f"/api/v1/bulk-exports/{NEW_EXPORT_ID}":
+            return _job_payload(NEW_EXPORT_ID, "Completed", "2026-08-21T01:00:00+00:00")
+        if path == f"/api/v1/bulk-exports/{NEW_EXPORT_ID}/runs":
+            return [
+                {
+                    "bulk_export_id": NEW_EXPORT_ID,
+                    "session_id": PROJECT_ID,
+                    "id": "62345678-1234-5678-1234-567812345678",
+                    "status": "Completed",
+                    "retry_number": 0,
+                    "errors": None,
+                    "created_at": "2026-08-21T01:00:00+00:00",
+                    "updated_at": "2026-08-21T01:01:00+00:00",
+                    "finished_at": "2026-08-21T01:01:00+00:00",
+                    "start_time": TRACE_START.isoformat(),
+                    "end_time": TRACE_END.isoformat(),
+                    "metadata": {
+                        "prefix": "langsmith/bulk",
+                        "start_time": TRACE_START.isoformat(),
+                        "end_time": TRACE_END.isoformat(),
+                        "execution_backend": "smithdb",
+                        "result": {
+                            "rows_written": 7,
+                            "exported_files": [
+                                "traces-dev/langsmith/bulk/export_id="
+                                f"{NEW_EXPORT_ID}/tenant_id=t/session_id={PROJECT_ID}/"
+                                "resource=runs/year=2026/month=8/day=19/runs.parquet"
+                            ],
+                            "export_path": "langsmith/bulk/export",
+                            "latest_cursor": "cursor",
+                            "pending_upload": None,
+                        },
+                    },
+                }
+            ]
+        raise AssertionError((method, path, params, payload))
+
+    exporter = LangSmithBulkExporter(
+        api_url="https://api.smith.langchain.com",
+        api_key="test-key",
+        workspace_id=None,
+        destination_id=DESTINATION_ID,
+        archive_uri="s3://traces-dev/langsmith",
+        request_json=request,
+        poll_interval_seconds=0,
+    )
+    snapshot = exporter.export_window(
+        project_id=PROJECT_ID,
+        start_time=TRACE_START,
+        end_time=TRACE_END,
+        excluded_export_ids=frozenset({PRIMARY_EXPORT_ID}),
+    )
+
+    assert snapshot.export_id == NEW_EXPORT_ID
+    assert snapshot.run_count == 7
+    assert snapshot.file_uris == (
+        "s3://traces-dev/langsmith/bulk/export_id="
+        f"{NEW_EXPORT_ID}/tenant_id=t/session_id={PROJECT_ID}/"
+        "resource=runs/year=2026/month=8/day=19/runs.parquet",
+    )
+    assert ("POST", "/api/v1/bulk-exports") not in requests
+
+
+def test_bulk_snapshot_integrates_with_canonical_reconciliation(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import duckdb
+
+    run = create_run(outputs={"source": "bulk"}, tags=["bulk-provider"])
+    source = tmp_path / "bulk.parquet"
+    rows = tmp_path / "bulk.json"
+    payload = run.model_dump(mode="json")
+    for field in (
+        "extra",
+        "inputs",
+        "outputs",
+        "feedback_stats",
+        "events",
+        "tags",
+        "parent_run_ids",
+    ):
+        if field in payload and payload[field] is not None:
+            payload[field] = json.dumps(payload[field])
+    rows.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+    connection = duckdb.connect()
+    try:
+        source_sql = str(source).replace("'", "''")
+        connection.execute(
+            f"COPY (SELECT * FROM read_json_auto(?)) TO '{source_sql}' "
+            "(FORMAT PARQUET)",
+            [str(rows)],
+        )
+    finally:
+        connection.close()
+
+    archive_uri = str(tmp_path / "archive")
+    monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
+    exporter = FakeBulkExporter(source)
+    manifest = sync_project_day(
+        None,
+        create_store(archive_uri),
+        project_id=PROJECT_ID,
+        project_name="dev/agent",
+        trace_date=date(2026, 8, 19),
+        phase=ArchivePhase.RECONCILIATION,
+        bulk_exporter=exporter,
+    )
+
+    assert manifest.reconciliation is not None
+    assert manifest.reconciliation.generation_id == NEW_EXPORT_ID
+    assert manifest.canonical_run_count == 1
+    assert exporter.excluded_export_ids == frozenset()
+    archived = query_archive_runs(ArchiveRunQuery(project="dev/agent", limit=0))
+    assert archived[0].outputs == {"source": "bulk"}
+    tagged = query_archive_runs(
+        ArchiveRunQuery(project="dev/agent", tags=("bulk-provider",), limit=0)
+    )
+    assert len(tagged) == 1
+
+
+def test_bulk_reconciliation_unifies_runs_api_and_v2_json_column_types(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A Bulk v2 reconciliation must replace native Runs API rows by run ID."""
+    import duckdb
+
+    primary_run = create_run(outputs={"version": "runs-api"}, tags=["primary"])
+    reconciled_run = primary_run.model_copy(
+        update={"outputs": {"version": "bulk-v2"}, "tags": ["reconciled"]}
+    )
+    late_child = create_run(
+        id_str="62345678-1234-5678-1234-567812345678",
+        parent_run_id=str(primary_run.id),
+        trace_id=str(primary_run.id),
+        outputs={"late": True},
+    )
+    json_rows = tmp_path / "bulk-mixed.json"
+    payloads: list[dict[str, object]] = []
+    for run in (reconciled_run, late_child):
+        payload = run.model_dump(mode="json")
+        for field in (
+            "extra",
+            "inputs",
+            "outputs",
+            "feedback_stats",
+            "events",
+            "tags",
+            "parent_run_ids",
+        ):
+            if field in payload and payload[field] is not None:
+                payload[field] = json.dumps(payload[field])
+        payloads.append(payload)
+    json_rows.write_text(
+        "".join(json.dumps(payload) + "\n" for payload in payloads),
+        encoding="utf-8",
+    )
+    bulk_parquet = tmp_path / "bulk-mixed.parquet"
+    connection = duckdb.connect()
+    try:
+        bulk_parquet_sql = str(bulk_parquet).replace("'", "''")
+        connection.execute(
+            f"COPY (SELECT * FROM read_json_auto(?)) TO '{bulk_parquet_sql}' "
+            "(FORMAT PARQUET)",
+            [str(json_rows)],
+        )
+    finally:
+        connection.close()
+
+    archive_uri = str(tmp_path / "archive")
+    monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
+    store = create_store(archive_uri)
+    sync_project_day(
+        SingleRunClient(primary_run),
+        store,
+        project_id=PROJECT_ID,
+        project_name="dev/agent",
+        trace_date=date(2026, 8, 19),
+        phase=ArchivePhase.PRIMARY,
+    )
+    exporter = FakeBulkExporter(bulk_parquet, run_count=2)
+    manifest = sync_project_day(
+        None,
+        store,
+        project_id=PROJECT_ID,
+        project_name="dev/agent",
+        trace_date=date(2026, 8, 19),
+        phase=ArchivePhase.RECONCILIATION,
+        bulk_exporter=exporter,
+    )
+
+    assert manifest.canonical_run_count == 2
+    archived = query_archive_runs(ArchiveRunQuery(project="dev/agent", limit=0))
+    assert {str(run.id) for run in archived} == {
+        str(primary_run.id),
+        str(late_child.id),
+    }
+    root = next(run for run in archived if run.id == primary_run.id)
+    assert root.outputs == {"version": "bulk-v2"}
+    assert root.tags == ["reconciled"]
+
+
+def test_range_backfill_publishes_daily_partitions_and_resumes(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import duckdb
+
+    files: list[Path] = []
+    partitions: list[BulkExportPartition] = []
+    for offset, day in enumerate((19, 20)):
+        run = create_run(
+            id_str=f"{offset + 1}2345678-1234-5678-1234-567812345678",
+            outputs={"day": day},
+        )
+        rows = tmp_path / f"day-{day}.json"
+        parquet = tmp_path / f"day-{day}.parquet"
+        rows.write_text(run.model_dump_json() + "\n", encoding="utf-8")
+        connection = duckdb.connect()
+        try:
+            parquet_sql = str(parquet).replace("'", "''")
+            connection.execute(
+                f"COPY (SELECT * FROM read_json_auto(?)) TO '{parquet_sql}' "
+                "(FORMAT PARQUET)",
+                [str(rows)],
+            )
+        finally:
+            connection.close()
+        files.append(parquet)
+        start = datetime(2026, 8, day, tzinfo=timezone.utc)
+        partitions.append(
+            BulkExportPartition(
+                start_time=start,
+                end_time=start.replace(day=day + 1),
+                run_count=1,
+                file_uris=(str(parquet),),
+            )
+        )
+
+    snapshot = BulkExportSnapshot(
+        export_id=NEW_EXPORT_ID,
+        start_time=datetime(2026, 8, 19, tzinfo=timezone.utc),
+        end_time=datetime(2026, 8, 21, tzinfo=timezone.utc),
+        run_count=2,
+        file_uris=tuple(str(path) for path in files),
+        partitions=tuple(partitions),
+    )
+    archive_uri = str(tmp_path / "archive")
+    monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
+    store = create_store(archive_uri)
+
+    first = import_backfill_snapshot(
+        store,
+        project_id=PROJECT_ID,
+        project_name="dev/agent",
+        snapshot=snapshot,
+    )
+    second = import_backfill_snapshot(
+        store,
+        project_id=PROJECT_ID,
+        project_name="dev/agent",
+        snapshot=snapshot,
+    )
+
+    assert first.imported_days == 2
+    assert first.skipped_days == 0
+    assert first.canonical_run_count == 2
+    assert second.imported_days == 0
+    assert second.skipped_days == 2
+    archived = query_archive_runs(ArchiveRunQuery(project="dev/agent", limit=0))
+    assert {cast(dict[str, object], run.outputs)["day"] for run in archived} == {19, 20}

--- a/tests/test_bulk_export.py
+++ b/tests/test_bulk_export.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Iterator, cast
 
 import pytest
 from conftest import create_run
+from langsmith import Client
 from langsmith.schemas import Run
 from langsmith_cli.archive.backfill import import_backfill_snapshot
 from langsmith_cli.archive.bulk import (
@@ -204,6 +205,365 @@ def test_bulk_export_rejects_destination_outside_archive() -> None:
             start_time=TRACE_START,
             end_time=TRACE_END,
             excluded_export_ids=frozenset(),
+        )
+
+
+def test_bulk_export_creates_exact_v2_job_when_none_can_be_adopted() -> None:
+    created_payload: dict[str, object] = {}
+
+    def request(
+        method: str,
+        path: str,
+        params: dict[str, object] | None,
+        payload: dict[str, object] | None,
+    ) -> object:
+        if path.startswith("/api/v1/bulk-exports/destinations/"):
+            return _destination_request(method, path, params, payload)
+        if method == "GET" and path == "/api/v1/bulk-exports":
+            assert params == {"limit": 1000, "offset": 0}
+            return []
+        if method == "POST" and path == "/api/v1/bulk-exports":
+            assert payload is not None
+            created_payload.update(payload)
+            return _job_payload(NEW_EXPORT_ID, "Created", TRACE_START.isoformat())
+        raise AssertionError((method, path))
+
+    job = _exporter(request_json=request).begin_window(
+        project_id=PROJECT_ID,
+        start_time=TRACE_START,
+        end_time=TRACE_END,
+        excluded_export_ids=frozenset(),
+    )
+
+    assert job.export_id == NEW_EXPORT_ID
+    assert created_payload == {
+        "bulk_export_destination_id": DESTINATION_ID,
+        "session_id": PROJECT_ID,
+        "start_time": TRACE_START.isoformat(),
+        "end_time": TRACE_END.isoformat(),
+        "format_version": "v2_beta",
+        "compression": "zstandard",
+        "export_fields": list(BULK_EXPORT_FIELDS),
+    }
+
+
+def test_bulk_export_http_adapter_sends_workspace_headers_and_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    class FakeResponse:
+        def __init__(self, payload: object) -> None:
+            self.payload = payload
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> object:
+            return self.payload
+
+    def request(method: str, url: str, **kwargs: object) -> FakeResponse:
+        calls.append({"method": method, "url": url, **kwargs})
+        if url.endswith(f"/destinations/{DESTINATION_ID}"):
+            return FakeResponse(
+                {
+                    "id": DESTINATION_ID,
+                    "config": {
+                        "bucket_name": "traces-dev",
+                        "prefix": "langsmith/bulk",
+                    },
+                }
+            )
+        if method == "GET":
+            return FakeResponse([])
+        return FakeResponse(
+            _job_payload(NEW_EXPORT_ID, "Created", TRACE_START.isoformat())
+        )
+
+    monkeypatch.setattr("httpx.request", request)
+    exporter = LangSmithBulkExporter(
+        api_url="https://self-hosted.example/api",
+        api_key="test-key",
+        workspace_id="workspace-id",
+        destination_id=DESTINATION_ID,
+        archive_uri="s3://traces-dev/langsmith",
+    )
+    exporter.begin_window(
+        project_id=PROJECT_ID,
+        start_time=TRACE_START,
+        end_time=TRACE_END,
+        excluded_export_ids=frozenset(),
+    )
+
+    assert [call["method"] for call in calls] == ["GET", "GET", "POST"]
+    assert all(
+        call["headers"] == {"X-API-Key": "test-key", "X-Tenant-Id": "workspace-id"}
+        for call in calls
+    )
+    assert calls[1]["params"] == {"limit": "1000", "offset": "0"}
+    assert calls[2]["json"] is not None
+    assert all(
+        str(call["url"]).startswith("https://self-hosted.example/api/v1")
+        for call in calls
+    )
+
+
+@pytest.mark.parametrize(
+    ("api_key", "poll_interval_seconds", "timeout_seconds", "message"),
+    (
+        ("", 10, 5 * 60 * 60, "API key must not be empty"),
+        ("test-key", -1, 5 * 60 * 60, "poll interval must be non-negative"),
+        ("test-key", 10, 0, "timeout must be positive"),
+    ),
+)
+def test_bulk_export_rejects_invalid_operator_configuration(
+    api_key: str,
+    poll_interval_seconds: float,
+    timeout_seconds: float,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        LangSmithBulkExporter(
+            api_url="https://api.smith.langchain.com",
+            api_key=api_key,
+            workspace_id=None,
+            destination_id=DESTINATION_ID,
+            archive_uri="s3://traces-dev/langsmith",
+            poll_interval_seconds=poll_interval_seconds,
+            timeout_seconds=timeout_seconds,
+        )
+
+
+def test_bulk_export_builds_from_langsmith_client() -> None:
+    client = Client(
+        api_url="https://api.smith.langchain.com",
+        api_key="test-key",
+    )
+    exporter = LangSmithBulkExporter.from_langsmith_client(
+        client,
+        destination_id=DESTINATION_ID,
+        archive_uri="s3://traces-dev/langsmith",
+    )
+    assert isinstance(exporter, LangSmithBulkExporter)
+    with pytest.raises(TypeError, match="requires a LangSmith Client"):
+        LangSmithBulkExporter.from_langsmith_client(
+            object(),
+            destination_id=DESTINATION_ID,
+            archive_uri="s3://traces-dev/langsmith",
+        )
+
+
+@pytest.mark.parametrize(
+    ("api_url", "destination_id", "archive_uri", "message"),
+    (
+        (
+            "ftp://api.smith.langchain.com",
+            DESTINATION_ID,
+            "s3://traces-dev/langsmith",
+            "must use HTTP or HTTPS",
+        ),
+        (
+            "https://api.smith.langchain.com",
+            "{" + PROJECT_ID + "}",
+            "s3://traces-dev/langsmith",
+            "canonical UUID format",
+        ),
+        (
+            "https://api.smith.langchain.com",
+            DESTINATION_ID,
+            "https://traces-dev/langsmith",
+            "requires an s3:// archive URI",
+        ),
+        (
+            "https://api.smith.langchain.com",
+            DESTINATION_ID,
+            "s3://traces-dev",
+            "requires a bucket prefix",
+        ),
+    ),
+)
+def test_bulk_export_rejects_unsafe_identity_and_storage_configuration(
+    api_url: str, destination_id: str, archive_uri: str, message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        LangSmithBulkExporter(
+            api_url=api_url,
+            api_key="test-key",
+            workspace_id=None,
+            destination_id=destination_id,
+            archive_uri=archive_uri,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    (
+        ("end_time", 1, "end_time must be a string"),
+        ("interval_hours", "1", "interval_hours must be an integer or null"),
+        ("filter", 1, "filter must be a string or null"),
+        ("all_experiments", "false", "all_experiments must be a boolean"),
+    ),
+)
+def test_bulk_export_rejects_malformed_adoption_jobs(
+    field: str, value: object, message: str
+) -> None:
+    malformed = _job_payload(NEW_EXPORT_ID, "Created", TRACE_START.isoformat())
+    malformed[field] = value
+
+    def request(
+        method: str,
+        path: str,
+        params: dict[str, object] | None,
+        payload: dict[str, object] | None,
+    ) -> object:
+        if path.startswith("/api/v1/bulk-exports/destinations/"):
+            return _destination_request(method, path, params, payload)
+        return [malformed]
+
+    with pytest.raises(ValueError, match=message):
+        _exporter(request_json=request).begin_window(
+            project_id=PROJECT_ID,
+            start_time=TRACE_START,
+            end_time=TRACE_END,
+            excluded_export_ids=frozenset(),
+        )
+
+
+def _partition_payload(
+    *, rows_written: int, exported_files: list[str], status: str = "Completed"
+) -> dict[str, object]:
+    return {
+        "id": "62345678-1234-5678-1234-567812345678",
+        "status": status,
+        "metadata": {
+            "start_time": TRACE_START.isoformat(),
+            "end_time": TRACE_END.isoformat(),
+            "result": {
+                "rows_written": rows_written,
+                "exported_files": exported_files,
+            },
+        },
+    }
+
+
+def test_bulk_export_polls_then_accepts_complete_empty_partition() -> None:
+    polled: list[str] = []
+
+    def request(
+        method: str,
+        path: str,
+        params: dict[str, object] | None,
+        payload: dict[str, object] | None,
+    ) -> object:
+        if path.startswith("/api/v1/bulk-exports/destinations/"):
+            return _destination_request(method, path, params, payload)
+        if path == f"/api/v1/bulk-exports/{NEW_EXPORT_ID}":
+            polled.append(path)
+            return _job_payload(NEW_EXPORT_ID, "Completed", TRACE_START.isoformat())
+        if path == f"/api/v1/bulk-exports/{NEW_EXPORT_ID}/runs":
+            return [_partition_payload(rows_written=0, exported_files=[])]
+        raise AssertionError((method, path))
+
+    snapshot = _exporter(request_json=request).complete_export(
+        _job(BulkExportStatus.CREATED)
+    )
+
+    assert polled == [f"/api/v1/bulk-exports/{NEW_EXPORT_ID}"]
+    assert snapshot.run_count == 0
+    assert snapshot.file_uris == ()
+    assert len(snapshot.partitions) == 1
+
+
+@pytest.mark.parametrize(
+    ("partition", "message"),
+    (
+        (
+            _partition_payload(rows_written=1, exported_files=[]),
+            "did not publish Parquet files",
+        ),
+        (
+            _partition_payload(
+                rows_written=1,
+                exported_files=["traces-prd/langsmith/bulk/out.parquet"],
+            ),
+            "outside the configured destination",
+        ),
+        (
+            _partition_payload(rows_written=0, exported_files=[], status="Failed"),
+            "partition .* is Failed",
+        ),
+    ),
+)
+def test_bulk_export_rejects_invalid_completed_partitions(
+    partition: dict[str, object], message: str
+) -> None:
+    def request(
+        method: str,
+        path: str,
+        params: dict[str, object] | None,
+        payload: dict[str, object] | None,
+    ) -> object:
+        if path.startswith("/api/v1/bulk-exports/destinations/"):
+            return _destination_request(method, path, params, payload)
+        if path == f"/api/v1/bulk-exports/{NEW_EXPORT_ID}/runs":
+            return [partition]
+        raise AssertionError((method, path))
+
+    error = BulkExportFailedError if partition["status"] == "Failed" else ValueError
+    with pytest.raises(error, match=message):
+        _exporter(request_json=request).complete_export(
+            _job(BulkExportStatus.COMPLETED)
+        )
+
+
+@pytest.mark.parametrize(
+    ("result", "message"),
+    (
+        (None, "partition has no result"),
+        ({"rows_written": -1, "exported_files": []}, "must be non-negative"),
+        (
+            {"rows_written": 1, "exported_files": [123]},
+            "file path must be a string",
+        ),
+    ),
+)
+def test_bulk_export_rejects_malformed_partition_results(
+    result: object, message: str
+) -> None:
+    partition = _partition_payload(rows_written=0, exported_files=[])
+    metadata = cast(dict[str, object], partition["metadata"])
+    metadata["result"] = result
+
+    def request(
+        method: str,
+        path: str,
+        params: dict[str, object] | None,
+        payload: dict[str, object] | None,
+    ) -> object:
+        if path.startswith("/api/v1/bulk-exports/destinations/"):
+            return _destination_request(method, path, params, payload)
+        return [partition]
+
+    with pytest.raises(ValueError, match=message):
+        _exporter(request_json=request).complete_export(
+            _job(BulkExportStatus.COMPLETED)
+        )
+
+
+def test_bulk_export_rejects_missing_partition_coverage() -> None:
+    def request(
+        method: str,
+        path: str,
+        params: dict[str, object] | None,
+        payload: dict[str, object] | None,
+    ) -> object:
+        if path.startswith("/api/v1/bulk-exports/destinations/"):
+            return _destination_request(method, path, params, payload)
+        return []
+
+    with pytest.raises(ValueError, match="has no partition runs"):
+        _exporter(request_json=request).complete_export(
+            _job(BulkExportStatus.COMPLETED)
         )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -396,7 +396,7 @@ wheels = [
 
 [[package]]
 name = "langsmith-cli"
-version = "0.10.3"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
@@ -407,6 +407,7 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "pytz" },
     { name = "pyyaml" },
     { name = "rich" },
 ]
@@ -434,6 +435,7 @@ requires-dist = [
     { name = "platformdirs", specifier = ">=4.0" },
     { name = "pydantic", specifier = ">=2.11.0" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
+    { name = "pytz", specifier = ">=2025.2" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "rich", specifier = ">=14.2.0" },
 ]
@@ -795,6 +797,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.3.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/48/fb042503b6ca6cd271261dc559fd6432f7d8c713153e9ec5c591af4dfc1c/pytz-2026.3.post1.tar.gz", hash = "sha256:2211d3fcf9a797d3405cac96ac7f61d80e6a644f72a3309607282fe8a2010c5d", size = 319745, upload-time = "2026-07-25T15:12:07.385Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/7b/39c34ca613b0b198cb866466651b26b045e2009864c5183c979a3b83f383/pytz-2026.3.post1-py2.py3-none-any.whl", hash = "sha256:dd95840dd199baea12d9cc096a1d452caa6596a1c1e4b5f3dbd1541855d5e815", size = 508283, upload-time = "2026-07-25T15:12:05.782Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Today, exporting more than a year of LangSmith traces through the Runs API is too slow and fragile, and the first bulk-backfill implementation still serialized canonical publication behind project completion order. This PR adds a managed Bulk Export provider, resumable historical backfill, and DuckDB/S3 query path, so trace scans move off the live API and a stopped operator process can resume without duplicate exports or mutable archive days.

## Before / after

```text
BEFORE
LangSmith Runs API -> client pagination -> one project/day at a time -> local Parquet
                         134.3 s for one 9,257-run day

AFTER
LangSmith Bulk Export -> hourly Parquet in S3 -> strict contract validation
                                             -> 8 bounded project workers
                                             -> immutable daily canonical + manifest CAS
                                             -> DuckDB scans / LangSmith point reads
```

This PR is both a feature and a bug fix:

- **Feature:** establish managed Bulk Export as an archive provider and add `archive backfill` plus partition-pruned archived point reads.
- **Bug fix found by reality:** strengthen the intended resumability invariant so queued or failed projects cannot hide already-complete peers, and independent projects compact concurrently.

## Measured impact

Higher is better for publication throughput; lower is better for query latency.

| Measurement | Before | After | Observed change |
|---|---:|---:|---:|
| Canonical publication, project-days/min/environment | ~15 | 116-124 | 7.7-8.3x higher |
| One-time backfill, project-days/min aggregate | ~45 (three serial env processes) | 632 (six disjoint shards, 48 bounded workers) | ~14x higher |
| Full-day enumeration, 9,257 runs, end-to-end CLI | 134.3 s API pagination | 10.4-10.8 s bounded-memory DuckDB/S3 | ~12.5-12.9x lower latency |
| Same DuckDB scan after archive discovery | — | 2.1-2.3 s | engine-only measurement |
| Point run read | 0.7-1.7 s API | 4.5-5.0 s DuckDB/S3 | API remains faster |
| Root + six children | 4.3 s API | 5.8 s DuckDB/S3 | API remains faster |
| Dev archive completion status | full manifest audit >168.42 s | key-derived summary 8.37 s | >20x lower latency |

Publication throughput is from the live 399-day Gigaverse backfill: an initial ~10-minute sample with one 8-worker process per environment published 1,169 dev, 1,177 staging, and 1,239 production manifests. A later one-minute sample used six disjoint project shards and 48 aggregate workers on a 6-core host and sealed 632 project-days without increasing writers per project. The old foreground path published roughly one project-day every four seconds. The end-to-end query row includes CLI startup, S3 manifest discovery, and a 1 GiB DuckDB memory limit; the engine-only row measures the partition-pruned scan after discovery. The API comparison is pagination, not a server-side LangSmith aggregation. The supported product split is DuckDB/S3 for scans and analytics, LangSmith API for interactive point reads.

## Data flow and reuse

- Reuses the existing raw -> canonical -> manifest archive contract; Bulk Export is a provider, not a second archive format.
- Reuses `sync_project_day` for backfill publication, including manifest compare-and-swap and sealed-day behavior.
- Defines provider-dependent JSON columns once for canonicalization, query normalization, and realistic fixtures.
- Normalizes event timestamps through one UTC-preserving helper before and after SDK validation.
- Routes sync and backfill projects through one config snapshot and one identity-deduplicating selector.
- `complete_export` delegates to the batch completion iterator; single-job and batch callers share one status/timeout/identity implementation.

## Invariants

| ID | Guarantee | Enforcement point | Regression proof |
|---|---|---|---|
| I1 | Every job/snapshot has canonical IDs and a non-empty UTC window; adoption additionally requires the exact destination/project/format/compression/29-field contract | dataclass `__post_init__`, `LangSmithBulkExporter._matches_window`, and every-poll identity recheck | direct-model, create/adopt, and polled-identity-drift tests |
| I2 | Every exported file stays inside a normalized configured S3 prefix | destination validation plus `_require_normalized_s3_path` | destination, traversal, metacharacter, and file-path tests |
| I3 | Completed partitions exactly cover the UTC window and row IDs are unique | `_validate_partition_coverage` and DuckDB count/distinct checks | missing/gapped/overlapping partition and duplicate-ID tests |
| I4 | Mixed providers produce one queryable canonical schema | `ARCHIVE_JSON_COLUMNS` canonicalization | Runs API + Bulk v2 reconciliation integration test |
| I5 | A sealed project-day is immutable; stale writers cannot replace a newer manifest | sealed check and storage compare-and-swap | backfill resume and concurrent-publication tests |
| I6 | Completion order never controls harvest order; ready peers are durable before a failed peer aborts the batch | `complete_exports` removes/yields every ready job before reporting terminal peers | queued-first and failed-first batch tests |
| I7 | One invocation schedules at most one import worker per project and export | `_routed_projects` rejects duplicate project IDs and export mapping rejects duplicate export IDs before worker submission | both duplicate-ID tests and two-worker barrier journey |
| I8 | API and archive full traces retain the same semantic values and topology | archive read normalization restores Bulk nested input, UTC event offsets, and derived child IDs without discarding explicit nulls | real three-trace comparison plus API/archive CLI journey test |
| I9 | Completion counts never require one S3 GET per manifest | `status --summary` parses normalized immutable keys and explicitly reports `manifest_contents_verified: false`; full audits and queries share bounded metadata reads | no-GET summary test and concurrent full-audit test |
| I10 | Concurrent archive connections have bounded memory and never share mutable spill state | every connection has a 1 GiB memory limit and owns a unique temporary directory for exactly its lifetime | `test_duckdb_resources_are_bounded_and_unique_to_each_project_staging_area` plus failed-shard live replay |

## Live proof

Against the real Gigaverse LangSmith workspace and dev S3:

- exported `dev/chat_message_quality_service` for 2026-08-19 UTC;
- 24/24 hourly partitions, 9,257 rows, 13 Parquet files;
- Bulk IDs vs Runs API IDs: 9,257 vs 9,257, symmetric difference 0/0;
- two-day canonical result: 26,724 rows; rerun skipped the sealed day;
- three real roots (six children each) matched API topology and every non-null value after the archive reader restored Bulk nested input, UTC event offsets, and derived child IDs; remaining raw differences were only Bulk schema padding (`missing` versus `null`: 481/485/481 fields), with canonical SHA-256 equality for all three;
- live red-team findings fixed: server-normalized fields, missing `pytz`, Bulk VARCHAR JSON, provider schema union, tag predicates, point-read partition pruning, head-of-line blocking, serial publication, non-normalized S3 paths, status doing one sequential S3 GET per manifest, and cross-process DuckDB spill-file collisions.

### Historical run status

The 2025-07-17 inclusive to 2026-08-20 exclusive inventory is **146 projects** (60 dev, 39 staging, 47 production), each with a 399-day exact-window matrix: **58,254 manifests** total. The earlier journal-derived 147-project estimate was wrong; the authoritative completed staging result contains 39 projects. At the latest S3 key-derived audit, 57,057/58,254 manifests were present (97.9%): staging was exactly complete at 15,561/15,561, dev had one 300-day gap, and production had 897 manifests remaining across six partially published projects plus one not-yet-published project. Every key was structurally valid.

One dev shard failed after a shared DuckDB spill file was truncated. The fixed replay adopted every completed export and reported 399 already-sealed days without duplicate publication. That replay then exposed a 10.4 GiB RSS long-tail peak, so the current head also enforces a 1 GiB limit per DuckDB connection. Inspection confirmed the tail is correctly partition-pruned, not rescanning the year: individual outlier days contain about 2.0 GiB dev and 1.97 GiB production Parquet and therefore take multi-minute compaction/upload. The remaining old-process compactions are still running; this PR stays draft until the complete matrix is sealed, final bounded-memory replay/query proof passes, and temporary writer credentials are removed.

## Documentation

- [README archive entry point](https://github.com/gigaverse-app/langsmith-cli/blob/codex/langsmith-bulk-export/README.md): first backfill and DuckDB query;
- [operator reference](https://github.com/gigaverse-app/langsmith-cli/blob/codex/langsmith-bulk-export/skills/langsmith/references/archive.md#historical-backfill): prerequisites, progress semantics, safe sharding, completion proof, restart, and cleanup;
- [design](https://github.com/gigaverse-app/langsmith-cli/blob/codex/langsmith-bulk-export/docs/TRACE_ARCHIVE_DESIGN.md#historical-backfill-execution-model): remote/local concurrency domains, one-writer invariant, storage publication order, and measured scaling.

## Verification

- full suite on the bounded-memory head: **1,409 passed** in 79.66s;
- focused archive/invariant/command suite after spill isolation: **126 passed**;
- Ruff: clean;
- Pyright: 0 errors;
- pre-commit hooks: clean;
- pinned-head GitHub Actions across Python 3.12/3.13 on Linux, macOS, and Windows plus package, dependency, lint, and patch coverage: green;
- live Bulk/S3/DuckDB checks above.

## Operational constraints

- Bulk Export cannot recover traces already purged by LangSmith retention.
- `--bulk-export-timeout-hours 73` is an idle safety ceiling: it fires only after no project completes for that interval; it is not expected duration.
- `--import-workers` defaults to 8 and caps at 32; increase only after measuring DuckDB/S3 and host memory.
- LangSmith Cloud needs separate S3 destination credentials. Kubernetes IRSA authorizes the in-cluster compactor, not the remote exporter.
- Bulk Parquet schema union cannot preserve the distinction between every absent nested member and an explicit null. The CLI preserves explicit nulls; provider parity is semantic modulo missing/null object members, not universally raw-byte identity.

Related: #161
