### PR TITLE
fix: expose release history on PyPI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "LangSmith CLI plugin marketplace",
-    "version": "0.11.0"
+    "version": "0.11.1"
   },
   "plugins": [
     {
       "name": "langsmith-cli",
       "source": "./",
       "description": "A context-efficient interface for LangSmith observability and evaluations.",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "author": {
         "name": "Gigaverse",
         "email": "aviadr1@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith-cli",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "A context-efficient interface for LangSmith observability and evaluations.",
   "author": {
     "name": "Aviad Rozenhek",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "langsmith-cli"
 # IMPORTANT: When bumping this version, also update .claude-plugin/plugin.json
-version = "0.11.0"
+version = "0.11.1"
 description = "Context-efficient CLI for LangSmith. Built for humans and agents."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -43,10 +43,11 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/aviadr1/langsmith-cli"
-Repository = "https://github.com/aviadr1/langsmith-cli"
-Issues = "https://github.com/aviadr1/langsmith-cli/issues"
-Documentation = "https://github.com/aviadr1/langsmith-cli#readme"
+Homepage = "https://github.com/gigaverse-app/langsmith-cli"
+Repository = "https://github.com/gigaverse-app/langsmith-cli"
+Issues = "https://github.com/gigaverse-app/langsmith-cli/issues"
+Documentation = "https://github.com/gigaverse-app/langsmith-cli#readme"
+Changelog = "https://github.com/gigaverse-app/langsmith-cli/releases"
 
 [dependency-groups]
 dev = [

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -1,0 +1,13 @@
+from importlib.metadata import metadata
+
+
+CANONICAL_REPOSITORY_URL = "https://github.com/gigaverse-app/langsmith-cli"
+
+
+def test_package_metadata_links_to_canonical_repository_and_release_history() -> None:
+    """INVARIANT: PyPI exposes the canonical repository and its release history."""
+    project_urls = metadata("langsmith-cli").get_all("Project-URL")
+
+    assert project_urls is not None
+    assert f"Repository, {CANONICAL_REPOSITORY_URL}" in project_urls
+    assert f"Changelog, {CANONICAL_REPOSITORY_URL}/releases" in project_urls

--- a/uv.lock
+++ b/uv.lock
@@ -396,7 +396,7 @@ wheels = [
 
 [[package]]
 name = "langsmith-cli"
-version = "0.11.0"
+version = "0.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Today, the PyPI project page points at the old personal repository and does not expose the project's release history. This PR publishes the canonical Gigaverse project URLs and an explicit Changelog link, so package consumers can reach previous releases directly from PyPI.

## Changes

- point Homepage, Repository, Issues, and Documentation metadata at `gigaverse-app/langsmith-cli`
- add a `Changelog` project URL targeting the GitHub releases index
- bump all package/plugin manifests to `0.11.1` so PyPI can receive the immutable metadata correction
- add a regression test against the installed distribution metadata

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `TMPDIR=/tmp TEMP=/tmp TMP=/tmp uv run pytest` — 1,410 passed
- `uv build --out-dir /tmp/langsmith-cli-0.11.1-dist`
- inspected wheel `METADATA`: version `0.11.1` and all five expected `Project-URL` entries are present

## Invariant

Published package metadata must expose the canonical repository and its release history. `tests/test_package_metadata.py` enforces this against the installed distribution metadata.
