### PR TITLE
Replicate exact LangSmith datasets across cloud, archive, and local

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,14 @@ if run.status == RunStatus.ERROR:
 
 The CLI must start instantly.
 
-* **RULE:** NO top-level imports of heavy libraries (`langsmith`, `pandas`, `pydantic`, `rich`).
-* **RULE:** Imports must be placed **inside** the command function or a dedicated getter function.
+* **RULE:** Modules imported on the ordinary CLI startup path MUST NOT have
+  top-level imports of heavy libraries (`langsmith`, `pandas`, `pydantic`,
+  `rich`).
+* **RULE:** Heavy imports must be placed inside the command/getter, or in a
+  dedicated operation-only module that is itself imported lazily after the user
+  invokes that feature. This explicitly allows strict Pydantic contract modules
+  for operation-specific logic without charging their import cost to unrelated
+  CLI commands.
 
 **❌ Bad (Eager):**
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,10 @@ langsmith-cli runs watch --project production
 # Export examples to JSONL (using --output for reliable file writing)
 langsmith-cli examples list --dataset my-dataset --output examples.jsonl
 
+# Freeze an exact dataset version locally, then work offline through the same facade
+langsmith-cli --json datasets pull my-dataset --to local
+langsmith-cli --json examples list --dataset my-dataset --source local
+
 # Upload to new dataset
 langsmith-cli datasets push examples.jsonl --dataset production-eval
 ```

--- a/docs/TRACE_SOURCES_DESIGN.md
+++ b/docs/TRACE_SOURCES_DESIGN.md
@@ -1,0 +1,1178 @@
+# Unified trace sources: one CLI over cloud, archive, and local data
+
+**Status:** Proposed · **Date:** 2026-08-22 · **Goal:** Make live LangSmith,
+durable archives, and disposable local trace caches queryable through one honest CLI
+contract without hiding their different freshness and completeness guarantees.
+
+## TL;DR
+
+1. **Use one named source at a time.** `runs list`, `search`, `get`, and
+   `get-latest` should accept `--source <name>` and construct the same typed query
+   for cloud, archive, and local data. Cloud remains the default for backward
+   compatibility.
+2. **Choose by intent, not by storage technology.** Cloud is for the freshest data
+   and live-only operations; an archive is for durable, shared historical truth;
+   local is a disposable cache for repeated analysis and offline intermediate work.
+3. **Local is an accumulating inventory, not a replaceable snapshot.** Pulling or
+   importing traces adds or refreshes those trace bundles without removing unrelated
+   cached traces. The cache has no automatic size limit; users remove individual
+   traces or evict it when it stops being useful.
+4. **Defer multi-source result merging.** It could bridge live retention and archive
+   history, but overlap, freshness, identity, ordering, and coverage make an
+   apparently simple union unsafe. A source-comparison command has earlier value and
+   lower semantic risk.
+5. **Adopt LangSmith datasets wholesale.** There is no parallel collection abstraction.
+   Cloud, archive, and local expose datasets, examples, versions/tags, schemas,
+   transformations, splits, metadata, attachments, and `source_run_id` with the same
+   meanings. Full traces remain separate data that may be materialized explicitly.
+
+| Decision | Recommendation |
+|---|---|
+| User-facing selector | Named `--source`; default is `cloud` |
+| Query commands | One typed query and view path for every readable source |
+| Local execution | DuckDB over Parquet cache fragments only |
+| Local writes | Immutable Parquet deltas plus an atomically revised inventory |
+| Dataset organization | Existing LangSmith Dataset and Example contracts; no parallel collection model |
+| JSONL | Explicit import/export format; never a queryable cache fragment |
+| Archive writes | Keep verified trace `sync/backfill`; add immutable dataset-version publication |
+| Automatic source choice | Do not add; freshness and coverage are user-visible decisions |
+| Multi-source query | Deferred; add explicit comparison before federation |
+
+## Product principles
+
+**A trace source is a user-visible choice about truth, not an implementation
+optimization.** The selector answers “which copy of the data do I trust for this
+task?” before DuckDB, S3, or an API enters the picture.
+
+| Principle | User promise | Consequence |
+|---|---|---|
+| Explicit truth boundary | The CLI says which source answered | Never fall back or switch sources silently |
+| Honest absence | Zero rows means “no matches within known coverage” | Partial or unknown coverage produces a visible warning |
+| Stable facade | Common read intent has common flags and output | Source-specific adapters cannot reinterpret a predicate |
+| No surprise movement | Reading one source does not copy to another | Every transfer is a separate, directional command |
+| Read-only derived copies | Archive and local cannot mutate cloud state | Writes fail before scanning or loading unrelated credentials |
+| Progressive commitment | A one-off query does not require a local cache | Cache only when repetition, isolation, or offline use earns it |
+| Dataset/trace separation | An example may retain `source_run_id`, but the source trace is not dataset content | Dataset transfer does not imply trace transfer |
+
+Users should be able to choose in seconds:
+
+| If the deciding question is… | Choose |
+|---|---|
+| “What is true in LangSmith right now?” | Cloud |
+| “What did the organization durably retain?” | Archive |
+| “What is in the disposable cache on this machine?” | Local |
+
+The CLI should reinforce that choice in diagnostics. Human output identifies a
+non-default source in its heading; verbose output reports source revision and
+coverage; JSON row output stays backward-compatible and sparse. `runs source
+status <name>` is the authoritative way to inspect freshness and coverage before a
+query.
+
+## Product contract
+
+**The same query should mean the same thing everywhere, while source selection makes
+freshness and coverage explicit.** The CLI may execute through LangSmith or DuckDB,
+but it must return the same validated LangSmith `Run` contract and use the existing
+JSON/table/CSV/YAML views.
+
+```bash
+# Fresh data in LangSmith Cloud (default)
+langsmith-cli --json runs search "timeout" \
+  --source cloud --project prd/my-agent --last 24h
+
+# Durable history in the organization archive
+langsmith-cli --json runs search "timeout" \
+  --source archive --project prd/my-agent --last 365d
+
+# Whatever has been accumulated locally
+langsmith-cli --json runs search "timeout" \
+  --source local --project prd/my-agent --last 30d
+
+# The same dataset/examples facade through any readable source
+langsmith-cli --json examples list \
+  --source local --dataset incident-2841 --as-of prod
+```
+
+Read commands share the facade. Commands whose behavior depends on LangSmith itself
+remain cloud-only and fail clearly for other sources.
+
+| Command family | Cloud | Archive | Local | Product rule |
+|---|---:|---:|---:|---|
+| `runs list/search/get/get-latest` | Yes | Yes | Yes | Same typed query and output contract |
+| Row-derived analytics (`usage`, `pricing`, discovery) | Yes | Later | Later | Migrate after core-read predicate and normalization parity |
+| Service aggregate `runs stats` | Yes | No | No | LangSmith service metrics are not reconstructed from retained rows |
+| `runs watch` | Yes | No | No | Watching requires a mutable live service |
+| `runs open` | Yes | No | No | The LangSmith UI owns cloud URLs |
+| Run mutations or feedback writes | Yes | No | No | No implicit write-back from retained copies |
+| `datasets list/get`, `examples list/get`, versions | Yes | Yes | Yes | Same strict SDK contracts and `as_of` semantics |
+| Dataset/Example mutations | Yes | No | No | Cloud applies validation, transformations, attachments, and version creation |
+
+Selecting an incapable source is an error, not an invitation to fall back to cloud.
+Selecting a capable source with incomplete coverage is different: the query may
+return matching rows, but it also emits structured coverage evidence and a warning.
+Automation can opt into a strict coverage policy and fail unless the request is
+fully covered.
+
+### Scope and non-goals
+
+The initial scope is trace-row reads, source inspection, explicit materialization,
+and source-aware dataset/example reads and replication. The Dataset and Example
+contracts are copied, not reinterpreted. Prompts, feedback, annotation queues,
+experiments, public sharing, and resource permissions remain separate LangSmith
+service resources; adopting the dataset model does not imply cloning every adjacent
+cloud feature. Restoring retained trace rows into LangSmith, treating a workstation
+cache as archive truth, automatic source selection, and multi-source result union
+are not goals of this design.
+
+### Resolved CLI surface
+
+**Use `runs source` for source lifecycle and comparison; keep data reads on the
+existing `runs` commands.** The source command family is singular because every
+lifecycle command has one explicit target, except the deliberately two-sided
+comparison. Existing `datasets` and `examples` gain the same source selector.
+
+| Command | Contract |
+|---|---|
+| `runs source list` | List configured source names, kinds, and capabilities |
+| `runs source status <name>` | Report availability, coverage, freshness, and cache/archive health |
+| `runs source pull local --from <cloud\|archive>` | Add or refresh selected full trace bundles; preserve unrelated cached traces |
+| `runs source import local <path> --format jsonl` | Validate and convert external JSONL into the Parquet cache |
+| `runs source remove local <selector>` | Remove selected traces; never affect datasets or another source |
+| `runs source evict local` | Delete the disposable local trace inventory; dataset replicas are separate |
+| `runs source compare <left> <right>` | Report bounded identity/content differences without merging rows |
+| `datasets list/get/status --source <name>` | Read the Dataset contract; status adds replica lineage/head/attachment health |
+| `examples list/get --source <name> --dataset <dataset>` | Read examples, splits, attachments, and `--as-of` versions uniformly |
+| `datasets pull <dataset> --from <source> --to <source> [--as-of <version>\|--all-versions]` | Replicate exact dataset version(s) and their examples/attachments |
+| `datasets versions --source <name>` / `datasets tag --source cloud` | Inspect versions everywhere; let LangSmith mutate version tags |
+| `datasets create/delete` and `examples create/update/delete/from-run` | Cloud-only mutations using the existing LangSmith model |
+| `datasets evict <dataset> --source local` | Remove a disposable replica; this is cache lifecycle, not a Dataset mutation |
+
+`runs cache download/list/clear` remain temporary aliases for local
+pull/status/evict. Commands fail before loading a backend when the selected source
+lacks the requested capability. A local trace pull must select traces by IDs or a
+bounded project/time/filter query. It performs an idempotent set-union/upsert: new
+trace identities are added, a newer observation of an existing trace replaces its
+logical cached value, and unrelated inventory is preserved. No command silently
+evicts traces to meet a size target.
+
+### Machine-readable coverage
+
+**Preserve sparse `--json` and add an explicit envelope mode.** Existing automation
+continues to receive a run array. `--json-envelope` is a mutually exclusive output
+mode for callers that need source and coverage evidence:
+
+```json
+{
+  "runs": [],
+  "source": {"name": "local", "kind": "cache", "revision": "..."},
+  "coverage": {"state": "partial", "requested": {}, "available": {}},
+  "diagnostics": {"scanned_fragments": 0, "warnings": []}
+}
+```
+
+Human and sparse JSON modes warn on partial/unknown coverage through stderr. The
+source-aware read commands also accept `--require-complete`; when coverage cannot
+satisfy the request, they exit nonzero without presenting rows as a complete
+answer. `runs source status <name> --json` remains the preflight interface for full
+source metadata.
+
+Dataset/example sparse JSON likewise remains the SDK model shape. Replica lineage,
+source namespace, resolved `as_of`, content digest, attachment health, and optional
+linked-trace status live in `datasets status <dataset> --json` or an explicit
+dataset envelope, never as invented Dataset/Example fields.
+
+## Terminology and current state
+
+**A source, backend, catalog, fragment, and store are different layers.** Keeping
+them separate lets local and S3 data share DuckDB without pretending that a file
+path and a remote service have the same lifecycle.
+
+| Term | Meaning | Examples |
+|---|---|---|
+| Trace source | Named query origin selected by the user | `cloud`, `archive`, `local` |
+| Trace backend | Implements query/count/get for one source | LangSmith backend, DuckDB backend |
+| Catalog | Discovers relevant data fragments and their coverage | Archive manifests, local cache metadata |
+| Fragment | Queryable unit with project, time, and row metadata | One canonical Parquet partition or cache fragment |
+| Store | Reads/writes catalog and data objects | S3, local filesystem |
+| Executor | Runs a physical query | LangSmith SDK/API, DuckDB |
+
+The repository already contains two local models:
+
+- `LocalArchiveStore` gives the canonical manifest/Parquet archive a filesystem
+  store equivalent to S3.
+- The current local run cache stores per-project JSONL plus `CacheMetadata`, but
+  only cache and usage commands treat it as a source. General run commands do not.
+
+The design does not promote that JSONL layout or create a third archive. It replaces
+the cache storage with Parquet and adds a backend-neutral query boundary plus enough
+cache metadata to make freshness and coverage honest. Old JSONL may be handled by
+an explicit one-way importer; it is not auto-discovered as a source.
+
+## Architecture
+
+**Commands construct one logical query; source resolution selects how it is
+executed.** DuckDB is shared by archive and local sources, while their catalogs and
+coverage models remain distinct.
+
+```text
+runs list / search / get / get-latest
+                  |
+                  v
+           typed TraceQuery
+                  |
+                  v
+        TraceSourceRegistry.resolve(name)
+             /                    \
+            v                      v
+ LangSmithTraceBackend      DuckDBTraceBackend
+            |                 /              \
+            v                v                v
+   LangSmith SDK/API   ArchiveCatalog   LocalCacheCatalog
+                           |                    |
+                           v                    v
+                     S3/local               local Parquet
+                     manifests                 cache
+             \                    |                    /
+              \                   v                   /
+               +---- canonical Run normalization ----+
+                                  |
+                                  v
+                   TracePage(runs, source, coverage)
+                                  |
+                                  v
+                      existing output/view layer
+```
+
+Datasets use the same source registry but a separate typed backend so trace and
+dataset semantics cannot leak into one another:
+
+```text
+datasets / examples commands
+           |
+           v
+  typed DatasetQuery / ExampleQuery
+           |
+           v
+ DatasetSourceRegistry.resolve(name)
+      /                         \
+     v                           v
+LangSmithDatasetBackend   DuckDBDatasetReplicaBackend
+     |                       /               \
+     v                      v                 v
+strict SDK models      archive manifest   local replica catalog
+                              \               /
+                               v             v
+                      strict SDK-model round trip
+```
+
+### Backend contract
+
+The command layer depends on a small strongly typed protocol:
+
+```python
+class TraceBackend(Protocol):
+    capabilities: TraceCapabilities
+
+    def query(self, query: TraceQuery) -> TracePage: ...
+    def count(self, query: TraceQuery) -> TraceCount: ...
+    def get(self, lookup: TraceLookup) -> TraceBundle: ...
+
+class DatasetBackend(Protocol):
+    capabilities: DatasetCapabilities
+
+    def list_datasets(self, query: DatasetQuery) -> DatasetPage: ...
+    def get_dataset(self, lookup: DatasetLookup) -> Dataset: ...
+    def list_examples(self, query: ExampleQuery) -> ExamplePage: ...
+    def get_example(self, lookup: ExampleLookup) -> Example: ...
+    def list_versions(self, lookup: DatasetLookup) -> DatasetVersionPage: ...
+```
+
+`search` is a query with a text predicate. `get-latest` is a query ordered by
+`start_time` descending with limit one. `get --follow-children` is a lookup with
+trace expansion. They are not separate backend capabilities.
+
+`Dataset`, `Example`, and `DatasetVersion` above are the pinned LangSmith SDK
+models. Mutation is a separate cloud-only capability protocol in the initial
+release; a read backend cannot accidentally expose create/update/delete methods.
+
+### Typed query model
+
+**CLI flags are parsed once into backend-neutral semantics.** Backends compile a
+typed predicate tree rather than reimplementing flag behavior in command adapters.
+
+| Query component | Representative typed values |
+|---|---|
+| Project selection | exact ID/name, glob, regex |
+| Exact identity selection | one or more scoped run/trace IDs |
+| Time | half-open UTC `[since, before)` |
+| Predicates | status, root/child, run type, tag, metadata, latency, text |
+| Text search | fields, literal/regex, case sensitivity |
+| Result shape | order, limit, count, projection, trace expansion |
+
+LangSmith compiles predicates to SDK arguments and FQL. DuckDB compiles the same
+predicates to SQL with bound values and an allowlist for identifiers. Raw `--filter`
+remains an explicitly cloud-only escape hatch until it can be parsed into the typed
+predicate model; unsupported semantics fail instead of being approximated.
+
+### Result and coverage model
+
+**Rows alone are not enough to interpret a local or archived result.** Every backend
+returns source and coverage evidence even when the default view renders only runs.
+
+```text
+TracePage
+  runs                 validated LangSmith Run objects
+  source               source name, kind, and revision/generation
+  coverage             project/time or identity scope, completeness, freshness, filters
+  diagnostics          scanned fragments, skipped/corrupt fragments, warnings
+```
+
+Coverage uses typed states rather than a boolean:
+
+| State | Meaning |
+|---|---|
+| Authoritative | Backend is the live authority for its stated availability window |
+| Sealed | Verified immutable project/time partitions cover the requested interval |
+| IdentityComplete | Every explicitly requested trace identity has a complete bundle |
+| Filtered | Materialization deliberately contains only a recorded predicate subset |
+| Partial | Some requested projects or intervals are absent |
+| Unknown | Imported/external data has insufficient evidence to claim coverage |
+
+Machine-readable run output remains sparse and backward-compatible. Coverage
+warnings go to stderr, while `runs source status <name> --json` returns the full
+evidence. `--json-envelope` returns the complete `TracePage` evidence with the runs.
+
+## Local trace cache
+
+**Local is a disposable acceleration cache for intermediate work, not a retained
+dataset or system of record.** It is the growing set of trace bundles the user has
+chosen to keep on this machine. Pulling more data expands that set; it does not
+declare a new global scope or delete unrelated work. Anything that must survive, be
+shared as evidence, or be reproduced later belongs in the archive or an explicit
+export.
+
+| Property | Local contract |
+|---|---|
+| Authority | Never authoritative; derived from cloud, archive, or explicit import |
+| Durability | None; loss is recovered by pulling/importing again |
+| Contents | An accumulating, deduplicated inventory of trace bundles; source transfers are complete, explicit imports may be `Unknown` |
+| Capacity | No configured maximum and no automatic LRU/TTL eviction initially |
+| Mutability | Published fragments are immutable; additions publish new fragments and one catalog revision |
+| Storage | Parquet only |
+| Correctness | Metadata separates item presence, observation freshness, and coverage evidence |
+| Eviction | Explicit per-trace removal or whole-cache eviction; compaction is physical only |
+
+The logical unit of caching is a **trace bundle**: the root run and its descendants
+for one stable `trace_id`. Source pulls require the complete
+bundle; an explicit external import may be admitted only with `Unknown`
+completeness. Individual run rows remain the physical Parquet records, but commands
+do not cache a child run without resolving its root trace. This makes
+deduplication, removal, and transfer well-defined.
+
+Adding an already-cached trace is idempotent. If its canonical content digest is
+unchanged, only new provenance is recorded. If the same stable
+identity is observed again with different content, the newest successful
+observation becomes the logical value; the older physical row version remains
+invisible and can be discarded by compaction. The cache never merges two versions
+field by field.
+
+### Minimal cache metadata
+
+The cache needs a typed inventory catalog and coverage ledger, not an archive
+manifest. If the active catalog is absent, incompatible, or corrupt, the CLI treats
+the cache as unavailable and asks the user to rebuild it; it never scans whatever
+files happen to be present.
+
+| Field | Why it is required |
+|---|---|
+| Catalog revision | Gives each reader one atomic view of fragments and inventory |
+| Scoped trace identity | Provider/workspace, project ID, and root `trace_id`; names are labels only |
+| Fragment sequence and schema version | Selects the newest logical trace version and the only paths DuckDB may scan |
+| Trace digest, run count, and completeness | Detects conflicting observations and incomplete bundles |
+| Origin source and observation time | Explains provenance and staleness per trace/batch |
+| Pull-batch predicate and absolute UTC bounds | Records why items were selected and supports honest coverage |
+| Coverage evidence | Distinguishes “this item exists” from “this entire interval was materialized” |
+
+Coverage is a ledger over successful pull batches, not a bounding box inferred from
+the oldest and newest cached row. For example, traces from Monday and Friday do not
+prove Tuesday–Thursday coverage. A project/time query is complete only when the
+union of compatible, unfiltered successful batch records covers the requested
+interval. An exact-ID query can be `IdentityComplete` even when no continuous time
+interval is covered.
+
+### Cache filesystem layout
+
+**Use one versioned application-cache root and one active pointer.** The default is
+derived from `platformdirs.user_cache_dir("langsmith-cli", appauthor=False)` so it
+follows each operating system's cache conventions:
+
+```text
+<langsmith-cli user cache>/traces/v1/local/
+  active.json
+  fragments/
+    runs-<sequence>-<uuid>.parquet
+    inventory-<sequence>-<uuid>.parquet
+    coverage-<sequence>-<uuid>.parquet
+  staging/
+```
+
+`active.json` is a small typed control file containing the catalog revision and the
+approved relative fragment paths. Trace inventory and pull-batch evidence are
+stored as typed Parquet tables referenced by that catalog so the metadata remains
+queryable as it grows. An addition writes and validates uniquely
+named fragments under `staging/`, renames them into `fragments/`, and atomically
+replaces `active.json`. Readers therefore see either the old inventory or the old
+inventory plus the complete addition. Orphaned staged/unreferenced files are safe to
+delete during recovery.
+
+Compaction writes replacement run and inventory fragments, validates that their
+logical trace set is identical, and atomically publishes a new catalog revision. It
+may remove superseded trace observations, but it must not change which traces the
+user sees. Old referenced
+fragments are deleted only after existing readers release their catalog revision.
+
+### JSONL versus Parquet for the cache
+
+**Choose Parquet as the single local-cache format.** JSONL remains useful at an
+explicit import/export boundary, but it is never cataloged or queried as local cache
+storage.
+
+| Criterion | JSONL | Parquet | Cache priority | Winner |
+|---|---|---|---:|---|
+| Selective queries | Parses candidate objects and fields | Projection and filter pushdown skip columns and row groups | High | Parquet |
+| Repeated aggregation | Repeats text parsing and nested conversion | Reuses typed columnar encoding | High | Parquet |
+| Schema | Sampled inference can drift unless every read supplies a schema | Typed schema is embedded in every file | High | Parquet |
+| Disk and I/O | Repeats keys and text values per row | Per-column encoding and compression | High | Parquet |
+| Parallel scans | Limited by parsing work and file layout | Parallelizes across files and row groups | High | Parquet |
+| Atomic additions | Partial appended lines can expose corruption | Staged immutable fragments are validated before catalog publication | High | Parquet |
+| Streaming append | Natural byte append | Adds immutable batch fragments; compacts later | Medium; the inventory grows | Tie on capability; Parquet wins overall |
+| Manual inspection | Readable with text tools | Requires DuckDB or another reader | Low; the CLI is the inspection facade | JSONL |
+| Generic interchange | Nearly universal | Broad analytical support but binary | Low; import/export handles this | JSONL |
+
+JSONL wins capabilities that are explicitly not cache requirements: hand editing,
+tail append, and zero-tool inspection. Parquet wins the analytical path for which
+the cache exists. DuckDB's Parquet reader supports projection and filter pushdown,
+including row-group skipping from column statistics; its JSON reader otherwise
+needs explicit columns to avoid sampled-schema behavior. See DuckDB's official
+[Parquet reader](https://duckdb.org/docs/current/data/parquet/overview),
+[Parquet writing guidance](https://duckdb.org/docs/current/data/parquet/tips), and
+[JSON reader](https://duckdb.org/docs/current/data/json/loading_json).
+
+| Situation | Required behavior |
+|---|---|
+| Pull from cloud | Resolve complete trace bundles, normalize in DuckDB, and add Parquet fragments |
+| Pull from archive | Read/copy selected complete trace bundles and extend the inventory |
+| Import JSONL | Explicit importer validates and converts to Parquet before the cache becomes visible |
+| Export for a person or generic tool | DuckDB writes JSONL outside the cache root |
+| Discover an old JSONL cache | Ignore it; offer an explicit import or pull command |
+
+There is no direct JSONL query mode and no transparent format conversion during a
+read. This keeps the backend, schema, tests, and failure semantics single-format.
+
+JSONL import handles one project per invocation. Every row is validated as a
+canonical `Run`; all non-null `session_id` values must agree. That ID is used as the
+project ID, or `--project-id` is required when the field is absent; an explicit ID
+must agree with any value in the rows. `--project-name` is an optional display label,
+the filename is never identity, and arbitrary imports receive `Unknown` coverage
+unless accompanied by a CLI-produced evidence sidecar that validates successfully.
+Rows are assembled by root `trace_id` and must be internally closed under their
+declared parent links. Without evidence that the export contained every descendant,
+bundle completeness remains `Unknown`: it is locally queryable but cannot satisfy
+`IdentityComplete` or be published as verified trace evidence until revalidated
+against cloud or archive.
+
+### DuckDB's role in the cache lifecycle
+
+**DuckDB owns cache reads, additions, deduplication, and compaction; the catalog owns
+atomic visibility and correctness evidence.** Catalog revisions are concurrency
+mechanics, not durable cache history or a user-visible rollback feature.
+
+| Responsibility | Owner |
+|---|---|
+| Query, normalize, validate, deduplicate, sort, and write Parquet | DuckDB |
+| Inventory identity, origin, batch coverage, and freshness | Typed Parquet catalog tables |
+| Atomic catalog publication, removal, and eviction | Cache manager |
+| JSONL import/export conversion | DuckDB import/export adapter |
+
+An addition follows this sequence:
+
+| # | Step | Failure behavior |
+|---:|---|---|
+| 1 | Resolve trace IDs directly or from bounded project/time/filter selectors | Fail before changing the active inventory |
+| 2 | Prefer source Parquet; otherwise stream API rows to a process-private staging spool for explicit-schema DuckDB ingestion | Staging is never a cache fragment and is deleted on interruption |
+| 3 | Resolve each selected run to its root, fetch the complete trace bundle, and validate schema, identities, and row counts | Any malformed/incomplete trace fails by default |
+| 4 | `COPY` sorted data to uniquely named Zstd Parquet files in a staging directory | Existing cache remains readable |
+| 5 | Reopen and validate the written Parquet; write inventory, provenance, and coverage deltas | Invalid output is deleted |
+| 6 | Atomically publish a catalog that references the old fragments plus the complete addition | Readers see either inventory before or after the addition |
+| 7 | Later compact superseded versions/small deltas without changing the logical sets | No user-visible history or rollback promise |
+
+Pull always preserves traces outside the request. It never appends bytes to a
+published Parquet file; “append” means publish another immutable fragment and merge
+its trace identities into the logical inventory. Explicit `remove` publishes
+tombstones or a replacement compacted catalog, while `evict` clears the whole
+inventory. DuckDB warns that excessive small partitions are expensive in its
+[partitioned-write guidance](https://duckdb.org/docs/current/data/partitioning/partitioned_writes).
+
+### Initial Parquet physical defaults
+
+**Start with one sorted file for small caches and approximately 512 MiB files for
+larger caches.** These are implementation defaults, not part of the source API.
+
+| Setting | Initial decision | Rationale |
+|---|---|---|
+| Sort order | `session_id, start_time, id` | Tightens project/time zonemaps and makes tie ordering deterministic |
+| Compression | Zstd, level 3 | Existing archive choice; balanced cache size and decompression cost |
+| Row group | DuckDB default `122,880` rows | Falls inside DuckDB's recommended 100K–1M range |
+| File target | `FILE_SIZE_BYTES='512MB'` | Inside DuckDB's recommended 100 MB–10 GB range without giant local files |
+| Small cache | One file; do not pad or partition | Avoids tiny-file overhead |
+| Hive partitioning | None initially | Cache metadata and Parquet statistics already prune; project/day folders would fragment small caches |
+| Write result | `RETURN_STATS` | Populate file paths, counts, sizes, and column bounds without rescanning |
+
+The cache manager compacts when fragment count or small-file overhead crosses an
+implementation threshold; that threshold affects performance only, never retention.
+The implementation records actual file and row-group statistics and adds a
+benchmark before changing these defaults. DuckDB documents `FILE_SIZE_BYTES`,
+`ROW_GROUP_SIZE`, and `RETURN_STATS` in its
+[`COPY` reference](https://duckdb.org/docs/current/sql/statements/copy) and publishes
+the file/row-group ranges in its
+[file-format performance guide](https://duckdb.org/docs/current/guides/performance/file_formats).
+
+A persistent `.duckdb` file is outside this JSONL-versus-Parquet decision. Because
+the cache is disposable, DuckDB storage-version coupling is not a durability
+blocker; however, native storage has different multi-process locking and incremental
+write tradeoffs. The initial Parquet choice maximizes reuse of the archive schema
+and query compiler and keeps concurrent readers on immutable fragments. Native
+DuckDB storage should be evaluated only as a separate performance proposal, not
+introduced accidentally as a third format.
+
+## Datasets across sources
+
+**Dataset means the LangSmith Dataset model everywhere.** The CLI will not introduce
+another trace-collection type, reinterpret examples as membership rows, or discard
+dataset features that are inconvenient outside cloud. `datasets` and `examples` become source-aware
+facades over replicas of the SDK contracts.
+
+### Replicated contract
+
+The pinned LangSmith SDK models are the schema authority. The replica preserves all
+fields rather than maintaining a hand-written “common subset”:
+
+| Contract | Replicated semantics |
+|---|---|
+| Dataset | ID, name, description, data type, created/modified times, counts, input/output schemas, transformations, metadata |
+| Example | ID, dataset ID, inputs, outputs/reference outputs, metadata, created/modified times, optional `source_run_id`, attachments |
+| Splits | The same example split assignments and filtering behavior exposed by LangSmith |
+| Versions | Every example add, update, or delete creates a timestamped dataset version |
+| Version tags | Human-readable tags resolve to an exact immutable `as_of` version; the tag pointer itself may later move |
+| Attachments | Names, media types, bytes, and attachment operations; never expiring URLs as durable content |
+
+“Wholesale” does not mean silently accepting future SDK drift. Every storage schema
+is stamped with the LangSmith model/schema version it implements. A newly required
+or changed SDK field fails fast until an explicit migration and round-trip fixture
+are added. Dataset and Example are strict typed objects at the backend boundary;
+replica catalog metadata is a separate typed transfer envelope, never injected into
+their metadata fields.
+
+Service-derived Dataset summary fields such as experiment/session counts and last
+session time are preserved exactly as observed at pull time, with that observation
+time in the replica envelope. They do not imply that associated experiments,
+feedback, or runs were copied, and they do not update while the replica is offline.
+
+This contract follows LangSmith's official
+[dataset management model](https://docs.langchain.com/langsmith/manage-datasets-in-application),
+[Example schema](https://docs.langchain.com/langsmith/example-data-format),
+[version/tag semantics](https://docs.langchain.com/langsmith/manage-datasets), and
+[attachment behavior](https://docs.langchain.com/langsmith/evaluate-with-attachments).
+
+### Dataset content versus source traces
+
+**An example's `source_run_id` is lineage, not ownership of the source trace.** A
+dataset remains complete and useful when an example has no source run or when the
+source trace has expired. Pulling a dataset therefore copies Dataset, Example,
+version, split, schema/transformation, metadata, and attachment state; it does not
+copy traces by default.
+
+Callers that need the original traces request a separate companion materialization:
+
+```bash
+langsmith-cli --json datasets pull incident-2841 \
+  --from cloud --to local --as-of prod \
+  --include-source-traces
+```
+
+The dataset version is replicated first and remains valid even if trace
+materialization is incomplete. For each non-null `source_run_id`, the optional trace
+phase resolves the run to its root `trace_id`, fetches a complete trace bundle, and
+adds it to the ordinary destination trace inventory. Null links are normal and are
+reported as `examples_without_source_run`; expired/missing linked runs fail the trace
+phase by default or are recorded explicitly with `--allow-partial-traces`. The
+dataset object and examples are never changed to encode trace-transfer status.
+
+### Backend behavior
+
+| Source | Dataset role | Mutability in the initial design | Version behavior |
+|---|---|---|---|
+| Cloud | LangSmith authority | Full existing Dataset/Example APIs | LangSmith creates versions and applies schema validation/transformations |
+| Archive | Durable replica | Publish exact source versions only | Retains every published version, tags, examples, and attachments immutably |
+| Local | Disposable working replica | Read-only replica initially | Retains downloaded versions until explicit dataset deletion or cache eviction |
+
+Cloud is initially the only mutation authority. This is deliberate: reproducing
+LangSmith schema validation, transformations, split mutation, attachment operations,
+and version creation in local/archive code would recreate the drift risk this
+decision is meant to eliminate. “Append to an archive dataset” means mutate the
+cloud dataset through its normal API, then publish its newer exact version to the
+archive. Local authoring can be added only if the same SDK-backed mutation engine
+can produce byte-for-byte and version-for-version parity.
+
+Archive and local still satisfy the uniform read facade: `datasets list/get`,
+`examples list/get`, split/metadata filters, attachment inclusion, and `--as-of`
+resolve with the same typed semantics. Unsupported cloud-only adjacency—running an
+experiment, sharing publicly, or inspecting associated experiment runs—fails as a
+capability error rather than being approximated.
+
+`datasets pull` defaults to the source's resolved `latest` version. `--as-of`
+selects one timestamp or tag; `--all-versions` replicates every available version
+and tag mapping. `datasets versions --source archive|local` reports versions actually
+present in that replica, while `datasets status` distinguishes a one-version checkout
+from a complete copied history.
+
+### Identity, lineage, and conflict policy
+
+**A replica is identified by source namespace plus Dataset ID, never by name.** The
+destination catalog stores origin workspace/source, source dataset ID, fetched
+version, content digest, and transfer time outside the Dataset object. Dataset and
+Example IDs are preserved in local/archive replicas; names remain lookup labels.
+
+| Situation | Decision |
+|---|---|
+| Pull same dataset/version again | Idempotent no-op after digest verification |
+| Pull a later version from the same lineage | Fast-forward; retain the older version and publish the new immutable head |
+| Pull an older version from the same lineage | Add the historical snapshot; do not move the current head backward |
+| Same name, different source Dataset ID | Keep as distinct datasets; ambiguous name lookup fails |
+| Destination head is not an ancestor of incoming version | Fail divergence; no example-by-example merge |
+| Same lineage and `as_of`, different canonical digest | Fail corruption/divergence; never choose one silently |
+| Example deleted in a newer version | Absent from that version, present when reading an older `as_of` version |
+| Source dataset later deleted | Existing local/archive replicas remain; deletion never propagates implicitly |
+
+No union or mirror policy is invented. Dataset updates and deletions already have
+meaning through LangSmith versions; replaying exact versions preserves that meaning.
+A future writable local fork must receive a new lineage and cannot masquerade as a
+fast-forward replica.
+
+### Dataset replication transaction
+
+`datasets pull` freezes one source version and publishes it atomically:
+
+| Step | Required behavior |
+|---:|---|
+| 1 | Resolve the source dataset by ID/name and freeze an exact timestamp/tag target |
+| 2 | Read the full Dataset object, version/tag records, and all examples at that `as_of` |
+| 3 | Fetch attachment bytes, validate media/name/digest metadata, and reject expiring URLs as stored content |
+| 4 | Validate every strict SDK object and cross-reference Dataset/Example IDs |
+| 5 | Write immutable dataset/example/version Parquet plus content-addressed attachment blobs |
+| 6 | Reopen and round-trip all typed records; conditionally publish the destination head |
+| 7 | Optionally materialize linked source traces as a separate, auditable phase |
+
+The dataset transaction is all-or-nothing. The optional trace phase has its own
+status so an expired source trace cannot corrupt or roll back a valid dataset
+replica. In strict mode a trace-phase failure exits nonzero but reports that the
+dataset version committed successfully; rerunning is idempotent and retries only
+missing traces.
+
+### Physical storage
+
+Dataset replicas are separate from the trace cache while sharing DuckDB as the
+reader:
+
+```text
+<langsmith-cli user cache>/datasets/v1/local/
+  active.json
+  datasets/<origin-namespace>/<dataset-id>/
+    versions/<version-digest>/dataset.parquet
+    versions/<version-digest>/examples-*.parquet
+    versions/<version-digest>/version.parquet
+  attachments/sha256/<digest>
+  staging/
+```
+
+Parquet remains the typed query format for Dataset/Example/version rows. Attachments
+are content-addressed binary blobs because wrapping arbitrary media in Parquet would
+not reproduce LangSmith attachment semantics. `active.json` exposes only validated
+versions and attachment digests. Dataset names, version tags, attachment names, and
+raw timestamps are metadata only and never become path components. Archive uses the
+equivalent object layout with conditionally published manifests and durable
+retention; local uses the same logical schema without a durability promise. Local
+performs no automatic version, TTL, size, or attachment eviction; `datasets evict`
+removes the replica explicitly, and garbage collection deletes attachment blobs
+only when no visible version references their digest.
+
+## Source selection
+
+**Select the narrowest source that truthfully satisfies the task.** Do not optimize
+for fewer keystrokes at the cost of freshness or completeness.
+
+| Need | Preferred source | Why | Main caveat |
+|---|---|---|---|
+| Debug a run that just happened | Cloud | Freshest data and full live semantics | Retention, API/network dependency |
+| Watch or mutate LangSmith state | Cloud | Only authoritative writable backend | Cannot work offline |
+| Investigate history beyond retention | Archive | Durable sealed organization record | Read-only; publication lag |
+| Shared audit/reproducible historical analysis | Archive | Verified immutable partitions | S3/IAM and scan cost |
+| Repeated exploration of accumulated traces | Local | Low latency and no repeated API/S3 scan | Freshness and coverage must be checked |
+| Curate or mutate a dataset | Cloud | LangSmith owns validation, transformations, attachments, and version creation | Requires service access |
+| Reproduce a known dataset version | Archive | Exact durable Dataset/Example snapshot | Replica is read-only |
+| Use a dataset offline | Local | Same examples/version without network access | Replica is disposable and read-only |
+| Work offline or isolate sensitive analysis | Local | Files remain on the workstation | Local disk/security responsibility |
+| One quick query already covered locally | Local | Avoid unnecessary transfer | Never assume the cache is current |
+
+Default behavior remains cloud. There is no `--source auto`: the CLI cannot infer
+whether the user values freshness, durability, privacy, or zero network use.
+
+## Core workflows
+
+**Query in place by default; cache only when the desired operating property
+changes.** Copying to local is justified by offline/private intermediate work or
+lower cost for repeated scans. Durable retention and reproducibility are separate
+archive/export workflows.
+
+| Workflow | Start with | Transfer trigger | End state |
+|---|---|---|---|
+| Debug a current incident | Cloud | Repeated deep analysis or impending offline work | Selected traces accumulate locally |
+| Investigate old behavior | Archive | Repeated scans, offline work, or workstation tooling | Selected traces added locally with archive provenance |
+| Retain organizational history | Cloud | Retention policy and scheduled archive window | Verified, sealed archive partitions |
+| Curate evaluation examples | Cloud | A run/example is worth preserving for evaluation | New LangSmith dataset version |
+| Reproduce an evaluation input set | Cloud dataset | Version is ready for durable/offline use | Exact archive and/or local dataset replica |
+| Audit archive publication | Cloud plus archive comparison | Suspected lag, omission, or divergence | Parity report; no merged rows |
+
+Do not transfer for a one-off query that the selected source can answer cheaply, to
+make stale data appear fresh, or to enable a mutation. A local trace pull extends a
+disposable working inventory; an archive trace sync or dataset-version publication
+creates durable, verified state.
+
+The commands below illustrate the target UX; they are design proposals, not a claim
+that every form is implemented today.
+
+### Current incident: stay live, then optionally cache
+
+```bash
+# Ask the live authority first.
+langsmith-cli --json runs search "timeout" \
+  --source cloud --project prd/my-agent --last 2h
+
+# If the investigation will be repeated or taken offline, add that slice locally.
+langsmith-cli --json runs source pull local --from cloud \
+  --project prd/my-agent --since 2026-08-22T08:00:00Z \
+  --before 2026-08-22T10:00:00Z
+
+langsmith-cli --json runs search "timeout" \
+  --source local --project prd/my-agent \
+  --since 2026-08-22T08:00:00Z --before 2026-08-22T10:00:00Z
+```
+
+The explicit interval matters for a reproducible pull: `--last 2h` means something
+different tomorrow. The pull ledger records absolute UTC bounds, origin, filters,
+and observation time. It adds this slice to whatever is already local; it does not
+make the cache globally equivalent to that interval.
+
+### Historical investigation: query the archive, check out only if useful
+
+```bash
+# Query sealed history directly without downloading it first.
+langsmith-cli --json runs search "timeout" \
+  --source archive --project prd/my-agent \
+  --since 2025-01-01 --before 2025-02-01
+
+# Check out the same evidence only when repeated/offline analysis justifies it.
+langsmith-cli --json runs source pull local --from archive \
+  --project prd/my-agent --since 2025-01-01 --before 2025-02-01
+```
+
+The local metadata records the archive manifest generation and selected bounds so
+the CLI can explain provenance and coverage. This does not make the cache durable;
+eviction still requires another archive read.
+
+### Dataset workflow: curate in cloud, preserve in archive, use locally
+
+```bash
+# LangSmith creates the Example and the next Dataset version.
+langsmith-cli --json examples from-run 7b1c... \
+  --dataset incident-2841
+
+# Preserve the exact current Dataset/Example version durably.
+langsmith-cli --json datasets pull incident-2841 \
+  --from cloud --to archive --as-of latest
+
+# Download that same version for offline/local use.
+langsmith-cli --json datasets pull incident-2841 \
+  --from archive --to local --as-of latest
+
+langsmith-cli --json examples list \
+  --source local --dataset incident-2841 --as-of latest
+```
+
+Append through the cloud model, then fast-forward both replicas:
+
+```bash
+langsmith-cli --json examples from-run 92ac... --dataset incident-2841
+langsmith-cli --json datasets pull incident-2841 --from cloud --to archive
+langsmith-cli --json datasets pull incident-2841 --from archive --to local
+```
+
+The first command lets LangSmith apply the dataset schema, transformations, and
+version semantics. Each pull publishes the exact newer version while retaining the
+older version for `--as-of` reads. It does not merge examples independently.
+
+### Scheduled retention: publish, verify, then seal
+
+Cloud-to-archive remains an operator workflow: discover the eligible window,
+export, validate counts and identities, reconcile late arrivals, and publish a
+manifest conditionally. It is neither a `runs list` mode nor a local-cache pull.
+Consumers query only published generations; partially written data is invisible.
+
+### Offline/private analysis: prove locality before relying on it
+
+```bash
+langsmith-cli --json runs source status local
+langsmith-cli --json runs list --source local \
+  --project prd/my-agent --since 2026-08-01 --before 2026-08-08
+```
+
+The status check exposes inventory counts, pull-batch coverage, freshness, and
+fragment health.
+Local querying then operates with cloud and archive credentials absent and network
+access denied. “Private” here means no query-time transfer; users must still decide
+whether downloading the traces was permitted in the first place.
+
+### Publication audit: compare evidence instead of unioning it
+
+```bash
+langsmith-cli --json runs source compare cloud archive \
+  --project prd/my-agent --since 2026-08-01 --before 2026-08-02
+```
+
+The report separates missing IDs, differing canonical row digests, source coverage,
+and publication lag. It does not choose a winner, combine rows, or mutate either
+source.
+
+## Transfer model
+
+**Transfers are directional materializations with different trust guarantees, not a
+generic byte copy.** Query syntax is uniform; publication and pull syntax may
+remain purpose-specific.
+
+| From | To | Product purpose | Required semantics | Decision |
+|---|---|---|---|---|
+| Cloud traces | Archive traces | Long-term retention and shared historical truth | Full-window export, verification, reconciliation, sealing | Supported by `archive sync/backfill` |
+| Cloud traces | Local trace cache | Fast/offline intermediate work | Explicit IDs/window/filter; add complete bundles and provenance | Supported trace pull |
+| Archive traces | Local trace cache | Repeated/offline historical analysis | Add selected bundles and manifest provenance | Supported trace pull |
+| Cloud dataset | Archive dataset | Durable reproducible evaluation data | Freeze and publish exact Dataset/Example version plus attachments | Supported dataset pull |
+| Cloud/archive dataset | Local dataset | Offline evaluation inputs and inspection | Replicate exact version read-only | Supported dataset pull |
+| Dataset source | Destination trace store | Optional original-trace analysis | Explicit `--include-source-traces`; separate trace-phase evidence | Supported companion materialization |
+| Local traces | Canonical archive windows | Promote a partial cache to retention truth | Cache has no authoritative completeness guarantee | Unsupported; retention sync sources from cloud |
+| Archive/local traces | Cloud | Restore traces into LangSmith | LangSmith is not a general trace-import target | Non-goal |
+| Archive/local dataset | Cloud dataset | Create a new cloud lineage from a replica | IDs, validation, transformations, and conflict policy need a separate import design | Deferred |
+| Archive | Archive | Storage migration or replication | Preserve trace manifests and dataset versions/identities | Separate operator workflow |
+
+Cloud-to-archive remains deliberately specialized because D+2/D+12 reconciliation,
+Bulk Export adoption, uniqueness checks, and conditional publication are stronger
+than a local pull. The resolved pull command makes direction explicit:
+
+```bash
+# Add a bounded live slice to the cache
+langsmith-cli --json runs source pull local --from cloud \
+  --project prd/my-agent --last 7d
+
+# Check out sealed history without contacting LangSmith
+langsmith-cli --json runs source pull local --from archive \
+  --project prd/my-agent --since 2025-01-01 --before 2025-02-01
+```
+
+Existing `runs cache download` remains a compatibility alias during migration.
+
+## Multiple sources
+
+**General federation is valuable but not required for the uniform single-source
+facade.** Users may configure several sources and compare two bounded sources, but
+the first release selects exactly one source to produce run or dataset/example
+results for a query.
+Transfer commands necessarily read one source and write another, but that is an
+explicit materialization boundary—not a query that merges answers from two sources.
+
+| Potential value | Example |
+|---|---|
+| Bridge retention boundary | Query recent cloud data plus older sealed archive data |
+| Audit publication parity | Compare cloud rows with the corresponding archive day |
+| Local overlay | Combine a disposable private cache with organization history |
+| Availability fallback | Continue reading an archive when LangSmith is unavailable |
+
+The same cases create non-obvious correctness requirements:
+
+- Overlapping sources contain the same run with different freshness.
+- Limit, ordering, and count must be applied after union and deduplication.
+- Project names can move while IDs remain stable.
+- A local subset cannot fill an archive coverage gap merely because it has rows.
+- Automatic fallback can return stale data while appearing successful.
+
+The near-term feature should be comparison, not union:
+
+```bash
+langsmith-cli --json runs source compare cloud archive \
+  --project prd/my-agent --since 2026-08-01 --before 2026-08-02
+```
+
+A later composite source requires explicit membership, precedence, deduplication by
+stable project/run identity, post-union ordering/limit/count, and combined coverage
+evidence. It must never be activated as an automatic fallback.
+
+## Compatibility and migration
+
+**Existing scripts keep working while the source model replaces boolean modes.**
+
+| Existing form | Transition |
+|---|---|
+| No source option | Resolves to `--source cloud` |
+| `--archive` | Deprecated alias for the configured archive source |
+| `runs cache ...` | Compatibility command family over the default local source |
+| `runs usage --from-cache` | Deprecated alias for `--source local` |
+| Existing `datasets`/`examples` without `--source` | Continue to resolve to cloud |
+| Existing JSONL cache files | Not auto-discovered; explicit import converts them to Parquet |
+| `LANGSMITH_ARCHIVE_URI/CONFIG` | Used to synthesize the default archive source |
+
+Conflicting selectors fail. The CLI never changes an existing command from cloud to
+local merely because a cache happens to exist.
+
+## Red-team review
+
+**The dangerous outcome is not a crash; it is a plausible but wrong answer.** The
+default policy is therefore fail-fast for corrupt identity, schema, or query
+semantics, and warn-or-fail by explicit policy for insufficient coverage.
+
+| Failure scenario | Incorrect conclusion it could create | Required guardrail |
+|---|---|---|
+| Stale local data returns zero rows | “No failures occurred” | Return requested-versus-known coverage and freshness; strict mode fails |
+| Local data was exported with `status=error` | “All runs in the interval were errors” | Record the materialization predicate; never claim unfiltered coverage |
+| Two project names sanitize to one filename | Runs silently mix or overwrite | Stable project IDs in cache metadata; ambiguous import fails |
+| A project is renamed | Old history appears to belong to a different project | Resolve names to stored project IDs and retain aliases as labels only |
+| A run changes after cache/archive materialization | Copies look identical because IDs match | Report origin observation time; comparison uses canonical row digests |
+| An imported JSONL row has a malformed shape | Import silently drops or coerces fields | Explicit import schema and canonical `Run` validation; import fails |
+| A cache fragment is missing or corrupt | Partial results look complete | Reject the catalog revision and require repair/re-pull; never best-effort scan |
+| A trace pull is interrupted | Half of the new traces appear | Publish immutable fragments first and atomically advance the catalog only after validation |
+| Monday and Friday traces are cached | The cache appears to cover the whole week | Compute interval coverage from successful pull batches, never min/max cached timestamps |
+| Dataset changes while examples are paginated | Replica mixes two versions | Resolve/freeze one `as_of` before the first page and use it for every page |
+| One examples page is skipped or repeated | A partial/duplicated version looks valid | Verify unique Example IDs, complete pagination, expected counts, and a canonical version digest |
+| A dataset example has no `source_run_id` | Example is treated as incomplete | Null is valid lineage; dataset replication succeeds without trace materialization |
+| A linked cloud trace has expired | Valid dataset is rejected or fake trace content is invented | Dataset phase succeeds; optional trace phase reports the missing linked run separately |
+| A signed attachment URL is archived | Replica appears valid until the URL expires | Fetch bytes, validate digest/media metadata, and store a content-addressed blob |
+| Attachment name contains traversal syntax | Pull writes outside the replica root | Treat name as metadata; address blobs only by validated digest |
+| Local code approximates a cloud transformation | Replica examples silently differ | Local/archive replicas are read-only; cloud remains mutation authority |
+| A newer version deletes an example | Destination union resurrects deleted data | Publish the exact new version; preserve deletion in latest and older `as_of` snapshot separately |
+| Same dataset name exists in two workspaces | Pull advances the wrong replica | Identity is source namespace plus Dataset ID; ambiguous names fail |
+| A version tag moves later | Previously copied evidence changes meaning | Resolve tag to exact `as_of` at pull time and record both tag and resolution |
+| SDK adds or changes a required field | Replica silently drops cloud semantics | Fail schema compatibility until explicit migration and round-trip fixture exist |
+| Backend compilers order ties differently | `--limit` returns different runs | Canonical ordering includes a stable run-ID tie-breaker |
+| Example filtering is pushed down differently | Cloud and DuckDB disagree on examples/splits | Shared typed semantics and cross-backend golden fixtures |
+| A local path references outside the cache | Metadata points DuckDB at unintended workstation files | Canonicalize paths and enforce a fixed root after symlink resolution |
+| DuckDB installs or auto-loads an unapproved extension | A “local” query reaches the network | Preload only bundled allowlisted format support; disable external access and unapproved extension loading |
+| User text reaches generated SQL | SQL injection or unexpected file reads | Bind values; compile identifiers and operators from typed allowlists |
+| A huge local scan spills without bounds | Workstation exhaustion | Configured memory, thread, scan-size, and unique spill-directory limits |
+| Cloud is unavailable | CLI silently serves stale retained data | Never fall back automatically; suggest an explicit source instead |
+| Cloud and archive are unioned before limiting | Recent or duplicate rows displace valid results | No federation in this proposal; comparison operates on full bounded sets |
+| A local subset is published as a retention window | Durable history acquires invisible holes | Forbid local-to-canonical-archive trace sync |
+
+### Correctness decisions produced by the red team
+
+- Canonical trace identity is scoped by provider/workspace, project ID, and root
+  `trace_id`; run ID identifies a row within that bundle. A display name or
+  filesystem path is never identity.
+- Published Parquet fragments are read-only. Pull and compaction atomically publish
+  a new catalog revision; concurrent readers finish on their prior revision before
+  unreferenced files are deleted.
+- Coverage is computed from pull-batch evidence, not from rows encountered by the
+  query. Filtered batches prove only their predicate subset; disjoint intervals are
+  not collapsed into one bounding interval. Exact-ID requests use
+  `IdentityComplete` only when every requested bundle validates.
+- Relative time expressions are resolved to absolute UTC bounds before dispatch.
+  Those bounds, rather than the original `--last` expression, are recorded during
+  materialization.
+- Invalid identity, manifest, digest, or schema fails the query. Missing coverage
+  can return partial rows only with visible evidence; automation may require full
+  coverage as a policy.
+- Comparison uses stable identities and canonical digests. A same-ID/different-row
+  result is reported as divergence, not deduplicated or assigned an implicit winner.
+- Dataset replication freezes one exact LangSmith version and round-trips strict
+  Dataset/Example models. It never unions examples, infers a custom membership
+  model, or mutates the dataset to record companion trace status.
+- Cloud is the dataset mutation authority initially. Archive/local fast-forward
+  exact versions from the same lineage and reject divergence.
+- `source_run_id` is optional lineage. Dataset completeness and optional linked-trace
+  materialization have separate result/status contracts.
+
+## Security and resource boundaries
+
+**Source selection must not cause implicit data movement or credential use.**
+
+- Local queries never upload trace content or contact LangSmith/S3.
+- Archive queries require read/list access only; archive publication remains a
+  separate write-capable operation.
+- Cloud credentials and AWS libraries remain lazily loaded by the selected backend.
+- Local cache roots reject traversal and symlink escapes outside the configured root.
+- Local DuckDB connections preload only required bundled format support, disable
+  external access and unapproved extension loading, and may scan only
+  cache-metadata-approved canonical paths.
+- Local cache metadata and Parquet default to user-only permissions; encryption at
+  rest is the workstation owner's responsibility and must be documented.
+- Dataset attachment blobs are addressed only by verified digests, never executed,
+  and never written using user-controlled attachment names as paths.
+- DuckDB connections retain bounded memory and unique spill directories.
+
+On POSIX systems the cache manager creates the root with mode `0700` and metadata,
+Parquet, attachment blobs, and spill files with mode `0600`; on Windows it inherits the current
+user's profile ACL and never broadens it. There is no built-in encryption or secure
+erase in the initial design. Environments that require either must use an encrypted
+volume/profile or disable the local cache; `evict` is logical deletion, not a
+forensic-erasure guarantee.
+
+## Delivery plan
+
+**Land the abstraction before adding behavior, then add local reads without
+federation.**
+
+| Phase | Outcome | Hard gate |
+|---|---|---|
+| 1. Query boundary | Typed `TraceQuery`, backend protocol, source registry | Cloud/archive parity tests pass unchanged |
+| 2. Source UX | `--source`, lifecycle commands, evidence modes, compatibility aliases | Sparse JSON stays stable; envelope and strict-coverage contracts are tested |
+| 3. Local reader | Parquet-only accumulating inventory through DuckDB plus explicit JSONL import | Identity and coverage are explicit; corrupt catalogs are rejected |
+| 4. Predicate parity | Metadata and latency compile to FQL and SQL | Same fixtures produce equivalent result IDs/order |
+| 5. Local materialization | Atomic pull/add/remove/compaction over immutable Parquet fragments | Additions preserve unrelated traces; provenance and batch coverage survive restart |
+| 6. Dataset replicas | Source-aware Dataset/Example reads and exact-version pull to archive/local | SDK-model, version, split, schema, transformation, and attachment round trips pass |
+| 7. Comparison | Source-to-source parity report | No merged result semantics |
+| Deferred: federation | Explicit composite source | Precedence and coverage model approved separately |
+
+## Definition of done
+
+- [ ] `runs list/search/get/get-latest` accept one named source and return the same
+      sparse output shape for equivalent fixtures.
+- [ ] Cloud, archive, and local backends validate rows into the same LangSmith `Run`
+      contract before the view layer.
+- [ ] A local empty result distinguishes no matching rows from missing/unknown
+      coverage.
+- [ ] Sparse `--json` remains unchanged; `--json-envelope` exposes source,
+      coverage, and diagnostics; `--require-complete` rejects insufficient coverage.
+- [ ] Local queries scan only Parquet cache fragments; JSONL is accepted only by an
+      explicit import that validates before conversion.
+- [ ] Local pull adds/upserts complete traces without removing unrelated inventory;
+      repeated pulls are idempotent.
+- [ ] Pull, remove, and compaction atomically publish catalog revisions over
+      immutable canonical Parquet; interrupted writes remain invisible.
+- [ ] There is no automatic size/TTL eviction; explicit trace removal affects no
+      dataset object or example.
+- [ ] `datasets` and `examples` accept `--source` and return strict LangSmith SDK
+      contracts with equivalent version, split, filter, and attachment semantics.
+- [ ] Dataset replicas preserve all Dataset/Example fields, schemas,
+      transformations, metadata, splits, version tags, and attachment bytes.
+- [ ] Archive/local dataset replicas are read-only; later cloud versions
+      fast-forward atomically while older `as_of` versions remain addressable.
+- [ ] Same-name/different-ID datasets remain distinct and divergent lineages fail
+      without unioning or overwriting examples.
+- [ ] `--include-source-traces` writes linked full traces only to the destination
+      trace store and reports its status separately from dataset replication.
+- [ ] Local cache files use the versioned platform layout and user-only permissions;
+      `evict` leaves no active catalog and makes no secure-erasure claim.
+- [ ] Unsupported predicates identify the selected source and fail explicitly.
+- [ ] No local query contacts LangSmith or S3 in an end-to-end network-denial test.
+- [ ] `--archive`, cache commands, and `--from-cache` remain compatible through the
+      documented deprecation window.
+- [ ] Multi-source union remains unavailable until its separate correctness gates
+      are met.
+
+## Alternatives rejected
+
+| Alternative | Why it is rejected |
+|---|---|
+| Add `--local` beside `--archive` | Produces another command branch and no extensible source identity |
+| Treat every local file as an archive | Conflates partial working sets with sealed verified history |
+| Make DuckDB the user-visible source | DuckDB is an executor; it says nothing about freshness or coverage |
+| Auto-select local when available | A stale or filtered cache would silently replace live truth |
+| Query every source by default | Deduplication and precedence become invisible product policy |
+| Use JSON schema inference as the contract | Adjacent files can infer incompatible nested types |
+| Keep JSONL as the canonical query format | Preserves inspectability but repeatedly pays parsing and loses Parquet pruning |
+| Use a persistent `.duckdb` file as the initial cache | Creates a separate mutable storage/concurrency path from archive Parquet before benchmarks justify it |
+| Rewrite or byte-append published cache files in place | Exposes mixed revisions to concurrent readers; use new immutable fragments plus atomic catalog publication |
+| Generic copy command for every direction | Hides the stronger verification required by archive publication |
+| Custom trace-collection model beside Dataset | Duplicates identity, membership, version, metadata, and transfer semantics that LangSmith already owns |
+| Writable local/archive datasets initially | Requires reimplementing cloud schema validation, transformations, splits, attachment operations, and version creation |
+| Replicate only latest examples | Breaks `as_of`, version tags, deletions, and reproducibility |
+| Omit attachments or retain signed URLs | Produces a replica that is neither semantically complete nor durable |
+
+# Appendix A: core invariants
+
+| ID | Invariant | Enforcement boundary |
+|---|---|---|
+| S1 | One query selects exactly one source | CLI/source registry |
+| S2 | One source name resolves to one typed backend configuration | Configuration validation |
+| S3 | Every returned row satisfies the canonical `Run` contract | Backend normalization boundary |
+| S4 | Project identity never depends on a sanitized filename | Local cache metadata/import validation |
+| S5 | Coverage claims are evidence-backed and never inferred from row presence | Catalog/result model |
+| S6 | Filter, time, ordering, and limit semantics are backend-independent | Typed query plus compiler parity tests |
+| S7 | Local reads cause no network traffic | Local backend dependency boundary |
+| S8 | Canonical archive retention publication never consumes the disposable local cache | Transfer policy |
+| S9 | Multi-source overlap is never silently resolved | Single-source query gate |
+| S10 | Dataset/Example contracts come from the pinned LangSmith SDK, not a custom reduced model | Model/storage boundary |
+| S11 | A dataset replica contains one exact source lineage/version and never unions divergent heads | Dataset catalog/publication |
+| S12 | `source_run_id` is optional lineage and never substitutes for copied trace content | Dataset/trace transfer boundary |
+| S13 | Pull/add preserves unrelated local traces; compaction preserves the logical trace inventory | Cache manager parity checks |
+| S14 | Attachment bytes and all historical dataset versions remain addressable for every published archive version | Dataset manifest validation |
+
+# Appendix B: resolved follow-up decisions
+
+**No blocking design questions remain for phases 1–7.** The follow-up passes
+resolved the former open items as follows.
+
+| Former question | Resolution |
+|---|---|
+| Source-management names | `runs source list/status/pull/import/remove/evict/compare`; existing cache commands are aliases |
+| Local root and metadata | Platform user-cache `traces/v1/local`, immutable fragments, typed Parquet catalogs, and atomic `active.json` revision |
+| JSON coverage envelope | Sparse `--json` stays stable; `--json-envelope` returns `runs/source/coverage/diagnostics` |
+| Coverage enforcement | `--require-complete` succeeds only when authoritative/sealed evidence, compatible pull batches, or `IdentityComplete` evidence covers the exact trace request |
+| Trace pull scope | IDs or a bounded query add/upsert selected complete trace bundles and preserve unrelated inventory |
+| Capacity and eviction | No maximum, TTL, or LRU initially; users explicitly remove traces or evict the whole disposable cache |
+| Coverage | Trace presence is separate from interval coverage; only compatible successful pull batches prove time-window completeness |
+| Dataset terminology | Use LangSmith Dataset/Example everywhere; no parallel CLI or storage-level collection domain |
+| Dataset schema authority | Pinned strict LangSmith SDK Dataset, Example, and DatasetVersion models plus explicit migrations |
+| Dataset mutation | Cloud only initially; archive/local are read-only exact-version replicas |
+| Dataset append | Mutate in cloud, then fast-forward the newer exact version into archive/local; never union example rows |
+| Dataset identity | Source namespace plus Dataset ID; preserve Dataset/Example IDs in replicas and treat names as labels |
+| Dataset completeness | Preserve schemas, transformations, metadata, splits, version tags, deletions, and attachment bytes |
+| Dataset history scope | Default pull freezes `latest`; `--as-of` copies one version and `--all-versions` copies complete available history |
+| Dataset/trace relationship | `source_run_id` remains optional lineage; linked full traces transfer only through a separate explicit phase |
+| JSONL import identity | One project per import; unanimous `session_id` or required matching `--project-id`; filename ignored |
+| Local encryption | No built-in crypto or secure erase; user-only permissions plus OS/encrypted-volume controls |
+| Parquet layout | Sort by `session_id,start_time,id`; Zstd level 3; 122,880-row groups; ~512 MiB files; no Hive partitioning |
+| Local physical retention | Current logical inventory persists until explicit removal/eviction; superseded physical observations disappear during compaction |
+
+# Appendix C: explicitly deferred proposals
+
+| Proposal | Why it is not open in this design | Re-entry gate |
+|---|---|---|
+| Multi-source union and precedence | The approved product contract returns rows from exactly one source; comparison covers near-term audit value | Separate federation design covering membership, precedence, deduplication, ordering, count, and combined coverage |
+| Native `.duckdb` cache storage | Parquet is the selected cache format and reuses the archive schema/compiler | Representative benchmark shows a material end-to-end win and a safe multi-process locking/rebuild model |
+| Multiple named local trace caches | Datasets organize evaluation examples, not trace-cache capacity; initial `local` remains one accumulating inventory | A workflow needs different security/capacity/eviction policies and cannot use explicit trace removal |
+| Writable local dataset forks | Initial replicas intentionally delegate all mutation semantics to LangSmith | One SDK-backed mutation engine demonstrates schema/transformation/split/attachment/version parity |
+| Dataset replica upload to cloud | Creating a new cloud lineage involves ID remapping and cloud validation | Separate import design defines lineage, conflicts, transformations, and attachment behavior |
+
+# Appendix D: review record
+
+| Pass | Lens | Change made |
+|---|---|---|
+| 1 | Core architecture | Separated source, backend, catalog, fragment, store, and executor; introduced one typed query boundary |
+| 2 | Product | Defined three user-visible truth questions, explicit source choice, and capability-versus-coverage behavior |
+| 3 | Usage/workflows | Tested current incidents, old history, retention, offline work, reproduction, and publication audit end to end |
+| 4 | Red team | Added failure cases and guardrails for identity, staleness, filtered data, atomicity, schema drift, determinism, and network isolation |
+| 5 | Final decision | Narrowed initial parity to core trace reads, clarified non-goals, and retained comparison while deferring merged results |
+| 6 | Local cache follow-up | Selected Parquet as the only cache format and removed durable local revision semantics |
+| 7 | Open-question pass 1 | Fixed lifecycle commands, the original bounded replacement semantics, JSON evidence, coverage policy, and import identity |
+| 8 | Open-question pass 2 | Fixed filesystem, permissions, encryption stance, Parquet sizing, and explicit re-entry gates for deferred proposals |
+| 9 | Accumulating-cache correction | Replaced global snapshot semantics with set-union/upsert, immutable deltas, explicit removal, and a batch coverage ledger |
+| 10 | Collection/product pass | Explored a custom trace-membership abstraction and cross-source download/append workflows |
+| 11 | Collection red-team pass | Identified revision, identity, partial-transfer, and overwrite hazards in that custom abstraction |
+| 12 | Dataset-model correction | Removed the custom abstraction; adopted strict Dataset/Example/version semantics for cloud, archive, and local |
+| 13 | Dataset parity pass | Made non-cloud replicas read-only, separated linked traces, preserved attachments/splits/transformations, and required fast-forward publication |

--- a/docs/TRACE_SOURCES_DESIGN.md
+++ b/docs/TRACE_SOURCES_DESIGN.md
@@ -641,7 +641,11 @@ from a complete copied history.
 **A replica is identified by source namespace plus Dataset ID, never by name.** The
 destination catalog stores origin workspace/source, source dataset ID, fetched
 version, content digest, and transfer time outside the Dataset object. Dataset and
-Example IDs are preserved in local/archive replicas; names remain lookup labels.
+Example IDs are preserved in local/archive replicas; names remain mutable lookup
+labels in the head and are deliberately excluded from immutable content identity.
+LangSmith's DatasetVersion freezes Example membership/content, while the Dataset
+envelope is observed at transfer time; the CLI does not claim a historical Dataset
+metadata API that LangSmith itself does not expose.
 
 | Situation | Decision |
 |---|---|
@@ -669,8 +673,8 @@ fast-forward replica.
 | 2 | Read the full Dataset object, version/tag records, and all examples at that `as_of` |
 | 3 | Fetch attachment bytes, validate media/name/digest metadata, and reject expiring URLs as stored content |
 | 4 | Validate every strict SDK object and cross-reference Dataset/Example IDs |
-| 5 | Write immutable dataset/example/version Parquet plus content-addressed attachment blobs |
-| 6 | Reopen and round-trip all typed records; conditionally publish the destination head |
+| 5 | Write content-addressed dataset/example Parquet, content-addressed attachment blobs, and one uniquely staged immutable manifest |
+| 6 | Verify object digests, then compare-and-swap the destination head; on contention, reread and merge independent versions |
 | 7 | Optionally materialize linked source traces as a separate, auditable phase |
 
 The dataset transaction is all-or-nothing. The optional trace phase has its own
@@ -685,15 +689,23 @@ Dataset replicas are separate from the trace cache while sharing DuckDB as the
 reader:
 
 ```text
-<langsmith-cli user cache>/datasets/v1/local/
-  active.json
-  datasets/<origin-namespace>/<dataset-id>/
-    versions/<version-digest>/dataset.parquet
-    versions/<version-digest>/examples-*.parquet
-    versions/<version-digest>/version.parquet
-  attachments/sha256/<digest>
-  staging/
+<replica-root>/
+  datasets/
+    heads/<dataset-id>.json
+    <dataset-id>/versions/<sha256(as-of)>/
+      objects/
+        dataset-<sha256>.parquet
+        examples-<sha256>.parquet
+      manifests/<publication-uuid>.json
+    blobs/<attachment-sha256>
+  .locks/<head-key-sha256>.lock        # local backend only
 ```
+
+The head is the only reachability boundary. Writers may leave unreachable staged
+objects after losing a race, but they cannot overwrite the bytes selected by the
+winning head: Parquet/blob keys are content-addressed and manifests are unique.
+Local writes stream to an adjacent temporary file, `fsync`, and atomically replace
+the target. Readers verify every Parquet and attachment digest before deserializing.
 
 Parquet remains the typed query format for Dataset/Example/version rows. Attachments
 are content-addressed binary blobs because wrapping arbitrary media in Parquet would
@@ -1121,6 +1133,13 @@ federation.**
 | S12 | `source_run_id` is optional lineage and never substitutes for copied trace content | Dataset/trace transfer boundary |
 | S13 | Pull/add preserves unrelated local traces; compaction preserves the logical trace inventory | Cache manager parity checks |
 | S14 | Attachment bytes and all historical dataset versions remain addressable for every published archive version | Dataset manifest validation |
+| S15 | `(Dataset ID, as_of)` identifies exactly one canonical Dataset/Example/attachment snapshot | Content digest comparison before idempotent return |
+| S16 | A published head references only complete immutable objects from one manifest, including under concurrent writers | Content-addressed objects, unique manifests, and head CAS |
+| S17 | Concurrent writers of independent versions merge by rereading the winning head; they never discard an already-published version | Bounded head-CAS retry loop |
+| S18 | Every replicated Example has the same `dataset_id` as its Dataset and example IDs are unique within a snapshot | Pre-publication cross-reference validation |
+| S19 | SDK contract additions/removals fail before read or publication rather than silently dropping fields | Runtime model-field-set assertion plus contract test |
+| S20 | Dataset names can change without changing stable Dataset identity or rewriting immutable version content | Mutable head label plus ID-based storage keys |
+| S21 | Catalog JSON, manifest cross-references, row counts, Dataset/Example IDs, and object digests are validated before SDK reconstruction | Replica schema and integrity boundary |
 
 # Appendix B: resolved follow-up decisions
 

--- a/docs/TRACE_SOURCES_DESIGN.md
+++ b/docs/TRACE_SOURCES_DESIGN.md
@@ -637,6 +637,10 @@ and tag mapping. `datasets versions --source archive|local` reports versions act
 present in that replica, while `datasets status` distinguishes a one-version checkout
 from a complete copied history.
 
+`--all-versions` and a non-default `--as-of` are mutually exclusive. A transfer also
+requires distinct physical repositories: selecting `archive` and `local` labels that
+resolve to the same directory fails before reading or publishing a snapshot.
+
 ### Identity, lineage, and conflict policy
 
 **A replica is identified by source namespace plus Dataset ID, never by name.** The
@@ -993,6 +997,7 @@ semantics, and warn-or-fail by explicit policy for insufficient coverage.
 | A large Dataset is pulled | Multiple full Python copies exhaust the workstation before DuckDB batching | Stream SDK pages into bounded Pydantic batches and disk-backed DuckDB staging; stream attachments in fixed chunks |
 | SDK adds or changes a required field | Replica silently drops cloud semantics | Fail schema compatibility until explicit migration and round-trip fixture exist |
 | Backend compilers order ties differently | `--limit` returns different runs | Canonical ordering includes a stable run-ID tie-breaker |
+| A list backend pages before client-side filtering or sorting | A valid match disappears or the wrong row occupies the page | Use one typed filter → sort → offset/limit pipeline; defer cloud pagination when a client-side operation requires the complete eligible set |
 | Example filtering is pushed down differently | Cloud and DuckDB disagree on examples/splits | Shared typed semantics and cross-backend golden fixtures |
 | A local path references outside the cache | Metadata points DuckDB at unintended workstation files | Canonicalize paths and enforce a fixed root after symlink resolution |
 | DuckDB installs or auto-loads an unapproved extension | A “local” query reaches the network | Preload only bundled allowlisted format support; disable external access and unapproved extension loading |

--- a/docs/TRACE_SOURCES_DESIGN.md
+++ b/docs/TRACE_SOURCES_DESIGN.md
@@ -573,10 +573,11 @@ are added. Dataset and Example are strict typed objects at the backend boundary;
 replica catalog metadata is a separate typed transfer envelope, never injected into
 their metadata fields.
 
-Service-derived Dataset summary fields such as experiment/session counts and last
-session time are preserved exactly as observed at pull time, with that observation
-time in the replica envelope. They do not imply that associated experiments,
-feedback, or runs were copied, and they do not update while the replica is offline.
+The complete Dataset envelope is mutable catalog state, exactly as it is in
+LangSmith. A successful pull refreshes its name, description, schemas, metadata,
+counts, and timestamps without rewriting an immutable DatasetVersion. Those fields
+remain the last source observation while the replica is offline; service-derived
+session/experiment summaries do not imply that their runs or feedback were copied.
 
 This contract follows LangSmith's official
 [dataset management model](https://docs.langchain.com/langsmith/manage-datasets-in-application),
@@ -639,22 +640,23 @@ from a complete copied history.
 ### Identity, lineage, and conflict policy
 
 **A replica is identified by source namespace plus Dataset ID, never by name.** The
-destination catalog stores origin workspace/source, source dataset ID, fetched
-version, content digest, and transfer time outside the Dataset object. Dataset and
-Example IDs are preserved in local/archive replicas; names remain mutable lookup
-labels in the head and are deliberately excluded from immutable content identity.
-LangSmith's DatasetVersion freezes Example membership/content, while the Dataset
-envelope is observed at transfer time; the CLI does not claim a historical Dataset
-metadata API that LangSmith itself does not expose.
+destination catalog stores the current Dataset envelope plus fetched versions,
+content digests, and manifest digests. Dataset and Example IDs are preserved in
+local/archive replicas. LangSmith's DatasetVersion freezes Example
+membership/content and attachments; the complete Dataset envelope remains mutable
+head state and is deliberately excluded from immutable version identity. An
+archive/local `datasets get --as-of` validates that the requested version exists but
+returns the current Dataset envelope, because LangSmith exposes no historical
+Dataset-metadata API.
 
 | Situation | Decision |
 |---|---|
-| Pull same dataset/version again | Idempotent no-op after digest verification |
+| Pull same dataset/version again | Idempotent version no-op after digest verification; refresh mutable Dataset catalog state |
 | Pull a later version from the same lineage | Fast-forward; retain the older version and publish the new immutable head |
 | Pull an older version from the same lineage | Add the historical snapshot; do not move the current head backward |
 | Same name, different source Dataset ID | Keep as distinct datasets; ambiguous name lookup fails |
 | Destination head is not an ancestor of incoming version | Fail divergence; no example-by-example merge |
-| Same lineage and `as_of`, different canonical digest | Fail corruption/divergence; never choose one silently |
+| Same lineage and `as_of`, different canonical Example/attachment digest | Fail corruption/divergence; never choose one silently |
 | Example deleted in a newer version | Absent from that version, present when reading an older `as_of` version |
 | Source dataset later deleted | Existing local/archive replicas remain; deletion never propagates implicitly |
 
@@ -670,11 +672,11 @@ fast-forward replica.
 | Step | Required behavior |
 |---:|---|
 | 1 | Resolve the source dataset by ID/name and freeze an exact timestamp/tag target |
-| 2 | Read the full Dataset object, version/tag records, and all examples at that `as_of` |
-| 3 | Fetch attachment bytes, validate media/name/digest metadata, and reject expiring URLs as stored content |
+| 2 | Read the current Dataset catalog object, version/tag records, and all examples at that `as_of` |
+| 3 | Stream attachment bytes into bounded local staging, validate media/name/digest metadata, and reject expiring URLs as stored content |
 | 4 | Validate every strict SDK object and cross-reference Dataset/Example IDs |
-| 5 | Write content-addressed dataset/example Parquet, content-addressed attachment blobs, and one uniquely staged immutable manifest |
-| 6 | Verify object digests, then compare-and-swap the destination head; on contention, reread and merge independent versions |
+| 5 | Stream Examples through a disk-backed DuckDB staging table into content-addressed Parquet; stage content-addressed attachment blobs and one unique immutable manifest |
+| 6 | Authenticate the manifest digest from the head, verify object/canonical digests, then compare-and-swap the destination head; on contention, reread and merge independent versions and unique tag pointers |
 | 7 | Optionally materialize linked source traces as a separate, auditable phase |
 
 The dataset transaction is all-or-nothing. The optional trace phase has its own
@@ -691,10 +693,9 @@ reader:
 ```text
 <replica-root>/
   datasets/
-    heads/<dataset-id>.json
+    heads/<dataset-id>.json             # schema v2: current Dataset + versions
     <dataset-id>/versions/<sha256(as-of)>/
       objects/
-        dataset-<sha256>.parquet
         examples-<sha256>.parquet
       manifests/<publication-uuid>.json
     blobs/<attachment-sha256>
@@ -705,15 +706,21 @@ The head is the only reachability boundary. Writers may leave unreachable staged
 objects after losing a race, but they cannot overwrite the bytes selected by the
 winning head: Parquet/blob keys are content-addressed and manifests are unique.
 Local writes stream to an adjacent temporary file, `fsync`, and atomically replace
-the target. Readers verify every Parquet and attachment digest before deserializing.
+the target. Each head version stores the SHA-256 of its exact manifest bytes; readers
+verify that trust edge, the Parquet/blob digests, row counts, cross-references, and
+the canonical Example/attachment digest before constructing any SDK Example.
 
-Parquet remains the typed query format for Dataset/Example/version rows. Attachments
+Parquet remains the typed query format for immutable Example-version rows. The
+current strict Pydantic Dataset envelope and movable tag pointers live in the CAS
+head because they are mutable LangSmith catalog state. Attachments
 are content-addressed binary blobs because wrapping arbitrary media in Parquet would
-not reproduce LangSmith attachment semantics. `active.json` exposes only validated
-versions and attachment digests. Dataset names, version tags, attachment names, and
-raw timestamps are metadata only and never become path components. Archive uses the
-equivalent object layout with conditionally published manifests and durable
-retention; local uses the same logical schema without a durability promise. Local
+not reproduce LangSmith attachment semantics. Heads expose only authenticated
+manifests and validated versions. Dataset names, version tags, attachment names, and
+raw timestamps are metadata only and never become path components; all identity
+timestamps are canonical aware UTC. Publication uses 1,000-row Pydantic batches, a
+disk-backed DuckDB staging database, and a dataset-specific memory cap. Archive uses
+the equivalent object layout with conditionally published heads and durable
+retention; local uses the same schema without a durability promise. Local
 performs no automatic version, TTL, size, or attachment eviction; `datasets evict`
 removes the replica explicitly, and garbage collection deletes attachment blobs
 only when no visible version references their digest.
@@ -979,6 +986,11 @@ semantics, and warn-or-fail by explicit policy for insufficient coverage.
 | A newer version deletes an example | Destination union resurrects deleted data | Publish the exact new version; preserve deletion in latest and older `as_of` snapshot separately |
 | Same dataset name exists in two workspaces | Pull advances the wrong replica | Identity is source namespace plus Dataset ID; ambiguous names fail |
 | A version tag moves later | Previously copied evidence changes meaning | Resolve tag to exact `as_of` at pull time and record both tag and resolution |
+| One transferred version moves a tag already present at the destination | The tag becomes ambiguous | Synchronize the source tag map and enforce at most one owner per tag inside the head CAS |
+| Equivalent instants use different timezone offsets | One version is published twice and makes the head unreadable | Canonicalize every identity timestamp to aware UTC before comparison or keying |
+| Dataset metadata changes without a new DatasetVersion | A routine refresh is rejected as divergent | Keep the Dataset envelope as mutable head state; version digests cover stable Dataset ID plus Examples/attachments |
+| A manifest redirects one version to another valid Parquet object | Historical reads return plausible data from the wrong version | Authenticate exact manifest bytes from the CAS head and recompute canonical content on read |
+| A large Dataset is pulled | Multiple full Python copies exhaust the workstation before DuckDB batching | Stream SDK pages into bounded Pydantic batches and disk-backed DuckDB staging; stream attachments in fixed chunks |
 | SDK adds or changes a required field | Replica silently drops cloud semantics | Fail schema compatibility until explicit migration and round-trip fixture exist |
 | Backend compilers order ties differently | `--limit` returns different runs | Canonical ordering includes a stable run-ID tie-breaker |
 | Example filtering is pushed down differently | Cloud and DuckDB disagree on examples/splits | Shared typed semantics and cross-backend golden fixtures |
@@ -1010,9 +1022,10 @@ semantics, and warn-or-fail by explicit policy for insufficient coverage.
   coverage as a policy.
 - Comparison uses stable identities and canonical digests. A same-ID/different-row
   result is reported as divergence, not deduplicated or assigned an implicit winner.
-- Dataset replication freezes one exact LangSmith version and round-trips strict
-  Dataset/Example models. It never unions examples, infers a custom membership
-  model, or mutates the dataset to record companion trace status.
+- Dataset replication freezes one exact LangSmith Example/attachment version and
+  round-trips strict Pydantic Dataset/Example contracts. The Dataset envelope and
+  unique version tags remain mutable catalog state, matching LangSmith rather than
+  inventing historical metadata semantics.
 - Cloud is the dataset mutation authority initially. Archive/local fast-forward
   exact versions from the same lineage and reject divergence.
 - `source_run_id` is optional lineage. Dataset completeness and optional linked-trace
@@ -1133,13 +1146,13 @@ federation.**
 | S12 | `source_run_id` is optional lineage and never substitutes for copied trace content | Dataset/trace transfer boundary |
 | S13 | Pull/add preserves unrelated local traces; compaction preserves the logical trace inventory | Cache manager parity checks |
 | S14 | Attachment bytes and all historical dataset versions remain addressable for every published archive version | Dataset manifest validation |
-| S15 | `(Dataset ID, as_of)` identifies exactly one canonical Dataset/Example/attachment snapshot | Content digest comparison before idempotent return |
-| S16 | A published head references only complete immutable objects from one manifest, including under concurrent writers | Content-addressed objects, unique manifests, and head CAS |
+| S15 | `(Dataset ID, canonical UTC as_of)` identifies exactly one canonical Example/attachment snapshot; Dataset metadata remains mutable catalog state | Content digest comparison before idempotent return plus mutable Pydantic Dataset head payload |
+| S16 | A published head references only complete immutable objects from one authenticated manifest, including under concurrent writers | Content-addressed objects, unique manifests, manifest SHA-256, and head CAS |
 | S17 | Concurrent writers of independent versions merge by rereading the winning head; they never discard an already-published version | Bounded head-CAS retry loop |
 | S18 | Every replicated Example has the same `dataset_id` as its Dataset and example IDs are unique within a snapshot | Pre-publication cross-reference validation |
 | S19 | SDK contract additions/removals fail before read or publication rather than silently dropping fields | Runtime model-field-set assertion plus contract test |
-| S20 | Dataset names can change without changing stable Dataset identity or rewriting immutable version content | Mutable head label plus ID-based storage keys |
-| S21 | Catalog JSON, manifest cross-references, row counts, Dataset/Example IDs, and object digests are validated before SDK reconstruction | Replica schema and integrity boundary |
+| S20 | The complete Dataset envelope can change without changing stable Dataset identity or rewriting immutable version content | Mutable strict Pydantic head payload plus ID-based storage keys |
+| S21 | Catalog JSON, authenticated manifest cross-references, row counts, Dataset/Example IDs, canonical content, and object digests are validated before SDK reconstruction | Replica schema-v2 and integrity boundary |
 
 # Appendix B: resolved follow-up decisions
 

--- a/docs/work-in-progress/tickets/codex-eng-6997-dataset-replicas-test-plan.md
+++ b/docs/work-in-progress/tickets/codex-eng-6997-dataset-replicas-test-plan.md
@@ -13,6 +13,16 @@
 - [x] One exact `DatasetVersion.as_of` is resolved before examples are fetched.
 - [x] Publication exposes a new head only after both Parquet objects, the manifest,
   and all attachment blobs are present.
+- [x] Concurrent independent versions both publish after CAS retries; concurrent
+  divergent content for one timestamp produces one winner and one typed conflict.
+- [x] Parquet objects are content-addressed, local writes replace atomically, and
+  every Parquet/attachment digest is verified before deserialization.
+- [x] `(Dataset ID, as_of)` is idempotent only for identical canonical content.
+- [x] Every Example belongs to the enclosing Dataset and duplicate IDs are rejected.
+- [x] LangSmith SDK model-field drift fails before publication instead of silently
+  omitting a new field.
+- [x] Malformed head/manifest JSON, cross-dataset manifest references, and row-count
+  mismatches fail as typed schema/integrity errors before SDK reconstruction.
 - [x] Dataset and example SDK fields round-trip through Parquet without changing
   IDs, timestamps, schemas, transformations, metadata, splits, or lineage.
 - [x] Attachment bytes are content-addressed and reconstructed with their name and

--- a/docs/work-in-progress/tickets/codex-eng-6997-dataset-replicas-test-plan.md
+++ b/docs/work-in-progress/tickets/codex-eng-6997-dataset-replicas-test-plan.md
@@ -7,6 +7,10 @@
 - [x] Pull the same version again and observe an idempotent result.
 - [x] Replicate an archive snapshot into the local store.
 - [x] List replica versions and select one with `--as-of`.
+- [x] Exercise every replica list filter, sort, projection, count, and pagination
+  option against both archive and local stores.
+- [x] Exercise selected-version, all-version, repeated/idempotent, and invalid
+  archive-to-local transfers through the public CLI.
 
 ## Correctness invariants
 
@@ -39,6 +43,11 @@
   MIME type.
 - [x] A dataset name cannot silently replace a different dataset ID in one store.
 - [x] Local and archive reads never instantiate or call the cloud client.
+- [x] Filtering and sorting always happen before `--offset`/`--limit`, independent
+  of whether the source performs some filters server-side.
+- [x] `latest` version selection is based on timestamps, never backend return order.
+- [x] Mutually exclusive transfer selectors and physically identical source/target
+  repositories fail before any snapshot is copied.
 
 ## CLI and regression coverage
 
@@ -47,5 +56,19 @@
 - [x] Existing cloud command arguments and calls remain unchanged by default.
 - [x] Invalid source/target combinations and unsupported offline filters fail with
   actionable errors.
+- [x] Non-positive limits, negative offsets, and non-object JSON option payloads
+  fail at the CLI boundary instead of producing source-dependent results.
 - [x] `skills/langsmith/SKILL.md` documents every new argument and workflow.
 - [x] Focused tests, full pytest, Ruff, Pyright, and startup-latency checks pass.
+
+## Final reality evidence
+
+- Public CLI matrix: 43/43 archive/local query, output, transfer, idempotence,
+  round-trip, and rejection cases passed.
+- Automated suite: 1,463 tests passed in 118.72 seconds; Ruff and Pyright passed.
+- Normal import latency stayed flat: parent median 273.8 ms, current median
+  273.9 ms over 20 warm samples. The operation-only Pydantic query/version modules
+  were absent from `sys.modules` after normal CLI import.
+- A selected tag reads exactly one authenticated manifest; filter-only cloud pages
+  stop after `offset + limit` survivors, while global sort is the only list operation
+  that requires full eligible-set materialization.

--- a/docs/work-in-progress/tickets/codex-eng-6997-dataset-replicas-test-plan.md
+++ b/docs/work-in-progress/tickets/codex-eng-6997-dataset-replicas-test-plan.md
@@ -1,0 +1,31 @@
+# ENG-6997 dataset replicas — test plan
+
+## User journey
+
+- [x] Pull an exact cloud dataset version into a local replica and read the same
+  dataset and examples without constructing a LangSmith client.
+- [x] Pull the same version again and observe an idempotent result.
+- [x] Replicate an archive snapshot into the local store.
+- [x] List replica versions and select one with `--as-of`.
+
+## Correctness invariants
+
+- [x] One exact `DatasetVersion.as_of` is resolved before examples are fetched.
+- [x] Publication exposes a new head only after both Parquet objects, the manifest,
+  and all attachment blobs are present.
+- [x] Dataset and example SDK fields round-trip through Parquet without changing
+  IDs, timestamps, schemas, transformations, metadata, splits, or lineage.
+- [x] Attachment bytes are content-addressed and reconstructed with their name and
+  MIME type.
+- [x] A dataset name cannot silently replace a different dataset ID in one store.
+- [x] Local and archive reads never instantiate or call the cloud client.
+
+## CLI and regression coverage
+
+- [x] `datasets pull`, `datasets versions`, source-aware `datasets list/get`, and
+  source-aware `examples list/get` cover both human and `--json` output.
+- [x] Existing cloud command arguments and calls remain unchanged by default.
+- [x] Invalid source/target combinations and unsupported offline filters fail with
+  actionable errors.
+- [x] `skills/langsmith/SKILL.md` documents every new argument and workflow.
+- [x] Focused tests, full pytest, Ruff, Pyright, and startup-latency checks pass.

--- a/docs/work-in-progress/tickets/codex-eng-6997-dataset-replicas-test-plan.md
+++ b/docs/work-in-progress/tickets/codex-eng-6997-dataset-replicas-test-plan.md
@@ -11,20 +11,30 @@
 ## Correctness invariants
 
 - [x] One exact `DatasetVersion.as_of` is resolved before examples are fetched.
-- [x] Publication exposes a new head only after both Parquet objects, the manifest,
-  and all attachment blobs are present.
+- [x] Publication exposes a new head only after Example Parquet, an authenticated
+  immutable manifest, and all attachment blobs are present.
 - [x] Concurrent independent versions both publish after CAS retries; concurrent
   divergent content for one timestamp produces one winner and one typed conflict.
 - [x] Parquet objects are content-addressed, local writes replace atomically, and
   every Parquet/attachment digest is verified before deserialization.
-- [x] `(Dataset ID, as_of)` is idempotent only for identical canonical content.
+- [x] `(Dataset ID, canonical UTC as_of)` is idempotent only for identical
+  Example/attachment content; mutable Dataset catalog metadata refreshes separately.
 - [x] Every Example belongs to the enclosing Dataset and duplicate IDs are rejected.
 - [x] LangSmith SDK model-field drift fails before publication instead of silently
   omitting a new field.
 - [x] Malformed head/manifest JSON, cross-dataset manifest references, and row-count
   mismatches fail as typed schema/integrity errors before SDK reconstruction.
-- [x] Dataset and example SDK fields round-trip through Parquet without changing
+- [x] Strict Pydantic Dataset and Example SDK fields round-trip without changing
   IDs, timestamps, schemas, transformations, metadata, splits, or lineage.
+- [x] Equivalent timestamp offsets collapse to one version identity and naive
+  timestamps fail before publication.
+- [x] A version tag has at most one owner and selected-version transfers synchronize
+  moved tag pointers.
+- [x] Redirecting an authenticated manifest to another valid Parquet object fails.
+- [x] Cloud/replica transfers stream Examples; attachment publication uses bounded
+  chunks; DuckDB staging is disk-backed and memory-capped.
+- [x] A global offline `examples list --as-of` skips unrelated histories that do
+  not contain the requested version.
 - [x] Attachment bytes are content-addressed and reconstructed with their name and
   MIME type.
 - [x] A dataset name cannot silently replace a different dataset ID in one store.

--- a/docs/work-in-progress/tickets/unified-dataset-trace-sources.md
+++ b/docs/work-in-progress/tickets/unified-dataset-trace-sources.md
@@ -1,0 +1,54 @@
+# Unify LangSmith datasets and traces across cloud, archive, and local sources
+
+## TL;DR
+
+**Expose cloud, archive, and local through one typed CLI facade while adopting the LangSmith Dataset and Example models without a parallel collection abstraction.** Deliver this in at most two independently useful PRs: exact dataset-version replicas first, then the accumulating DuckDB trace inventory and optional linked-trace materialization.
+
+## Plan
+
+| # | Independently usable PR | Capability after merge | Hard gate |
+|---:|---|---|---|
+| 1 | Exact dataset replicas | `datasets`/`examples` can read cloud, archive, or local; `datasets pull` publishes strict, read-only Dataset/Example versions with schemas, transformations, splits, tags, deletions, and attachment bytes | SDK-model round trips, frozen-version pagination, atomic publication, and cloud/archive/local CLI journeys pass |
+| 2 | Accumulating trace inventory | `runs` can query an additive DuckDB-over-Parquet local cache; explicit pulls preserve unrelated traces; dataset pulls can optionally materialize linked `source_run_id` traces | Coverage-ledger, idempotency, interruption, offline-network-denial, and cross-backend predicate tests pass |
+
+The critical path is PR 1 → PR 2. Do not split storage, CLI, and tests into separate PRs; each PR must expose a complete user workflow.
+
+## Why now — one model prevents permanent drift
+
+LangSmith datasets already define the semantics needed for organizing evaluation data. Recreating a trace-specific collection would duplicate identities, examples, versions, splits, transformations, metadata, and attachment behavior.
+
+| Concern | Decision | User-visible result |
+|---|---|---|
+| Dataset identity | Source namespace plus Dataset ID; names are labels | Same-name datasets never overwrite each other |
+| Dataset semantics | Strict pinned LangSmith `Dataset`, `Example`, and `DatasetVersion` contracts | Cloud/archive/local return the same shapes |
+| Mutation | Cloud is authoritative initially | LangSmith alone applies validation, transformations, splits, attachments, and version creation |
+| Archive/local | Exact, read-only version replicas | `--as-of` remains reproducible and later versions fast-forward safely |
+| Trace relationship | `source_run_id` remains optional lineage | Dataset transfer succeeds independently of trace retention |
+| Local traces | Accumulating inventory with explicit removal | Pulling new work never replaces unrelated cached traces |
+
+## Decisions and non-goals
+
+| Decision | Rationale |
+|---|---|
+| Use the existing `datasets` and `examples` commands with `--source` | Avoid a second facade and preserve current cloud scripts |
+| Store typed rows in Parquet and attachments as content-addressed blobs | DuckDB can query strict data while arbitrary media retains native bytes |
+| Freeze one exact `as_of` before pagination | A replica must never mix two cloud versions |
+| Publish archive/local heads atomically | Readers see either the previous complete version or the new complete version |
+| Keep dataset replication separate from linked trace transfer | An example without a live source trace is still a valid example |
+| Defer writable local dataset forks | Reimplementing cloud mutation semantics would recreate the drift risk |
+| Defer multi-source query union | Precedence, overlap, ordering, and coverage require a separate correctness design |
+
+## Definition of done
+
+- [ ] `datasets list/get/status`, `examples list/get`, and `datasets versions` accept one named source and preserve sparse JSON output.
+- [ ] `datasets pull` supports exact `latest`, `--as-of`, and `--all-versions` replication from cloud to archive/local and archive to local.
+- [ ] Dataset replicas preserve strict SDK fields, schemas, transformations, metadata, splits, version tags, deletions, and attachment bytes.
+- [ ] Archive/local replicas are read-only, same-lineage pulls are idempotent/fast-forward only, and divergent identities fail before publication.
+- [ ] The local trace cache is additive, deduplicated, Parquet-only, and has no automatic TTL/LRU/size eviction.
+- [ ] Optional linked-trace materialization writes only to the trace inventory and reports status separately from dataset replication.
+- [ ] All new CLI arguments are documented in `skills/langsmith/SKILL.md`; human and sparse `--json` journeys are covered.
+- [ ] Unit, integration, full-suite, startup-latency, formatting, and type checks pass with measured evidence in each PR.
+
+## Background
+
+The existing CLI already supports LangSmith datasets/examples in cloud and durable trace archives through local/S3 object stores. The design extends those primitives instead of replacing them: archive/local dataset versions use the same strict SDK contracts, while trace caching remains a separate additive source. The canonical design is `docs/TRACE_SOURCES_DESIGN.md` in the repository.

--- a/skills/langsmith/SKILL.md
+++ b/skills/langsmith/SKILL.md
@@ -125,6 +125,11 @@ langsmith-cli --json runs get <id> --fields inputs,outputs,error
 | View experiment results | `langsmith-cli --json experiments results <experiment-name>` |
 | Open run in browser | Construct URL manually — see **LangSmith URLs** section below |
 
+Dataset/example list bounds are strict and source-independent: `--limit` must be
+positive, `--offset` must be non-negative, and filtering/sorting happens before the
+page is selected. Do not combine `datasets pull --all-versions` with a non-default
+`--as-of`.
+
 ---
 
 ## 📚 When to Read Reference Files

--- a/skills/langsmith/SKILL.md
+++ b/skills/langsmith/SKILL.md
@@ -113,7 +113,10 @@ langsmith-cli --json runs get <id> --fields inputs,outputs,error
 | Count runs | `langsmith-cli --json runs list --project <name> --count` |
 | Run stats | `langsmith-cli --json runs stats --project <name>` |
 | Stratified run sample | `langsmith-cli --json runs sample --project <name> --stratify-by tag:<key> --values a,b --fields id,name,stratum` |
-| List datasets | `langsmith-cli --json datasets list --fields id,name` |
+| List cloud datasets | `langsmith-cli --json datasets list --source cloud --fields id,name` |
+| Pull dataset locally | `langsmith-cli --json datasets pull <name-or-id> --to local` |
+| List local datasets | `langsmith-cli --json datasets list --source local --fields id,name` |
+| List dataset versions | `langsmith-cli --json datasets versions <name-or-id> --source local` |
 | List prompts | `langsmith-cli --json prompts list --fields repo_handle,description` |
 | List feedback for a run | `langsmith-cli --json feedback list --run-id <run-id> --fields id,key,score` |
 | Create feedback | `langsmith-cli --json feedback create <run-id> --key correctness --score 0.9` |

--- a/skills/langsmith/references/datasets.md
+++ b/skills/langsmith/references/datasets.md
@@ -9,6 +9,9 @@ langsmith-cli --json datasets list [OPTIONS]
 ```
 
 **Options:**
+- `--source [cloud|archive|local]` - Read from one backend (default: `cloud`)
+- `--archive-uri TEXT` - Archive root; defaults to `LANGSMITH_ARCHIVE_URI`
+- `--local-dir DIRECTORY` - Override the platform-local dataset cache
 - `--limit INTEGER` - Maximum results (default: 20)
 - `--name TEXT` - Filter by exact dataset name
 - `--name-contains TEXT` - Filter by name substring
@@ -47,13 +50,17 @@ langsmith-cli --json datasets list --data-type llm
 Get dataset details.
 
 ```bash
-langsmith-cli --json datasets get <dataset-id> [OPTIONS]
+langsmith-cli --json datasets get <dataset-id-or-name> [OPTIONS]
 ```
 
 **Arguments:**
-- `dataset-id` (required) - Dataset UUID
+- `dataset-id-or-name` (required) - Dataset UUID, or a unique replica name
 
 **Options:**
+- `--source [cloud|archive|local]` - Read from one backend (default: `cloud`)
+- `--as-of TEXT` - Replica version tag or ISO timestamp (default: `latest`)
+- `--archive-uri TEXT` - Archive root; defaults to `LANGSMITH_ARCHIVE_URI`
+- `--local-dir DIRECTORY` - Override the platform-local dataset cache
 - `--fields TEXT` - Comma-separated field names to include
 - `--output TEXT` - Write output to file (JSON format)
 
@@ -63,6 +70,57 @@ langsmith-cli --json datasets get <dataset-id> [OPTIONS]
 ```bash
 langsmith-cli --json datasets get "ae99b6fa-a6db-4f1c-8868-bc6764f4c29e"
 ```
+
+### `datasets pull`
+
+Copy exact, read-only dataset versions between backends. Cloud is the mutation
+authority; archive and local replicas preserve LangSmith `Dataset`, `Example`, and
+`DatasetVersion` fields in Parquet, with attachment bytes stored separately.
+
+```bash
+langsmith-cli --json datasets pull <dataset-id-or-name> --to local [OPTIONS]
+```
+
+**Options:**
+- `--source [cloud|archive|local]` - Source backend (default: `cloud`)
+- `--to [archive|local]` - Destination backend (required)
+- `--as-of TEXT` - Exact version tag or ISO timestamp (default: `latest`)
+- `--all-versions` - Replicate every version, oldest first
+- `--archive-uri TEXT` - Archive root; defaults to `LANGSMITH_ARCHIVE_URI`
+- `--local-dir DIRECTORY` - Override the platform-local dataset cache
+
+```bash
+# Freeze the latest cloud version for offline intermediate work
+langsmith-cli --json datasets pull my-evals --to local
+
+# Publish all cloud versions into the durable archive
+langsmith-cli --json datasets pull my-evals --to archive --all-versions
+
+# Hydrate local work from an archive without contacting LangSmith
+langsmith-cli --json datasets pull my-evals --source archive --to local
+```
+
+Repeated pulls of the same exact version are idempotent. Use `--archive-uri` when
+the command needs the archive; local data defaults to the OS cache directory.
+
+### `datasets versions`
+
+```bash
+langsmith-cli --json datasets versions <dataset-id-or-name> \
+  --source [cloud|archive|local]
+```
+
+Lists exact timestamps and tags available in the selected backend. Archive/local
+versions are immutable replica snapshots.
+
+### `datasets status`
+
+```bash
+langsmith-cli --json datasets status --source [archive|local]
+```
+
+Lists replicated dataset identities, latest timestamps, version counts, and the
+resolved storage URI.
 
 ### `datasets create`
 

--- a/skills/langsmith/references/datasets.md
+++ b/skills/langsmith/references/datasets.md
@@ -59,7 +59,9 @@ langsmith-cli --json datasets get <dataset-id-or-name> [OPTIONS]
 **Options:**
 - `--source [cloud|archive|local]` - Read from one backend (default: `cloud`)
 - `--as-of TEXT` - Archive/local version tag or ISO timestamp (default: `latest`);
-  cloud Dataset metadata has no versioned read API, so non-latest cloud values fail
+  this validates replica version availability but returns the current mutable
+  Dataset catalog envelope; cloud Dataset metadata has no versioned read API, so
+  non-latest cloud values fail
 - `--archive-uri TEXT` - Archive root; defaults to `LANGSMITH_ARCHIVE_URI`
 - `--local-dir DIRECTORY` - Override the platform-local dataset cache
 - `--fields TEXT` - Comma-separated field names to include
@@ -75,8 +77,9 @@ langsmith-cli --json datasets get "ae99b6fa-a6db-4f1c-8868-bc6764f4c29e"
 ### `datasets pull`
 
 Copy exact, read-only dataset versions between backends. Cloud is the mutation
-authority; archive and local replicas preserve LangSmith `Dataset`, `Example`, and
-`DatasetVersion` fields in Parquet, with attachment bytes stored separately.
+authority; archive and local replicas preserve the current strict Pydantic `Dataset`
+catalog envelope plus exact `Example`/`DatasetVersion` state. Immutable Examples use
+Parquet and attachment bytes are stored separately.
 
 ```bash
 langsmith-cli --json datasets pull <dataset-id-or-name> --to local [OPTIONS]
@@ -101,10 +104,12 @@ langsmith-cli --json datasets pull my-evals --to archive --all-versions
 langsmith-cli --json datasets pull my-evals --source archive --to local
 ```
 
-Repeated pulls of the same exact version are idempotent only when the canonical
-Dataset/Example/attachment content matches; divergent content at the same timestamp
-fails. Parquet and attachments are content-addressed and digest-verified, while a
-compare-and-swap head safely merges concurrent pulls of independent versions. Use
+Repeated pulls of the same exact version are idempotent when canonical
+Example/attachment content matches; Dataset metadata refreshes independently in the
+mutable head. Divergent version content at the same canonical UTC timestamp fails.
+Parquet, attachments, and exact manifest bytes are digest-verified, while a
+compare-and-swap head safely merges concurrent versions and keeps each movable tag
+unique. Use
 `--archive-uri` when the command needs the archive; local data defaults to the OS
 cache directory.
 

--- a/skills/langsmith/references/datasets.md
+++ b/skills/langsmith/references/datasets.md
@@ -12,7 +12,8 @@ langsmith-cli --json datasets list [OPTIONS]
 - `--source [cloud|archive|local]` - Read from one backend (default: `cloud`)
 - `--archive-uri TEXT` - Archive root; defaults to `LANGSMITH_ARCHIVE_URI`
 - `--local-dir DIRECTORY` - Override the platform-local dataset cache
-- `--limit INTEGER` - Maximum results (default: 20)
+- `--limit INTEGER` - Maximum results after filtering and sorting (default: 20;
+  must be at least 1)
 - `--name TEXT` - Filter by exact dataset name
 - `--name-contains TEXT` - Filter by name substring
 - `--dataset-ids TEXT` - Comma-separated list of dataset UUIDs
@@ -112,6 +113,10 @@ compare-and-swap head safely merges concurrent versions and keeps each movable t
 unique. Use
 `--archive-uri` when the command needs the archive; local data defaults to the OS
 cache directory.
+
+`--all-versions` cannot be combined with a non-default `--as-of` selection. Source
+and destination must also resolve to different physical repositories; changing only
+the source label does not make one directory a valid transfer pair.
 
 ### `datasets versions`
 

--- a/skills/langsmith/references/datasets.md
+++ b/skills/langsmith/references/datasets.md
@@ -58,7 +58,8 @@ langsmith-cli --json datasets get <dataset-id-or-name> [OPTIONS]
 
 **Options:**
 - `--source [cloud|archive|local]` - Read from one backend (default: `cloud`)
-- `--as-of TEXT` - Replica version tag or ISO timestamp (default: `latest`)
+- `--as-of TEXT` - Archive/local version tag or ISO timestamp (default: `latest`);
+  cloud Dataset metadata has no versioned read API, so non-latest cloud values fail
 - `--archive-uri TEXT` - Archive root; defaults to `LANGSMITH_ARCHIVE_URI`
 - `--local-dir DIRECTORY` - Override the platform-local dataset cache
 - `--fields TEXT` - Comma-separated field names to include
@@ -100,8 +101,12 @@ langsmith-cli --json datasets pull my-evals --to archive --all-versions
 langsmith-cli --json datasets pull my-evals --source archive --to local
 ```
 
-Repeated pulls of the same exact version are idempotent. Use `--archive-uri` when
-the command needs the archive; local data defaults to the OS cache directory.
+Repeated pulls of the same exact version are idempotent only when the canonical
+Dataset/Example/attachment content matches; divergent content at the same timestamp
+fails. Parquet and attachments are content-addressed and digest-verified, while a
+compare-and-swap head safely merges concurrent pulls of independent versions. Use
+`--archive-uri` when the command needs the archive; local data defaults to the OS
+cache directory.
 
 ### `datasets versions`
 

--- a/skills/langsmith/references/examples.md
+++ b/skills/langsmith/references/examples.md
@@ -9,6 +9,9 @@ langsmith-cli --json examples list [OPTIONS]
 ```
 
 **Options:**
+- `--source [cloud|archive|local]` - Read from one backend (default: `cloud`)
+- `--archive-uri TEXT` - Archive root; defaults to `LANGSMITH_ARCHIVE_URI`
+- `--local-dir DIRECTORY` - Override the platform-local dataset cache
 - `--dataset TEXT` (required) - Dataset name or UUID
 - `--limit INTEGER` - Maximum results (default: 20)
 - `--offset INTEGER` - Skip N examples (default: 0)
@@ -50,7 +53,14 @@ langsmith-cli --json examples list \
 
 # Paginated access
 langsmith-cli --json examples list --dataset "my-dataset" --offset 100 --limit 50
+
+# Offline read from an exact local replica
+langsmith-cli --json examples list --dataset "my-dataset" --source local \
+  --as-of baseline
 ```
+
+`--filter` is cloud-only in the initial replica implementation. ID, metadata,
+split, pagination, field selection, and sorting filters work for replica sources.
 
 ### `examples get`
 
@@ -65,6 +75,10 @@ langsmith-cli --json examples get <example-id> [OPTIONS]
 
 **Options:**
 - `--as-of TEXT` - Version tag or ISO timestamp
+- `--source [cloud|archive|local]` - Read from one backend (default: `cloud`)
+- `--archive-uri TEXT` - Archive root; defaults to `LANGSMITH_ARCHIVE_URI`
+- `--local-dir DIRECTORY` - Override the platform-local dataset cache
+- `--include-attachments` - Rehydrate replica attachment readers from durable blobs
 - `--fields TEXT` - Comma-separated field names to include
 - `--output TEXT` - Write output to file (JSON format)
 

--- a/skills/langsmith/references/examples.md
+++ b/skills/langsmith/references/examples.md
@@ -21,6 +21,7 @@ langsmith-cli --json examples list [OPTIONS]
 - `--splits TEXT` - Comma-separated list of splits (e.g., "train,test")
 - `--as-of TEXT` - Version tag or ISO timestamp
 - `--inline-s3-urls`, `--no-inline-s3-urls` - Include or omit S3 URLs inline
+  (cloud only; explicit use with archive/local fails instead of being ignored)
 - `--include-attachments`, `--no-include-attachments` - Include or omit attachments
 - `--exclude TEXT` - Exclude items containing substring (repeatable)
 - `--fields TEXT` - Comma-separated field names to include
@@ -74,7 +75,8 @@ langsmith-cli --json examples get <example-id> [OPTIONS]
 - `example-id` (required) - Example UUID
 
 **Options:**
-- `--as-of TEXT` - Version tag or ISO timestamp
+- `--as-of TEXT` - Archive/local version tag or ISO timestamp; cloud `get`
+  accepts ISO timestamps only because the SDK requires a `datetime`
 - `--source [cloud|archive|local]` - Read from one backend (default: `cloud`)
 - `--archive-uri TEXT` - Archive root; defaults to `LANGSMITH_ARCHIVE_URI`
 - `--local-dir DIRECTORY` - Override the platform-local dataset cache

--- a/skills/langsmith/references/examples.md
+++ b/skills/langsmith/references/examples.md
@@ -13,8 +13,10 @@ langsmith-cli --json examples list [OPTIONS]
 - `--archive-uri TEXT` - Archive root; defaults to `LANGSMITH_ARCHIVE_URI`
 - `--local-dir DIRECTORY` - Override the platform-local dataset cache
 - `--dataset TEXT` (required) - Dataset name or UUID
-- `--limit INTEGER` - Maximum results (default: 20)
-- `--offset INTEGER` - Skip N examples (default: 0)
+- `--limit INTEGER` - Maximum results after filtering and sorting (default: 20;
+  must be at least 1)
+- `--offset INTEGER` - Skip N examples after filtering and sorting (default: 0;
+  must be non-negative)
 - `--example-ids TEXT` - Comma-separated list of example UUIDs
 - `--filter TEXT` - Advanced FQL query
 - `--metadata JSON` - Filter by metadata (JSON object)
@@ -62,6 +64,9 @@ langsmith-cli --json examples list --dataset "my-dataset" --source local \
 
 `--filter` is cloud-only in the initial replica implementation. ID, metadata,
 split, pagination, field selection, and sorting filters work for replica sources.
+The uniform list pipeline is filter, then sort, then offset/limit; cloud fetches an
+unbounded SDK page only when a client-side option such as `--sort-by` or `--exclude`
+requires it.
 
 ### `examples get`
 

--- a/src/langsmith_cli/archive/duckdb.py
+++ b/src/langsmith_cli/archive/duckdb.py
@@ -42,6 +42,7 @@ ARCHIVE_PARQUET_COPY_OPTIONS = (
 
 class DuckConnection(Protocol):
     def execute(self, query: str, parameters: object | None = None) -> Any: ...
+    def fetchmany(self, size: int = 1) -> list[tuple[Any, ...]]: ...
 
 
 def configure_duckdb_resources(
@@ -64,14 +65,23 @@ def configure_duckdb_resources(
 @contextmanager
 def archive_duckdb_connection(
     staging_directory: Path | None = None,
+    *,
+    database_path: Path | None = None,
 ) -> Iterator[DuckConnection]:
-    """Open DuckDB with a unique spill directory and deterministic cleanup."""
+    """Open DuckDB with a unique spill directory and deterministic cleanup.
+
+    Most archive transforms use an in-memory catalog. Callers ingesting an
+    unbounded stream can opt into a temporary on-disk database so buffered table
+    pages remain evictable under DuckDB's memory limit.
+    """
     import duckdb
 
     with tempfile.TemporaryDirectory(
         prefix="langsmith-duckdb-", dir=staging_directory
     ) as connection_staging:
-        connection = duckdb.connect()
+        connection = duckdb.connect(
+            str(database_path) if database_path is not None else ":memory:"
+        )
         try:
             configure_duckdb_resources(connection, Path(connection_staging))
             yield connection

--- a/src/langsmith_cli/archive/storage.py
+++ b/src/langsmith_cli/archive/storage.py
@@ -20,7 +20,10 @@ class ArchiveStore(Protocol):
     def base_uri(self) -> str: ...
 
     def put_file(self, key: str, source: Path) -> None: ...
+    def put_bytes(self, key: str, content: bytes) -> None: ...
     def put_text(self, key: str, content: str) -> None: ...
+    def get_file(self, key: str, destination: Path) -> None: ...
+    def get_bytes(self, key: str) -> bytes: ...
     def get_text(self, key: str) -> str: ...
     def get_text_with_version(self, key: str) -> TextObject: ...
     def put_text_if_version(
@@ -54,6 +57,12 @@ class LocalArchiveStore:
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(source, target)
 
+    def put_bytes(self, key: str, content: bytes) -> None:
+        _validate_store_key(key)
+        target = self.root / key
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+
     def put_text(self, key: str, content: str) -> None:
         _validate_store_key(key)
         target = self.root / key
@@ -63,6 +72,17 @@ class LocalArchiveStore:
     def get_text(self, key: str) -> str:
         _validate_store_key(key)
         return (self.root / key).read_text(encoding="utf-8")
+
+    def get_file(self, key: str, destination: Path) -> None:
+        import shutil
+
+        _validate_store_key(key)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(self.root / key, destination)
+
+    def get_bytes(self, key: str) -> bytes:
+        _validate_store_key(key)
+        return (self.root / key).read_bytes()
 
     def get_text_with_version(self, key: str) -> TextObject:
         content = self.get_text(key)
@@ -150,6 +170,14 @@ class S3ArchiveStore:
     def put_file(self, key: str, source: Path) -> None:
         self.client.upload_file(str(source), self.bucket, self._full_key(key))
 
+    def put_bytes(self, key: str, content: bytes) -> None:
+        self.client.put_object(
+            Bucket=self.bucket,
+            Key=self._full_key(key),
+            Body=content,
+            ContentType="application/octet-stream",
+        )
+
     def put_text(self, key: str, content: str) -> None:
         self.client.put_object(
             Bucket=self.bucket,
@@ -161,6 +189,14 @@ class S3ArchiveStore:
     def get_text(self, key: str) -> str:
         response = self.client.get_object(Bucket=self.bucket, Key=self._full_key(key))
         return response["Body"].read().decode("utf-8")
+
+    def get_file(self, key: str, destination: Path) -> None:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        self.client.download_file(self.bucket, self._full_key(key), str(destination))
+
+    def get_bytes(self, key: str) -> bytes:
+        response = self.client.get_object(Bucket=self.bucket, Key=self._full_key(key))
+        return response["Body"].read()
 
     def get_text_with_version(self, key: str) -> TextObject:
         response = self.client.get_object(Bucket=self.bucket, Key=self._full_key(key))

--- a/src/langsmith_cli/archive/storage.py
+++ b/src/langsmith_cli/archive/storage.py
@@ -11,7 +11,7 @@ import os
 from pathlib import Path
 from pathlib import PurePosixPath
 import tempfile
-from typing import Any, Protocol
+from typing import Any, Callable, Protocol
 from urllib.parse import urlparse
 
 
@@ -34,6 +34,10 @@ class ArchiveStore(Protocol):
     def object_uri(self, key: str) -> str: ...
 
 
+class BinaryWriter(Protocol):
+    def write(self, content: bytes, /) -> int: ...
+
+
 class ConcurrentArchiveWriteError(RuntimeError):
     """A stale writer attempted to replace a newer archive metadata object."""
 
@@ -54,20 +58,23 @@ class LocalArchiveStore:
 
         _validate_store_key(key)
         target = self.root / key
-        target.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copyfile(source, target)
+
+        def copy_source(destination: BinaryWriter) -> None:
+            with source.open("rb") as input_file:
+                shutil.copyfileobj(input_file, destination)
+
+        _atomic_local_write(target, copy_source)
 
     def put_bytes(self, key: str, content: bytes) -> None:
         _validate_store_key(key)
         target = self.root / key
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_bytes(content)
+        _atomic_local_write(target, lambda destination: destination.write(content))
 
     def put_text(self, key: str, content: str) -> None:
         _validate_store_key(key)
         target = self.root / key
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(content, encoding="utf-8")
+        encoded = content.encode("utf-8")
+        _atomic_local_write(target, lambda destination: destination.write(encoded))
 
     def get_text(self, key: str) -> str:
         _validate_store_key(key)
@@ -109,24 +116,8 @@ class LocalArchiveStore:
                 raise ConcurrentArchiveWriteError(
                     f"Archive metadata changed concurrently: {key}"
                 )
-            temporary_path: Path | None = None
-            try:
-                with tempfile.NamedTemporaryFile(
-                    mode="w",
-                    encoding="utf-8",
-                    dir=target.parent,
-                    prefix=f".{target.name}.",
-                    suffix=".tmp",
-                    delete=False,
-                ) as temporary:
-                    temporary.write(content)
-                    temporary.flush()
-                    os.fsync(temporary.fileno())
-                    temporary_path = Path(temporary.name)
-                os.replace(temporary_path, target)
-            finally:
-                if temporary_path is not None and temporary_path.exists():
-                    temporary_path.unlink()
+            encoded = content.encode("utf-8")
+            _atomic_local_write(target, lambda destination: destination.write(encoded))
 
     def exists(self, key: str) -> bool:
         _validate_store_key(key)
@@ -316,6 +307,32 @@ def _content_version(content: str) -> str:
     return hashlib.sha256(content.encode("utf-8")).hexdigest()
 
 
+def _atomic_local_write(target: Path, writer: Callable[[BinaryWriter], object]) -> None:
+    """Replace one local object atomically after its complete bytes are durable.
+
+    INVARIANT: a reader sees either the previous complete object or the next
+    complete object. It never observes the temporary bytes being streamed.
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w+b",
+            dir=target.parent,
+            prefix=f".{target.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            writer(temporary)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+            temporary_path = Path(temporary.name)
+        os.replace(temporary_path, target)
+    finally:
+        if temporary_path is not None and temporary_path.exists():
+            temporary_path.unlink()
+
+
 @contextmanager
 def _exclusive_file_lock(path: Path) -> Iterator[None]:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -328,10 +345,10 @@ def _exclusive_file_lock(path: Path) -> Iterator[None]:
             import msvcrt
 
             try:
-                msvcrt.locking(lock.fileno(), msvcrt.LK_NBLCK, 1)
+                msvcrt.locking(lock.fileno(), msvcrt.LK_LOCK, 1)
             except OSError as exc:
                 raise ConcurrentArchiveWriteError(
-                    f"Archive metadata is being published concurrently: {path.name}"
+                    f"Archive metadata lock failed: {path.name}"
                 ) from exc
             try:
                 yield
@@ -342,12 +359,10 @@ def _exclusive_file_lock(path: Path) -> Iterator[None]:
 
         import fcntl
 
-        try:
-            fcntl.flock(lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError as exc:
-            raise ConcurrentArchiveWriteError(
-                f"Archive metadata is being published concurrently: {path.name}"
-            ) from exc
+        # Wait for the tiny critical section instead of making callers spin and
+        # potentially starve the lock holder. Freshness is still enforced by the
+        # content-version comparison performed after this lock is acquired.
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
         try:
             yield
         finally:

--- a/src/langsmith_cli/commands/datasets.py
+++ b/src/langsmith_cli/commands/datasets.py
@@ -4,7 +4,15 @@ import os
 from typing import TYPE_CHECKING, Any, TypedDict
 
 import click
+from langsmith_cli.dataset_replica.cli import (
+    replica_repository,
+    replica_source_options,
+)
 from langsmith_cli.dataset_replica.models import ReplicaDestination, ReplicaSource
+from langsmith_cli.dataset_resolution import (
+    DatasetResolutionError,
+    resolve_dataset as resolve_dataset_strict,
+)
 from langsmith_cli.utils import (
     ConsoleProtocol,
     LazyConsole,
@@ -21,7 +29,6 @@ from langsmith_cli.utils import (
     get_or_create_client,
     is_json_context,
     json_dumps,
-    resolve_by_name_or_id,
     sort_by_option,
     sort_items,
     parse_fields_option,
@@ -39,6 +46,14 @@ if TYPE_CHECKING:
     from langsmith.schemas import Dataset
 
 console = LazyConsole()
+
+
+def resolve_dataset(client: Client, name_or_id: str) -> Dataset:
+    """Translate pure Dataset identity failures at the Click view boundary."""
+    try:
+        return resolve_dataset_strict(client, name_or_id)
+    except DatasetResolutionError as exc:
+        raise click.ClickException(str(exc)) from exc
 
 
 class DatasetPushRow(TypedDict):
@@ -81,14 +96,7 @@ def datasets():
 
 
 @datasets.command("list")
-@click.option(
-    "--source",
-    type=click.Choice([item.value for item in ReplicaSource]),
-    default=ReplicaSource.CLOUD.value,
-    show_default=True,
-)
-@click.option("--archive-uri", envvar="LANGSMITH_ARCHIVE_URI")
-@click.option("--local-dir", type=click.Path(file_okay=False))
+@replica_source_options()
 @click.option("--dataset-ids", help="Specific dataset IDs (comma-separated).")
 @click.option("--limit", default=20, help="Limit number of datasets (default 20).")
 @click.option("--data-type", help="Filter by dataset type (kv, chat, llm).")
@@ -160,7 +168,7 @@ def list_datasets(
             list_kwargs["dataset_ids"] = dataset_ids_list
         datasets_list = list(client.list_datasets(**list_kwargs))
     else:
-        repository = _replica_repository(source, archive_uri, local_dir)
+        repository = replica_repository(source, archive_uri, local_dir)
         datasets_list = repository.list_datasets()
         if dataset_ids_list is not None:
             selected_ids = set(dataset_ids_list)
@@ -239,14 +247,7 @@ def list_datasets(
 
 @datasets.command("get")
 @click.argument("dataset_id")
-@click.option(
-    "--source",
-    type=click.Choice([item.value for item in ReplicaSource]),
-    default=ReplicaSource.CLOUD.value,
-    show_default=True,
-)
-@click.option("--archive-uri", envvar="LANGSMITH_ARCHIVE_URI")
-@click.option("--local-dir", type=click.Path(file_okay=False))
+@replica_source_options()
 @click.option("--as-of", default="latest", show_default=True)
 @fields_option()
 @output_option()
@@ -260,10 +261,15 @@ def get_dataset(ctx, dataset_id, source, archive_uri, local_dir, as_of, fields, 
     logger.debug(f"Fetching dataset: dataset_id={dataset_id}")
 
     if source is ReplicaSource.CLOUD:
+        if as_of != "latest":
+            raise click.ClickException(
+                "--as-of is only supported for --source archive or local on "
+                "datasets get; cloud Dataset metadata has no versioned read API"
+            )
         client = get_or_create_client(ctx)
-        dataset = client.read_dataset(dataset_id=dataset_id)
+        dataset = resolve_dataset(client, dataset_id)
     else:
-        repository = _replica_repository(source, archive_uri, local_dir)
+        repository = replica_repository(source, archive_uri, local_dir)
         dataset = repository.read_dataset(dataset_id, as_of)
 
     data = filter_fields(dataset, fields)
@@ -380,19 +386,6 @@ def push_dataset(ctx, file_path, dataset):
     )
 
 
-def resolve_dataset(
-    client: Client,
-    name_or_id: str,
-) -> Dataset:
-    """Resolve a dataset by name or UUID, with smart UUID auto-detection."""
-    return resolve_by_name_or_id(
-        name_or_id,
-        read_by_name=lambda n: client.read_dataset(dataset_name=n),
-        read_by_id=lambda i: client.read_dataset(dataset_id=i),
-        entity_name="Dataset",
-    )
-
-
 @datasets.command("delete")
 @click.argument("name_or_id")
 @confirm_option()
@@ -424,14 +417,7 @@ def delete_dataset(ctx, name_or_id, confirm):
 
 @datasets.command("versions")
 @click.argument("dataset")
-@click.option(
-    "--source",
-    type=click.Choice([item.value for item in ReplicaSource]),
-    default=ReplicaSource.CLOUD.value,
-    show_default=True,
-)
-@click.option("--archive-uri", envvar="LANGSMITH_ARCHIVE_URI")
-@click.option("--local-dir", type=click.Path(file_okay=False))
+@replica_source_options()
 @fields_option()
 @output_option()
 @click.pass_context
@@ -445,7 +431,7 @@ def list_dataset_versions(ctx, dataset, source, archive_uri, local_dir, fields, 
         resolved = resolve_dataset(client, dataset)
         versions = list(client.list_dataset_versions(dataset_id=resolved.id))
     else:
-        repository = _replica_repository(source, archive_uri, local_dir)
+        repository = replica_repository(source, archive_uri, local_dir)
         versions = repository.list_versions(dataset)
 
     def build_versions_table(items):
@@ -469,14 +455,7 @@ def list_dataset_versions(ctx, dataset, source, archive_uri, local_dir, fields, 
 
 
 @datasets.command("status")
-@click.option(
-    "--source",
-    type=click.Choice([ReplicaSource.ARCHIVE.value, ReplicaSource.LOCAL.value]),
-    default=ReplicaSource.LOCAL.value,
-    show_default=True,
-)
-@click.option("--archive-uri", envvar="LANGSMITH_ARCHIVE_URI")
-@click.option("--local-dir", type=click.Path(file_okay=False))
+@replica_source_options(include_cloud=False, default=ReplicaSource.LOCAL)
 @output_option()
 @click.pass_context
 def dataset_replica_status(ctx, source, archive_uri, local_dir, output):
@@ -484,7 +463,7 @@ def dataset_replica_status(ctx, source, archive_uri, local_dir, output):
     source = ReplicaSource(source)
     logger = ctx.obj["logger"]
     configure_logger_streams(ctx, logger, output=output)
-    repository = _replica_repository(source, archive_uri, local_dir)
+    repository = replica_repository(source, archive_uri, local_dir)
     payload = [
         {
             "dataset_id": item.dataset_id,
@@ -525,12 +504,7 @@ def dataset_replica_status(ctx, source, archive_uri, local_dir, output):
 
 @datasets.command("pull")
 @click.argument("dataset")
-@click.option(
-    "--source",
-    type=click.Choice([item.value for item in ReplicaSource]),
-    default=ReplicaSource.CLOUD.value,
-    show_default=True,
-)
+@replica_source_options()
 @click.option(
     "--to",
     "destination",
@@ -539,8 +513,6 @@ def dataset_replica_status(ctx, source, archive_uri, local_dir, output):
 )
 @click.option("--as-of", default="latest", show_default=True)
 @click.option("--all-versions", is_flag=True)
-@click.option("--archive-uri", envvar="LANGSMITH_ARCHIVE_URI")
-@click.option("--local-dir", type=click.Path(file_okay=False))
 @click.pass_context
 def pull_dataset_command(
     ctx,
@@ -575,10 +547,6 @@ def pull_dataset_command(
             archive_uri=archive_uri,
             local_directory=local_dir,
         )
-    except KeyError as exc:
-        raise click.ClickException(
-            "Archive operations require --archive-uri or LANGSMITH_ARCHIVE_URI"
-        ) from exc
     except (DatasetReplicaError, ValueError, OSError) as exc:
         raise click.ClickException(str(exc)) from exc
     payload = [write_result_payload(result) for result in results]
@@ -590,16 +558,3 @@ def pull_dataset_command(
         f"Replicated {len(results)} version(s) of '{dataset}' "
         f"to {destination.value} ({created} new)"
     )
-
-
-def _replica_repository(source, archive_uri, local_dir):
-    from langsmith_cli.dataset_replica.service import repository_for
-
-    try:
-        return repository_for(
-            source, archive_uri=archive_uri, local_directory=local_dir
-        )
-    except KeyError as exc:
-        raise click.ClickException(
-            "Archive reads require --archive-uri or LANGSMITH_ARCHIVE_URI"
-        ) from exc

--- a/src/langsmith_cli/commands/datasets.py
+++ b/src/langsmith_cli/commands/datasets.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, TypedDict
 
 import click
 from langsmith_cli.dataset_replica.cli import (
+    replica_list_pagination_options,
     replica_repository,
     replica_source_options,
 )
@@ -17,8 +18,6 @@ from langsmith_cli.utils import (
     ConsoleProtocol,
     LazyConsole,
     add_name_filter_options,
-    apply_exclude_filter,
-    apply_name_filters,
     configure_logger_streams,
     confirm_option,
     count_option,
@@ -30,7 +29,6 @@ from langsmith_cli.utils import (
     is_json_context,
     json_dumps,
     sort_by_option,
-    sort_items,
     parse_fields_option,
     output_option,
     output_single_item,
@@ -98,8 +96,12 @@ def datasets():
 @datasets.command("list")
 @replica_source_options()
 @click.option("--dataset-ids", help="Specific dataset IDs (comma-separated).")
-@click.option("--limit", default=20, help="Limit number of datasets (default 20).")
-@click.option("--data-type", help="Filter by dataset type (kv, chat, llm).")
+@replica_list_pagination_options(item_name="datasets")
+@click.option(
+    "--data-type",
+    type=click.Choice(["kv", "chat", "llm"]),
+    help="Filter by dataset type (kv, chat, llm).",
+)
 @click.option("--name", "dataset_name", help="Exact dataset name match.")
 @click.option("--name-contains", help="Dataset name substring search.")
 @click.option("--metadata", help="Filter by metadata (JSON string).")
@@ -154,69 +156,40 @@ def list_datasets(
     # Parse metadata JSON
     metadata_dict = parse_json_string(metadata, "metadata")
 
-    if source is ReplicaSource.CLOUD:
-        client = get_or_create_client(ctx)
-        # Build kwargs for list_datasets (type-safe approach)
-        list_kwargs = {
-            "limit": limit,
-            "data_type": data_type,
-            "dataset_name": dataset_name,
-            "dataset_name_contains": name_contains,
-            "metadata": metadata_dict,
-        }
-        if dataset_ids_list is not None:
-            list_kwargs["dataset_ids"] = dataset_ids_list
-        datasets_list = list(client.list_datasets(**list_kwargs))
-    else:
-        repository = replica_repository(source, archive_uri, local_dir)
-        datasets_list = repository.list_datasets()
-        if dataset_ids_list is not None:
-            selected_ids = set(dataset_ids_list)
-            datasets_list = [d for d in datasets_list if str(d.id) in selected_ids]
-        if data_type is not None:
-            datasets_list = [
-                d
-                for d in datasets_list
-                if d.data_type is not None and d.data_type.value == data_type
-            ]
-        if dataset_name is not None:
-            datasets_list = [d for d in datasets_list if d.name == dataset_name]
-        if name_contains is not None:
-            datasets_list = [d for d in datasets_list if name_contains in d.name]
-        if metadata_dict is not None:
-            datasets_list = [
-                d
-                for d in datasets_list
-                if d.metadata is not None
-                and all(
-                    key in d.metadata and d.metadata[key] == value
-                    for key, value in metadata_dict.items()
-                )
-            ]
-        datasets_list = datasets_list[:limit]
+    from langsmith_cli.dataset_replica.query import DatasetListQuery
 
-    # Client-side name pattern/regex filtering
-    datasets_list = apply_name_filters(
-        datasets_list,
-        lambda d: d.name,
+    query = DatasetListQuery.from_options(
+        dataset_ids=dataset_ids_list,
+        limit=limit,
+        data_type=data_type,
+        dataset_name=dataset_name,
+        name_contains=name_contains,
+        metadata=metadata_dict,
         name_pattern=name_pattern,
         name_regex=name_regex,
+        sort_by=sort_by,
+        exclude=exclude,
     )
 
-    # Client-side exclude filtering
-    datasets_list = apply_exclude_filter(datasets_list, exclude, lambda d: d.name)
-
-    # Client-side sorting
-    if sort_by:
-        datasets_list = sort_items(
-            datasets_list,
-            sort_by,
-            {
-                "name": lambda d: d.name,
-                "created_at": lambda d: d.created_at,
-                "example_count": lambda d: d.example_count,
-            },
+    if source is ReplicaSource.CLOUD:
+        client = get_or_create_client(ctx)
+        datasets_list = query.apply_to_cloud_response(
+            client.list_datasets(
+                dataset_ids=(
+                    list(query.dataset_ids) if query.dataset_ids is not None else None
+                ),
+                limit=query.cloud_limit,
+                data_type=(
+                    query.data_type.value if query.data_type is not None else None
+                ),
+                dataset_name=query.dataset_name,
+                dataset_name_contains=query.name_contains,
+                metadata=query.metadata,
+            )
         )
+    else:
+        repository = replica_repository(source, archive_uri, local_dir)
+        datasets_list = query.apply_to_replica(repository.list_datasets())
 
     # Define table builder function
     def build_datasets_table(datasets):

--- a/src/langsmith_cli/commands/datasets.py
+++ b/src/langsmith_cli/commands/datasets.py
@@ -4,6 +4,7 @@ import os
 from typing import TYPE_CHECKING, Any, TypedDict
 
 import click
+from langsmith_cli.dataset_replica.models import ReplicaDestination, ReplicaSource
 from langsmith_cli.utils import (
     ConsoleProtocol,
     LazyConsole,
@@ -18,6 +19,8 @@ from langsmith_cli.utils import (
     fields_option,
     filter_fields,
     get_or_create_client,
+    is_json_context,
+    json_dumps,
     resolve_by_name_or_id,
     sort_by_option,
     sort_items,
@@ -78,6 +81,14 @@ def datasets():
 
 
 @datasets.command("list")
+@click.option(
+    "--source",
+    type=click.Choice([item.value for item in ReplicaSource]),
+    default=ReplicaSource.CLOUD.value,
+    show_default=True,
+)
+@click.option("--archive-uri", envvar="LANGSMITH_ARCHIVE_URI")
+@click.option("--local-dir", type=click.Path(file_okay=False))
 @click.option("--dataset-ids", help="Specific dataset IDs (comma-separated).")
 @click.option("--limit", default=20, help="Limit number of datasets (default 20).")
 @click.option("--data-type", help="Filter by dataset type (kv, chat, llm).")
@@ -99,6 +110,9 @@ def datasets():
 @click.pass_context
 def list_datasets(
     ctx,
+    source,
+    archive_uri,
+    local_dir,
     dataset_ids,
     limit,
     data_type,
@@ -115,6 +129,7 @@ def list_datasets(
     output,
 ):
     """List all available datasets."""
+    source = ReplicaSource(source)
     logger = ctx.obj["logger"]
     configure_logger_streams(
         ctx, logger, output=output, output_format=output_format, fields=fields
@@ -125,27 +140,52 @@ def list_datasets(
         f"dataset_name={dataset_name}, name_contains={name_contains}"
     )
 
-    client = get_or_create_client(ctx)
-
     # Parse comma-separated dataset IDs
     dataset_ids_list = parse_comma_separated_list(dataset_ids)
 
     # Parse metadata JSON
     metadata_dict = parse_json_string(metadata, "metadata")
 
-    # Build kwargs for list_datasets (type-safe approach)
-    list_kwargs = {
-        "limit": limit,
-        "data_type": data_type,
-        "dataset_name": dataset_name,
-        "dataset_name_contains": name_contains,
-        "metadata": metadata_dict,
-    }
-    if dataset_ids_list is not None:
-        list_kwargs["dataset_ids"] = dataset_ids_list
-
-    datasets_gen = client.list_datasets(**list_kwargs)
-    datasets_list = list(datasets_gen)
+    if source is ReplicaSource.CLOUD:
+        client = get_or_create_client(ctx)
+        # Build kwargs for list_datasets (type-safe approach)
+        list_kwargs = {
+            "limit": limit,
+            "data_type": data_type,
+            "dataset_name": dataset_name,
+            "dataset_name_contains": name_contains,
+            "metadata": metadata_dict,
+        }
+        if dataset_ids_list is not None:
+            list_kwargs["dataset_ids"] = dataset_ids_list
+        datasets_list = list(client.list_datasets(**list_kwargs))
+    else:
+        repository = _replica_repository(source, archive_uri, local_dir)
+        datasets_list = repository.list_datasets()
+        if dataset_ids_list is not None:
+            selected_ids = set(dataset_ids_list)
+            datasets_list = [d for d in datasets_list if str(d.id) in selected_ids]
+        if data_type is not None:
+            datasets_list = [
+                d
+                for d in datasets_list
+                if d.data_type is not None and d.data_type.value == data_type
+            ]
+        if dataset_name is not None:
+            datasets_list = [d for d in datasets_list if d.name == dataset_name]
+        if name_contains is not None:
+            datasets_list = [d for d in datasets_list if name_contains in d.name]
+        if metadata_dict is not None:
+            datasets_list = [
+                d
+                for d in datasets_list
+                if d.metadata is not None
+                and all(
+                    key in d.metadata and d.metadata[key] == value
+                    for key, value in metadata_dict.items()
+                )
+            ]
+        datasets_list = datasets_list[:limit]
 
     # Client-side name pattern/regex filtering
     datasets_list = apply_name_filters(
@@ -199,18 +239,32 @@ def list_datasets(
 
 @datasets.command("get")
 @click.argument("dataset_id")
+@click.option(
+    "--source",
+    type=click.Choice([item.value for item in ReplicaSource]),
+    default=ReplicaSource.CLOUD.value,
+    show_default=True,
+)
+@click.option("--archive-uri", envvar="LANGSMITH_ARCHIVE_URI")
+@click.option("--local-dir", type=click.Path(file_okay=False))
+@click.option("--as-of", default="latest", show_default=True)
 @fields_option()
 @output_option()
 @click.pass_context
-def get_dataset(ctx, dataset_id, fields, output):
+def get_dataset(ctx, dataset_id, source, archive_uri, local_dir, as_of, fields, output):
     """Fetch details of a single dataset."""
+    source = ReplicaSource(source)
     logger = ctx.obj["logger"]
     configure_logger_streams(ctx, logger, output=output, fields=fields)
 
     logger.debug(f"Fetching dataset: dataset_id={dataset_id}")
 
-    client = get_or_create_client(ctx)
-    dataset = client.read_dataset(dataset_id=dataset_id)
+    if source is ReplicaSource.CLOUD:
+        client = get_or_create_client(ctx)
+        dataset = client.read_dataset(dataset_id=dataset_id)
+    else:
+        repository = _replica_repository(source, archive_uri, local_dir)
+        dataset = repository.read_dataset(dataset_id, as_of)
 
     data = filter_fields(dataset, fields)
 
@@ -366,3 +420,186 @@ def delete_dataset(ctx, name_or_id, confirm):
         payload={"status": "success", "name": dataset.name},
         success_message=f"Deleted dataset '{dataset.name}'",
     )
+
+
+@datasets.command("versions")
+@click.argument("dataset")
+@click.option(
+    "--source",
+    type=click.Choice([item.value for item in ReplicaSource]),
+    default=ReplicaSource.CLOUD.value,
+    show_default=True,
+)
+@click.option("--archive-uri", envvar="LANGSMITH_ARCHIVE_URI")
+@click.option("--local-dir", type=click.Path(file_okay=False))
+@fields_option()
+@output_option()
+@click.pass_context
+def list_dataset_versions(ctx, dataset, source, archive_uri, local_dir, fields, output):
+    """List exact versions available from one dataset source."""
+    source = ReplicaSource(source)
+    logger = ctx.obj["logger"]
+    configure_logger_streams(ctx, logger, output=output, fields=fields)
+    if source is ReplicaSource.CLOUD:
+        client = get_or_create_client(ctx)
+        resolved = resolve_dataset(client, dataset)
+        versions = list(client.list_dataset_versions(dataset_id=resolved.id))
+    else:
+        repository = _replica_repository(source, archive_uri, local_dir)
+        versions = repository.list_versions(dataset)
+
+    def build_versions_table(items):
+        from rich.table import Table
+
+        table = Table(title=f"Dataset versions: {dataset}")
+        table.add_column("As of", style="cyan")
+        table.add_column("Tags")
+        for item in items:
+            table.add_row(item.as_of.isoformat(), ", ".join(item.tags or []))
+        return table
+
+    render_output(
+        versions,
+        build_versions_table,
+        ctx,
+        include_fields=parse_fields_option(fields),
+        empty_message="No dataset versions found",
+        output_path=output,
+    )
+
+
+@datasets.command("status")
+@click.option(
+    "--source",
+    type=click.Choice([ReplicaSource.ARCHIVE.value, ReplicaSource.LOCAL.value]),
+    default=ReplicaSource.LOCAL.value,
+    show_default=True,
+)
+@click.option("--archive-uri", envvar="LANGSMITH_ARCHIVE_URI")
+@click.option("--local-dir", type=click.Path(file_okay=False))
+@output_option()
+@click.pass_context
+def dataset_replica_status(ctx, source, archive_uri, local_dir, output):
+    """Show datasets and exact versions present in a replica source."""
+    source = ReplicaSource(source)
+    logger = ctx.obj["logger"]
+    configure_logger_streams(ctx, logger, output=output)
+    repository = _replica_repository(source, archive_uri, local_dir)
+    payload = [
+        {
+            "dataset_id": item.dataset_id,
+            "dataset_name": item.dataset_name,
+            "latest_as_of": item.latest_as_of.isoformat(),
+            "versions": item.versions,
+            "source": source.value,
+            "source_uri": item.source_uri,
+        }
+        for item in repository.statuses()
+    ]
+
+    def build_status_table(items):
+        from rich.table import Table
+
+        table = Table(title=f"Dataset replica: {source.value}")
+        table.add_column("Dataset", style="cyan")
+        table.add_column("ID", style="dim")
+        table.add_column("Versions", justify="right")
+        table.add_column("Latest")
+        for item in items:
+            table.add_row(
+                item["dataset_name"],
+                item["dataset_id"],
+                str(item["versions"]),
+                item["latest_as_of"],
+            )
+        return table
+
+    render_output(
+        payload,
+        build_status_table,
+        ctx,
+        empty_message="No replicated datasets found",
+        output_path=output,
+    )
+
+
+@datasets.command("pull")
+@click.argument("dataset")
+@click.option(
+    "--source",
+    type=click.Choice([item.value for item in ReplicaSource]),
+    default=ReplicaSource.CLOUD.value,
+    show_default=True,
+)
+@click.option(
+    "--to",
+    "destination",
+    type=click.Choice([item.value for item in ReplicaDestination]),
+    required=True,
+)
+@click.option("--as-of", default="latest", show_default=True)
+@click.option("--all-versions", is_flag=True)
+@click.option("--archive-uri", envvar="LANGSMITH_ARCHIVE_URI")
+@click.option("--local-dir", type=click.Path(file_okay=False))
+@click.pass_context
+def pull_dataset_command(
+    ctx,
+    dataset,
+    source,
+    destination,
+    as_of,
+    all_versions,
+    archive_uri,
+    local_dir,
+):
+    """Replicate exact, read-only dataset versions between sources."""
+    from langsmith_cli.dataset_replica.service import (
+        pull_dataset,
+        write_result_payload,
+    )
+    from langsmith_cli.dataset_replica.repository import DatasetReplicaError
+
+    source = ReplicaSource(source)
+    destination = ReplicaDestination(destination)
+    logger = ctx.obj["logger"]
+    configure_logger_streams(ctx, logger)
+    client = get_or_create_client(ctx) if source is ReplicaSource.CLOUD else None
+    try:
+        results = pull_dataset(
+            client=client,
+            dataset_name_or_id=dataset,
+            source=source,
+            destination=destination,
+            as_of=as_of,
+            all_versions=all_versions,
+            archive_uri=archive_uri,
+            local_directory=local_dir,
+        )
+    except KeyError as exc:
+        raise click.ClickException(
+            "Archive operations require --archive-uri or LANGSMITH_ARCHIVE_URI"
+        ) from exc
+    except (DatasetReplicaError, ValueError, OSError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    payload = [write_result_payload(result) for result in results]
+    if is_json_context(ctx):
+        click.echo(json_dumps(payload))
+        return
+    created = sum(not result.already_present for result in results)
+    logger.success(
+        f"Replicated {len(results)} version(s) of '{dataset}' "
+        f"to {destination.value} ({created} new)"
+    )
+
+
+def _replica_repository(source, archive_uri, local_dir):
+    from langsmith_cli.dataset_replica.service import repository_for
+
+    try:
+        return repository_for(
+            source, archive_uri=archive_uri, local_directory=local_dir
+        )
+    except KeyError as exc:
+        raise click.ClickException(
+            "Archive reads require --archive-uri or LANGSMITH_ARCHIVE_URI"
+        ) from exc

--- a/src/langsmith_cli/commands/examples.py
+++ b/src/langsmith_cli/commands/examples.py
@@ -1,4 +1,5 @@
 import click
+from langsmith_cli.dataset_replica.models import ReplicaSource
 from langsmith_cli.utils import (
     ConsoleProtocol,
     LazyConsole,
@@ -43,6 +44,14 @@ def examples():
 
 
 @examples.command("list")
+@click.option(
+    "--source",
+    type=click.Choice([item.value for item in ReplicaSource]),
+    default=ReplicaSource.CLOUD.value,
+    show_default=True,
+)
+@click.option("--archive-uri", envvar="LANGSMITH_ARCHIVE_URI")
+@click.option("--local-dir", type=click.Path(file_okay=False))
 @click.option("--dataset", help="Dataset ID or Name.")
 @click.option("--example-ids", help="Specific example IDs (comma-separated).")
 @click.option("--limit", default=20, help="Limit number of examples (default 20).")
@@ -75,6 +84,9 @@ def examples():
 @click.pass_context
 def list_examples(
     ctx,
+    source,
+    archive_uri,
+    local_dir,
     dataset,
     example_ids,
     limit,
@@ -93,6 +105,7 @@ def list_examples(
     output,
 ):
     """List examples for a dataset."""
+    source = ReplicaSource(source)
     logger = ctx.obj["logger"]
     configure_logger_streams(
         ctx, logger, output=output, output_format=output_format, fields=fields
@@ -103,27 +116,70 @@ def list_examples(
         f"offset={offset}, filter={filter_}"
     )
 
-    client = get_or_create_client(ctx)
-
     # Parse comma-separated values
     example_ids_list = parse_comma_separated_list(example_ids)
     splits_list = parse_comma_separated_list(splits)
     metadata_dict = parse_json_string(metadata, "metadata")
 
-    # list_examples takes dataset_name and limit
-    examples_gen = client.list_examples(
-        dataset_name=dataset,
-        example_ids=example_ids_list,
-        limit=limit,
-        offset=offset,
-        filter=filter_,
-        metadata=metadata_dict,
-        splits=splits_list,
-        inline_s3_urls=inline_s3_urls,
-        include_attachments=include_attachments,
-        as_of=as_of,
-    )
-    examples_list = list(examples_gen)
+    if source is ReplicaSource.CLOUD:
+        client = get_or_create_client(ctx)
+        examples_list = list(
+            client.list_examples(
+                dataset_name=dataset,
+                example_ids=example_ids_list,
+                limit=limit,
+                offset=offset,
+                filter=filter_,
+                metadata=metadata_dict,
+                splits=splits_list,
+                inline_s3_urls=inline_s3_urls,
+                include_attachments=include_attachments,
+                as_of=as_of,
+            )
+        )
+    else:
+        if filter_ is not None:
+            raise click.ClickException(
+                "--filter is currently available only for --source cloud"
+            )
+        repository = _replica_repository(source, archive_uri, local_dir)
+        dataset_refs = (
+            [dataset]
+            if dataset is not None
+            else [str(item.id) for item in repository.list_datasets()]
+        )
+        examples_list = []
+        for dataset_ref in dataset_refs:
+            examples_list.extend(
+                repository.read_examples(
+                    dataset_ref,
+                    as_of=as_of,
+                    include_attachments=bool(include_attachments),
+                )
+            )
+        if example_ids_list is not None:
+            selected_ids = set(example_ids_list)
+            examples_list = [e for e in examples_list if str(e.id) in selected_ids]
+        if metadata_dict is not None:
+            examples_list = [
+                e
+                for e in examples_list
+                if e.metadata is not None
+                and all(
+                    key in e.metadata and e.metadata[key] == value
+                    for key, value in metadata_dict.items()
+                )
+            ]
+        if splits_list is not None:
+            selected_splits = set(splits_list)
+            examples_list = [
+                e
+                for e in examples_list
+                if e.metadata is not None
+                and "dataset_split" in e.metadata
+                and bool(selected_splits.intersection(e.metadata["dataset_split"]))
+            ]
+        examples_list = examples_list[offset : offset + limit]
 
     # Client-side exclude filtering (filter by ID string representation)
     examples_list = apply_exclude_filter(examples_list, exclude, lambda e: str(e.id))
@@ -176,18 +232,46 @@ def list_examples(
 @examples.command("get")
 @click.argument("example_id")
 @click.option("--as-of", help="Dataset version tag or ISO timestamp.")
+@click.option(
+    "--source",
+    type=click.Choice([item.value for item in ReplicaSource]),
+    default=ReplicaSource.CLOUD.value,
+    show_default=True,
+)
+@click.option("--archive-uri", envvar="LANGSMITH_ARCHIVE_URI")
+@click.option("--local-dir", type=click.Path(file_okay=False))
+@click.option("--include-attachments", is_flag=True)
 @fields_option()
 @output_option()
 @click.pass_context
-def get_example(ctx, example_id, as_of, fields, output):
+def get_example(
+    ctx,
+    example_id,
+    as_of,
+    source,
+    archive_uri,
+    local_dir,
+    include_attachments,
+    fields,
+    output,
+):
     """Fetch details of a single example."""
+    source = ReplicaSource(source)
     logger = ctx.obj["logger"]
     configure_logger_streams(ctx, logger, output=output, fields=fields)
 
     logger.debug(f"Fetching example: example_id={example_id}, as_of={as_of}")
 
-    client = get_or_create_client(ctx)
-    example = client.read_example(example_id, as_of=as_of)
+    if source is ReplicaSource.CLOUD:
+        client = get_or_create_client(ctx)
+        example = client.read_example(example_id, as_of=as_of)
+    else:
+        repository = _replica_repository(source, archive_uri, local_dir)
+        example = repository.read_example(
+            example_id,
+            as_of=as_of,
+            include_attachments=include_attachments,
+        )
 
     data = filter_fields(example, fields)
 
@@ -205,6 +289,22 @@ def get_example(ctx, example_id, as_of, fields, output):
     output_single_item(
         ctx, data, console, output=output, render_fn=render_example_details
     )
+
+
+def _replica_repository(source, archive_uri, local_dir):
+    from langsmith_cli.dataset_replica.repository import DatasetReplicaError
+    from langsmith_cli.dataset_replica.service import repository_for
+
+    try:
+        return repository_for(
+            source, archive_uri=archive_uri, local_directory=local_dir
+        )
+    except KeyError as exc:
+        raise click.ClickException(
+            "Archive reads require --archive-uri or LANGSMITH_ARCHIVE_URI"
+        ) from exc
+    except (DatasetReplicaError, ValueError, OSError) as exc:
+        raise click.ClickException(str(exc)) from exc
 
 
 @examples.command("create")

--- a/src/langsmith_cli/commands/examples.py
+++ b/src/langsmith_cli/commands/examples.py
@@ -1,5 +1,9 @@
 import click
-from langsmith_cli.dataset_replica.models import ReplicaSource
+from langsmith_cli.dataset_replica.cli import (
+    replica_repository,
+    replica_source_options,
+)
+from langsmith_cli.dataset_replica.models import ReplicaSource, parse_datetime
 from langsmith_cli.utils import (
     ConsoleProtocol,
     LazyConsole,
@@ -44,14 +48,7 @@ def examples():
 
 
 @examples.command("list")
-@click.option(
-    "--source",
-    type=click.Choice([item.value for item in ReplicaSource]),
-    default=ReplicaSource.CLOUD.value,
-    show_default=True,
-)
-@click.option("--archive-uri", envvar="LANGSMITH_ARCHIVE_URI")
-@click.option("--local-dir", type=click.Path(file_okay=False))
+@replica_source_options()
 @click.option("--dataset", help="Dataset ID or Name.")
 @click.option("--example-ids", help="Specific example IDs (comma-separated).")
 @click.option("--limit", default=20, help="Limit number of examples (default 20).")
@@ -142,7 +139,11 @@ def list_examples(
             raise click.ClickException(
                 "--filter is currently available only for --source cloud"
             )
-        repository = _replica_repository(source, archive_uri, local_dir)
+        if inline_s3_urls is not None:
+            raise click.ClickException(
+                "--inline-s3-urls is only supported for --source cloud"
+            )
+        repository = replica_repository(source, archive_uri, local_dir)
         dataset_refs = (
             [dataset]
             if dataset is not None
@@ -232,14 +233,7 @@ def list_examples(
 @examples.command("get")
 @click.argument("example_id")
 @click.option("--as-of", help="Dataset version tag or ISO timestamp.")
-@click.option(
-    "--source",
-    type=click.Choice([item.value for item in ReplicaSource]),
-    default=ReplicaSource.CLOUD.value,
-    show_default=True,
-)
-@click.option("--archive-uri", envvar="LANGSMITH_ARCHIVE_URI")
-@click.option("--local-dir", type=click.Path(file_okay=False))
+@replica_source_options()
 @click.option("--include-attachments", is_flag=True)
 @fields_option()
 @output_option()
@@ -263,10 +257,20 @@ def get_example(
     logger.debug(f"Fetching example: example_id={example_id}, as_of={as_of}")
 
     if source is ReplicaSource.CLOUD:
+        cloud_as_of = None
+        if as_of is not None:
+            try:
+                cloud_as_of = parse_datetime(as_of)
+            except ValueError as exc:
+                raise click.ClickException(
+                    "Cloud examples get --as-of requires an ISO timestamp; "
+                    "version tags require dataset context and are supported by "
+                    "archive/local replica reads"
+                ) from exc
         client = get_or_create_client(ctx)
-        example = client.read_example(example_id, as_of=as_of)
+        example = client.read_example(example_id, as_of=cloud_as_of)
     else:
-        repository = _replica_repository(source, archive_uri, local_dir)
+        repository = replica_repository(source, archive_uri, local_dir)
         example = repository.read_example(
             example_id,
             as_of=as_of,
@@ -289,22 +293,6 @@ def get_example(
     output_single_item(
         ctx, data, console, output=output, render_fn=render_example_details
     )
-
-
-def _replica_repository(source, archive_uri, local_dir):
-    from langsmith_cli.dataset_replica.repository import DatasetReplicaError
-    from langsmith_cli.dataset_replica.service import repository_for
-
-    try:
-        return repository_for(
-            source, archive_uri=archive_uri, local_directory=local_dir
-        )
-    except KeyError as exc:
-        raise click.ClickException(
-            "Archive reads require --archive-uri or LANGSMITH_ARCHIVE_URI"
-        ) from exc
-    except (DatasetReplicaError, ValueError, OSError) as exc:
-        raise click.ClickException(str(exc)) from exc
 
 
 @examples.command("create")

--- a/src/langsmith_cli/commands/examples.py
+++ b/src/langsmith_cli/commands/examples.py
@@ -1,5 +1,6 @@
 import click
 from langsmith_cli.dataset_replica.cli import (
+    replica_list_pagination_options,
     replica_repository,
     replica_source_options,
 )
@@ -7,7 +8,6 @@ from langsmith_cli.dataset_replica.models import ReplicaSource, parse_datetime
 from langsmith_cli.utils import (
     ConsoleProtocol,
     LazyConsole,
-    apply_exclude_filter,
     configure_logger_streams,
     confirm_option,
     count_option,
@@ -28,7 +28,6 @@ from langsmith_cli.utils import (
     render_output,
     require_confirmation,
     sort_by_option,
-    sort_items,
 )
 
 console = LazyConsole()
@@ -51,8 +50,7 @@ def examples():
 @replica_source_options()
 @click.option("--dataset", help="Dataset ID or Name.")
 @click.option("--example-ids", help="Specific example IDs (comma-separated).")
-@click.option("--limit", default=20, help="Limit number of examples (default 20).")
-@click.option("--offset", default=0, help="Number of examples to skip (pagination).")
+@replica_list_pagination_options(include_offset=True, item_name="examples")
 @click.option("--filter", "filter_", help="LangSmith query filter.")
 @click.option("--metadata", help="Filter by metadata (JSON string).")
 @click.option("--splits", help="Filter by dataset splits (comma-separated).")
@@ -118,17 +116,31 @@ def list_examples(
     splits_list = parse_comma_separated_list(splits)
     metadata_dict = parse_json_string(metadata, "metadata")
 
+    from langsmith_cli.dataset_replica.query import ExampleListQuery
+
+    query = ExampleListQuery.from_options(
+        example_ids=example_ids_list,
+        limit=limit,
+        offset=offset,
+        metadata=metadata_dict,
+        splits=splits_list,
+        sort_by=sort_by,
+        exclude=exclude,
+    )
+
     if source is ReplicaSource.CLOUD:
         client = get_or_create_client(ctx)
-        examples_list = list(
+        examples_list = query.apply_to_cloud_response(
             client.list_examples(
                 dataset_name=dataset,
-                example_ids=example_ids_list,
-                limit=limit,
-                offset=offset,
+                example_ids=(
+                    list(query.example_ids) if query.example_ids is not None else None
+                ),
+                limit=query.cloud_limit,
+                offset=query.cloud_offset,
                 filter=filter_,
-                metadata=metadata_dict,
-                splits=splits_list,
+                metadata=query.metadata,
+                splits=list(query.splits) if query.splits is not None else None,
                 inline_s3_urls=inline_s3_urls,
                 include_attachments=include_attachments,
                 as_of=as_of,
@@ -169,43 +181,7 @@ def list_examples(
                 # A global query spans independent histories. A version absent
                 # from one Dataset does not invalidate eligible peer histories.
                 continue
-        if example_ids_list is not None:
-            selected_ids = set(example_ids_list)
-            examples_list = [e for e in examples_list if str(e.id) in selected_ids]
-        if metadata_dict is not None:
-            examples_list = [
-                e
-                for e in examples_list
-                if e.metadata is not None
-                and all(
-                    key in e.metadata and e.metadata[key] == value
-                    for key, value in metadata_dict.items()
-                )
-            ]
-        if splits_list is not None:
-            selected_splits = set(splits_list)
-            examples_list = [
-                e
-                for e in examples_list
-                if e.metadata is not None
-                and "dataset_split" in e.metadata
-                and bool(selected_splits.intersection(e.metadata["dataset_split"]))
-            ]
-        examples_list = examples_list[offset : offset + limit]
-
-    # Client-side exclude filtering (filter by ID string representation)
-    examples_list = apply_exclude_filter(examples_list, exclude, lambda e: str(e.id))
-
-    # Client-side sorting
-    if sort_by:
-        examples_list = sort_items(
-            examples_list,
-            sort_by,
-            {
-                "created_at": lambda e: e.created_at,
-                "modified_at": lambda e: e.modified_at,
-            },
-        )
+        examples_list = query.apply_to_replica(examples_list)
 
     # Define table builder function
     def build_examples_table(examples):

--- a/src/langsmith_cli/commands/examples.py
+++ b/src/langsmith_cli/commands/examples.py
@@ -135,6 +135,10 @@ def list_examples(
             )
         )
     else:
+        from langsmith_cli.dataset_replica.repository import (
+            DatasetReplicaNotFoundError,
+        )
+
         if filter_ is not None:
             raise click.ClickException(
                 "--filter is currently available only for --source cloud"
@@ -151,13 +155,20 @@ def list_examples(
         )
         examples_list = []
         for dataset_ref in dataset_refs:
-            examples_list.extend(
-                repository.read_examples(
-                    dataset_ref,
-                    as_of=as_of,
-                    include_attachments=bool(include_attachments),
+            try:
+                examples_list.extend(
+                    repository.read_examples(
+                        dataset_ref,
+                        as_of=as_of,
+                        include_attachments=bool(include_attachments),
+                    )
                 )
-            )
+            except DatasetReplicaNotFoundError:
+                if dataset is not None:
+                    raise
+                # A global query spans independent histories. A version absent
+                # from one Dataset does not invalidate eligible peer histories.
+                continue
         if example_ids_list is not None:
             selected_ids = set(example_ids_list)
             examples_list = [e for e in examples_list if str(e.id) in selected_ids]

--- a/src/langsmith_cli/dataset_replica/__init__.py
+++ b/src/langsmith_cli/dataset_replica/__init__.py
@@ -1,0 +1,6 @@
+"""Read-only LangSmith dataset replicas."""
+
+from langsmith_cli.dataset_replica.models import ReplicaDestination, ReplicaSource
+from langsmith_cli.dataset_replica.repository import DatasetReplicaRepository
+
+__all__ = ["DatasetReplicaRepository", "ReplicaDestination", "ReplicaSource"]

--- a/src/langsmith_cli/dataset_replica/__init__.py
+++ b/src/langsmith_cli/dataset_replica/__init__.py
@@ -1,6 +1,5 @@
 """Read-only LangSmith dataset replicas."""
 
 from langsmith_cli.dataset_replica.models import ReplicaDestination, ReplicaSource
-from langsmith_cli.dataset_replica.repository import DatasetReplicaRepository
 
-__all__ = ["DatasetReplicaRepository", "ReplicaDestination", "ReplicaSource"]
+__all__ = ["ReplicaDestination", "ReplicaSource"]

--- a/src/langsmith_cli/dataset_replica/cli.py
+++ b/src/langsmith_cli/dataset_replica/cli.py
@@ -46,6 +46,32 @@ def replica_source_options(
     return decorate
 
 
+def replica_list_pagination_options(
+    *, include_offset: bool = False, item_name: str
+) -> Callable[[CommandFunction], CommandFunction]:
+    """Apply validated list bounds consistently to every readable source."""
+
+    def decorate(function: CommandFunction) -> CommandFunction:
+        if include_offset:
+            function = click.option(
+                "--offset",
+                type=click.IntRange(min=0),
+                default=0,
+                show_default=True,
+                help=f"Number of {item_name} to skip after filtering and sorting.",
+            )(function)
+        function = click.option(
+            "--limit",
+            type=click.IntRange(min=1),
+            default=20,
+            show_default=True,
+            help=f"Maximum number of {item_name} to return.",
+        )(function)
+        return function
+
+    return decorate
+
+
 def replica_repository(
     source: ReplicaSource,
     archive_uri: str | None,

--- a/src/langsmith_cli/dataset_replica/cli.py
+++ b/src/langsmith_cli/dataset_replica/cli.py
@@ -1,0 +1,61 @@
+"""Small Click adapters shared by dataset and example replica commands."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, TypeVar
+
+import click
+
+from langsmith_cli.dataset_replica.models import ReplicaSource
+
+if TYPE_CHECKING:
+    from langsmith_cli.dataset_replica.repository import DatasetReplicaRepository
+
+
+CommandFunction = TypeVar("CommandFunction", bound=Callable[..., Any])
+
+
+def replica_source_options(
+    *,
+    include_cloud: bool = True,
+    default: ReplicaSource = ReplicaSource.CLOUD,
+) -> Callable[[CommandFunction], CommandFunction]:
+    """Apply the uniform source location options in one drift-free order."""
+    choices = (
+        list(ReplicaSource)
+        if include_cloud
+        else [ReplicaSource.ARCHIVE, ReplicaSource.LOCAL]
+    )
+
+    def decorate(function: CommandFunction) -> CommandFunction:
+        function = click.option("--local-dir", type=click.Path(file_okay=False))(
+            function
+        )
+        function = click.option("--archive-uri", envvar="LANGSMITH_ARCHIVE_URI")(
+            function
+        )
+        function = click.option(
+            "--source",
+            type=click.Choice([item.value for item in choices]),
+            default=default.value,
+            show_default=True,
+        )(function)
+        return function
+
+    return decorate
+
+
+def replica_repository(
+    source: ReplicaSource,
+    archive_uri: str | None,
+    local_directory: str | None,
+) -> DatasetReplicaRepository:
+    """Open a repository lazily so normal cloud CLI startup stays lightweight."""
+    from langsmith_cli.dataset_replica.service import repository_for
+
+    return repository_for(
+        source,
+        archive_uri=archive_uri,
+        local_directory=local_directory,
+    )

--- a/src/langsmith_cli/dataset_replica/contracts.py
+++ b/src/langsmith_cli/dataset_replica/contracts.py
@@ -1,0 +1,61 @@
+"""Strict Pydantic contracts loaded only for dataset-replica operations.
+
+Normal cloud CLI startup imports only the lightweight enums and TypedDict wire
+schemas from ``models``. Repository commands load this module lazily when they
+actually read or publish a replica.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict
+
+from langsmith_cli.dataset_replica.models import (
+    AttachmentPayload,
+    ExamplePayload,
+)
+
+
+class ReplicaContract(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        extra="forbid",
+        frozen=True,
+        strict=True,
+    )
+
+
+class SerializedExample(ReplicaContract):
+    payload: ExamplePayload
+    attachments: list[AttachmentPayload]
+
+
+class StagedAttachment(ReplicaContract):
+    path: Path
+
+
+class StagedSnapshot(ReplicaContract):
+    example_count: int
+    attachment_count: int
+    content_digest: str
+    attachments: dict[str, StagedAttachment]
+
+
+class ReplicaWriteResult(ReplicaContract):
+    dataset_id: str
+    dataset_name: str
+    as_of: datetime
+    example_count: int
+    attachment_count: int
+    already_present: bool
+    destination_uri: str
+
+
+class ReplicaStatus(ReplicaContract):
+    dataset_id: str
+    dataset_name: str
+    latest_as_of: datetime
+    versions: int
+    source_uri: str

--- a/src/langsmith_cli/dataset_replica/models.py
+++ b/src/langsmith_cli/dataset_replica/models.py
@@ -1,0 +1,138 @@
+"""Strict data contracts for dataset replicas.
+
+The public entities remain LangSmith's ``Dataset``, ``Example``, and
+``DatasetVersion`` models. These small contracts describe only the on-disk index
+and the JSON-compatible payload stored in Parquet.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Any, TypedDict
+
+
+REPLICA_SCHEMA_VERSION = 1
+
+
+class ReplicaSource(str, Enum):
+    CLOUD = "cloud"
+    ARCHIVE = "archive"
+    LOCAL = "local"
+
+
+class ReplicaDestination(str, Enum):
+    ARCHIVE = "archive"
+    LOCAL = "local"
+
+
+class AttachmentPayload(TypedDict):
+    name: str
+    mime_type: str | None
+    digest: str
+    size: int
+
+
+class DatasetPayload(TypedDict):
+    name: str
+    description: str | None
+    data_type: str | None
+    id: str
+    created_at: str
+    modified_at: str | None
+    example_count: int | None
+    session_count: int | None
+    last_session_start_time: str | None
+    inputs_schema: dict[str, Any] | None
+    outputs_schema: dict[str, Any] | None
+    transformations: list[DatasetTransformationPayload] | None
+    metadata: dict[str, Any] | None
+
+
+class ExamplePayload(TypedDict):
+    id: str
+    dataset_id: str
+    inputs: dict[str, Any] | None
+    outputs: dict[str, Any] | None
+    metadata: dict[str, Any] | None
+    created_at: str
+    modified_at: str | None
+    source_run_id: str | None
+
+
+class DatasetTransformationPayload(TypedDict, total=False):
+    path: list[str]
+    transformation_type: str
+
+
+class VersionPayload(TypedDict):
+    tags: list[str] | None
+    as_of: str
+
+
+class SnapshotManifestPayload(TypedDict):
+    schema_version: int
+    dataset_id: str
+    dataset_name: str
+    version: VersionPayload
+    dataset_key: str
+    examples_key: str
+    example_count: int
+    attachment_count: int
+    published_at: str
+
+
+class HeadVersionPayload(TypedDict):
+    as_of: str
+    manifest_key: str
+    tags: list[str] | None
+
+
+class DatasetHeadPayload(TypedDict):
+    schema_version: int
+    dataset_id: str
+    dataset_name: str
+    latest_as_of: str
+    versions: list[HeadVersionPayload]
+
+
+@dataclass(frozen=True)
+class AttachmentBlob:
+    payload: AttachmentPayload
+    content: bytes
+
+
+@dataclass(frozen=True)
+class SerializedExample:
+    payload: ExamplePayload
+    attachments: list[AttachmentPayload]
+    blobs: list[AttachmentBlob]
+
+
+@dataclass(frozen=True)
+class ReplicaWriteResult:
+    dataset_id: str
+    dataset_name: str
+    as_of: datetime
+    example_count: int
+    attachment_count: int
+    already_present: bool
+    destination_uri: str
+
+
+@dataclass(frozen=True)
+class ReplicaStatus:
+    dataset_id: str
+    dataset_name: str
+    latest_as_of: datetime
+    versions: int
+    source_uri: str
+
+
+def datetime_text(value: datetime | None) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+def parse_datetime(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))

--- a/src/langsmith_cli/dataset_replica/models.py
+++ b/src/langsmith_cli/dataset_replica/models.py
@@ -7,13 +7,12 @@ and the JSON-compatible payload stored in Parquet.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, TypedDict
 
 
-REPLICA_SCHEMA_VERSION = 1
+REPLICA_SCHEMA_VERSION = 2
 
 
 class ReplicaSource(str, Enum):
@@ -74,10 +73,7 @@ class VersionPayload(TypedDict):
 class SnapshotManifestPayload(TypedDict):
     schema_version: int
     dataset_id: str
-    dataset_name: str
     version: VersionPayload
-    dataset_key: str
-    dataset_sha256: str
     examples_key: str
     examples_sha256: str
     content_digest: str
@@ -89,53 +85,28 @@ class SnapshotManifestPayload(TypedDict):
 class HeadVersionPayload(TypedDict):
     as_of: str
     manifest_key: str
+    manifest_sha256: str
     tags: list[str] | None
 
 
 class DatasetHeadPayload(TypedDict):
     schema_version: int
     dataset_id: str
-    dataset_name: str
+    dataset: DatasetPayload
     latest_as_of: str
     versions: list[HeadVersionPayload]
 
 
-@dataclass(frozen=True)
-class AttachmentBlob:
-    payload: AttachmentPayload
-    content: bytes
-
-
-@dataclass(frozen=True)
-class SerializedExample:
-    payload: ExamplePayload
-    attachments: list[AttachmentPayload]
-    blobs: list[AttachmentBlob]
-
-
-@dataclass(frozen=True)
-class ReplicaWriteResult:
-    dataset_id: str
-    dataset_name: str
-    as_of: datetime
-    example_count: int
-    attachment_count: int
-    already_present: bool
-    destination_uri: str
-
-
-@dataclass(frozen=True)
-class ReplicaStatus:
-    dataset_id: str
-    dataset_name: str
-    latest_as_of: datetime
-    versions: int
-    source_uri: str
-
-
 def datetime_text(value: datetime | None) -> str | None:
-    return value.isoformat() if value is not None else None
+    if value is None:
+        return None
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("Replica timestamps must be timezone-aware")
+    return value.astimezone(timezone.utc).isoformat()
 
 
 def parse_datetime(value: str) -> datetime:
-    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError("Replica timestamps must be timezone-aware")
+    return parsed.astimezone(timezone.utc)

--- a/src/langsmith_cli/dataset_replica/models.py
+++ b/src/langsmith_cli/dataset_replica/models.py
@@ -77,7 +77,10 @@ class SnapshotManifestPayload(TypedDict):
     dataset_name: str
     version: VersionPayload
     dataset_key: str
+    dataset_sha256: str
     examples_key: str
+    examples_sha256: str
+    content_digest: str
     example_count: int
     attachment_count: int
     published_at: str

--- a/src/langsmith_cli/dataset_replica/query.py
+++ b/src/langsmith_cli/dataset_replica/query.py
@@ -1,0 +1,317 @@
+"""Typed list semantics shared by cloud, archive, and local dataset reads.
+
+The SDK can perform some predicates and pages server-side, while replica stores
+read complete snapshots. These contracts keep the observable CLI order fixed:
+filter first, sort second, and paginate exactly once at the end.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterable
+from enum import Enum
+from typing import Generic, TypeVar
+
+from langsmith.schemas import DataType, Dataset, Example
+from pydantic import BaseModel, ConfigDict, JsonValue
+
+from langsmith_cli.utils import (
+    apply_exclude_filter,
+    apply_name_filters,
+    sort_items,
+)
+
+
+Item = TypeVar("Item")
+
+
+class DatasetSortField(str, Enum):
+    NAME = "name"
+    CREATED_AT = "created_at"
+    EXAMPLE_COUNT = "example_count"
+
+
+class ExampleSortField(str, Enum):
+    CREATED_AT = "created_at"
+    MODIFIED_AT = "modified_at"
+
+
+class ReplicaListQuery(BaseModel, Generic[Item], ABC):
+    """Strict base for source-independent list operations."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    limit: int
+    offset: int = 0
+    exclude: tuple[str, ...] = ()
+    descending: bool = False
+
+    def _page(self, items: list[Item]) -> list[Item]:
+        """Apply the user page once, after every client-side operation."""
+        return items[self.offset : self.offset + self.limit]
+
+    @property
+    @abstractmethod
+    def requires_unbounded_cloud_fetch(self) -> bool:
+        """Whether client-side work requires reading beyond the SDK page."""
+
+    @property
+    @abstractmethod
+    def requires_global_materialization(self) -> bool:
+        """Whether an operation, currently sorting, needs every eligible item."""
+
+    @abstractmethod
+    def _filter_replica(self, items: list[Item]) -> list[Item]:
+        """Apply predicates the replica backend cannot execute itself."""
+
+    @abstractmethod
+    def _apply_client_operations(self, items: list[Item]) -> list[Item]:
+        """Apply operations that remain client-side for every backend."""
+
+    @property
+    def cloud_limit(self) -> int | None:
+        return None if self.requires_unbounded_cloud_fetch else self.limit
+
+    def apply_to_replica(self, items: list[Item]) -> list[Item]:
+        return self._page(self._apply_client_operations(self._filter_replica(items)))
+
+    def apply_to_cloud_response(self, items: Iterable[Item]) -> list[Item]:
+        # Cloud predicates remain authoritative. Reapplying their semantics
+        # locally would create exactly the source drift this facade prevents.
+        if not self.requires_unbounded_cloud_fetch:
+            # The SDK already applied offset. Limit again to protect test fakes
+            # and custom Client implementations that return too many rows.
+            result: list[Item] = []
+            for item in items:
+                result.append(item)
+                if len(result) == self.limit:
+                    break
+            return result
+        if self.requires_global_materialization:
+            return self._page(self._apply_client_operations(list(items)))
+
+        # Filter-only queries consume lazily. Once offset + limit survivors have
+        # arrived, later SDK pages cannot affect the selected page.
+        survivors: list[Item] = []
+        required = self.offset + self.limit
+        for item in items:
+            survivors.extend(self._apply_client_operations([item]))
+            if len(survivors) == required:
+                break
+        return self._page(survivors)
+
+
+class DatasetListQuery(ReplicaListQuery[Dataset]):
+    dataset_ids: tuple[str, ...] | None = None
+    data_type: DataType | None = None
+    dataset_name: str | None = None
+    name_contains: str | None = None
+    metadata: dict[str, JsonValue] | None = None
+    name_pattern: str | None = None
+    name_regex: str | None = None
+    sort_field: DatasetSortField | None = None
+
+    @classmethod
+    def from_options(
+        cls,
+        *,
+        dataset_ids: list[str] | None,
+        limit: int,
+        data_type: str | None,
+        dataset_name: str | None,
+        name_contains: str | None,
+        metadata: dict[str, JsonValue] | None,
+        name_pattern: str | None,
+        name_regex: str | None,
+        sort_by: str | None,
+        exclude: tuple[str, ...],
+    ) -> DatasetListQuery:
+        sort_field, descending = _parse_sort(sort_by, DatasetSortField)
+        return cls(
+            dataset_ids=tuple(dataset_ids) if dataset_ids is not None else None,
+            limit=limit,
+            data_type=DataType(data_type) if data_type is not None else None,
+            dataset_name=dataset_name,
+            name_contains=name_contains,
+            metadata=metadata,
+            name_pattern=name_pattern,
+            name_regex=name_regex,
+            sort_field=sort_field,
+            descending=descending,
+            exclude=exclude,
+        )
+
+    @property
+    def requires_unbounded_cloud_fetch(self) -> bool:
+        """Whether the SDK page must be deferred until after local operations."""
+        return bool(
+            self.name_pattern
+            or self.name_regex
+            or self.exclude
+            or self.sort_field is not None
+        )
+
+    @property
+    def requires_global_materialization(self) -> bool:
+        return self.sort_field is not None
+
+    def _filter_replica(self, items: list[Dataset]) -> list[Dataset]:
+        selected = items
+        if self.dataset_ids is not None:
+            selected_ids = set(self.dataset_ids)
+            selected = [item for item in selected if str(item.id) in selected_ids]
+        if self.data_type is not None:
+            selected = [item for item in selected if item.data_type == self.data_type]
+        if self.dataset_name is not None:
+            selected = [item for item in selected if item.name == self.dataset_name]
+        if self.name_contains is not None:
+            selected = [item for item in selected if self.name_contains in item.name]
+        if self.metadata is not None:
+            selected = [
+                item
+                for item in selected
+                if _metadata_contains(item.metadata, self.metadata)
+            ]
+        return selected
+
+    def _apply_client_operations(self, items: list[Dataset]) -> list[Dataset]:
+        selected = items
+        selected = apply_name_filters(
+            selected,
+            lambda item: item.name,
+            name_pattern=self.name_pattern,
+            name_regex=self.name_regex,
+        )
+        selected = apply_exclude_filter(selected, self.exclude, lambda item: item.name)
+        if self.sort_field is not None:
+            selected = sort_items(
+                selected,
+                _sort_expression(self.sort_field, self.descending),
+                {
+                    DatasetSortField.NAME.value: lambda item: item.name,
+                    DatasetSortField.CREATED_AT.value: lambda item: item.created_at,
+                    DatasetSortField.EXAMPLE_COUNT.value: (
+                        lambda item: (
+                            item.example_count if item.example_count is not None else 0
+                        )
+                    ),
+                },
+            )
+        return selected
+
+
+class ExampleListQuery(ReplicaListQuery[Example]):
+    example_ids: tuple[str, ...] | None = None
+    metadata: dict[str, JsonValue] | None = None
+    splits: tuple[str, ...] | None = None
+    sort_field: ExampleSortField | None = None
+
+    @classmethod
+    def from_options(
+        cls,
+        *,
+        example_ids: list[str] | None,
+        limit: int,
+        offset: int,
+        metadata: dict[str, JsonValue] | None,
+        splits: list[str] | None,
+        sort_by: str | None,
+        exclude: tuple[str, ...],
+    ) -> ExampleListQuery:
+        sort_field, descending = _parse_sort(sort_by, ExampleSortField)
+        return cls(
+            example_ids=tuple(example_ids) if example_ids is not None else None,
+            limit=limit,
+            offset=offset,
+            metadata=metadata,
+            splits=tuple(splits) if splits is not None else None,
+            sort_field=sort_field,
+            descending=descending,
+            exclude=exclude,
+        )
+
+    @property
+    def requires_unbounded_cloud_fetch(self) -> bool:
+        return bool(self.exclude or self.sort_field is not None)
+
+    @property
+    def requires_global_materialization(self) -> bool:
+        return self.sort_field is not None
+
+    @property
+    def cloud_offset(self) -> int:
+        return 0 if self.requires_unbounded_cloud_fetch else self.offset
+
+    def _filter_replica(self, items: list[Example]) -> list[Example]:
+        selected = items
+        if self.example_ids is not None:
+            selected_ids = set(self.example_ids)
+            selected = [item for item in selected if str(item.id) in selected_ids]
+        if self.metadata is not None:
+            selected = [
+                item
+                for item in selected
+                if _metadata_contains(item.metadata, self.metadata)
+            ]
+        if self.splits is not None:
+            selected_splits = set(self.splits)
+            selected = [
+                item
+                for item in selected
+                if bool(selected_splits.intersection(_example_splits(item)))
+            ]
+        return selected
+
+    def _apply_client_operations(self, items: list[Example]) -> list[Example]:
+        selected = items
+        selected = apply_exclude_filter(
+            selected, self.exclude, lambda item: str(item.id)
+        )
+        if self.sort_field is not None:
+            selected = sort_items(
+                selected,
+                _sort_expression(self.sort_field, self.descending),
+                {
+                    ExampleSortField.CREATED_AT.value: lambda item: item.created_at,
+                    ExampleSortField.MODIFIED_AT.value: lambda item: (
+                        item.modified_at or item.created_at
+                    ),
+                },
+            )
+        return selected
+
+
+SortField = TypeVar("SortField", bound=Enum)
+
+
+def _parse_sort(
+    value: str | None, field_type: type[SortField]
+) -> tuple[SortField | None, bool]:
+    if value is None:
+        return None, False
+    descending = value.startswith("-")
+    return field_type(value.removeprefix("-")), descending
+
+
+def _sort_expression(field: Enum, descending: bool) -> str:
+    prefix = "-" if descending else ""
+    return prefix + str(field.value)
+
+
+def _metadata_contains(
+    actual: dict[str, object] | None, expected: dict[str, JsonValue]
+) -> bool:
+    return actual is not None and all(
+        key in actual and actual[key] == value for key, value in expected.items()
+    )
+
+
+def _example_splits(example: Example) -> tuple[str, ...]:
+    if example.metadata is None or "dataset_split" not in example.metadata:
+        return ()
+    value = example.metadata["dataset_split"]
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, list) and all(isinstance(item, str) for item in value):
+        return tuple(value)
+    return ()

--- a/src/langsmith_cli/dataset_replica/repository.py
+++ b/src/langsmith_cli/dataset_replica/repository.py
@@ -1,0 +1,532 @@
+"""Atomic Parquet publication and strict SDK-model reads for dataset replicas."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import datetime, timezone
+import hashlib
+import io
+import json
+from pathlib import Path
+import tempfile
+from typing import TYPE_CHECKING, Any, cast
+
+from langsmith_cli.archive.duckdb import (
+    ARCHIVE_PARQUET_COPY_OPTIONS,
+    archive_duckdb_connection,
+)
+from langsmith_cli.archive.storage import ArchiveStore
+from langsmith_cli.dataset_replica.models import (
+    AttachmentBlob,
+    AttachmentPayload,
+    DatasetHeadPayload,
+    DatasetPayload,
+    DatasetTransformationPayload,
+    ExamplePayload,
+    HeadVersionPayload,
+    REPLICA_SCHEMA_VERSION,
+    ReplicaStatus,
+    ReplicaWriteResult,
+    SerializedExample,
+    SnapshotManifestPayload,
+    VersionPayload,
+    datetime_text,
+    parse_datetime,
+)
+
+if TYPE_CHECKING:
+    from langsmith.schemas import (
+        Dataset,
+        DatasetTransformation,
+        DatasetVersion,
+        Example,
+    )
+
+
+HEADS_PREFIX = "datasets/heads"
+BLOBS_PREFIX = "datasets/blobs"
+
+
+class DatasetReplicaError(RuntimeError):
+    """Base error for malformed or ambiguous replicas."""
+
+
+class DatasetReplicaNotFoundError(DatasetReplicaError):
+    """A requested dataset, version, or example is absent."""
+
+
+class DatasetReplicaAmbiguousError(DatasetReplicaError):
+    """A name resolves to multiple stable dataset identities."""
+
+
+class DatasetReplicaRepository:
+    """Read and atomically publish exact dataset versions in one object store."""
+
+    def __init__(self, store: ArchiveStore) -> None:
+        self._store = store
+
+    @property
+    def base_uri(self) -> str:
+        return self._store.base_uri
+
+    def write_snapshot(
+        self,
+        dataset: Dataset,
+        version: DatasetVersion,
+        examples: Iterable[Example],
+    ) -> ReplicaWriteResult:
+        dataset_payload = _serialize_dataset(dataset)
+        version_payload = _serialize_version(version)
+        dataset_id = dataset_payload["id"]
+        old_head, expected_version = self._read_head_for_update(dataset_id)
+        if old_head is not None:
+            for item in old_head["versions"]:
+                if item["as_of"] == version_payload["as_of"]:
+                    if (
+                        item["tags"] != version_payload["tags"]
+                        or old_head["dataset_name"] != dataset_payload["name"]
+                    ):
+                        item["tags"] = version_payload["tags"]
+                        updated_head: DatasetHeadPayload = {
+                            **old_head,
+                            "dataset_name": dataset_payload["name"],
+                        }
+                        self._store.put_text_if_version(
+                            _head_key(dataset_id),
+                            _json_text(updated_head),
+                            expected_version,
+                        )
+                    manifest = self._read_manifest(item["manifest_key"])
+                    return ReplicaWriteResult(
+                        dataset_id=dataset_id,
+                        dataset_name=dataset_payload["name"],
+                        as_of=version.as_of,
+                        example_count=manifest["example_count"],
+                        attachment_count=manifest["attachment_count"],
+                        already_present=True,
+                        destination_uri=self.base_uri,
+                    )
+
+        serialized_examples = [_serialize_example(example) for example in examples]
+        version_token = hashlib.sha256(
+            version_payload["as_of"].encode("utf-8")
+        ).hexdigest()
+        version_prefix = f"datasets/{dataset_id}/versions/{version_token}"
+        dataset_key = f"{version_prefix}/dataset.parquet"
+        examples_key = f"{version_prefix}/examples.parquet"
+        manifest_key = f"{version_prefix}/manifest.json"
+
+        with tempfile.TemporaryDirectory(prefix="langsmith-dataset-replica-") as raw:
+            staging = Path(raw)
+            dataset_path = staging / "dataset.parquet"
+            examples_path = staging / "examples.parquet"
+            _write_dataset_parquet(dataset_path, dataset_payload)
+            _write_examples_parquet(examples_path, serialized_examples)
+            self._store.put_file(dataset_key, dataset_path)
+            self._store.put_file(examples_key, examples_path)
+
+        unique_blobs: dict[str, AttachmentBlob] = {}
+        for example in serialized_examples:
+            for blob in example.blobs:
+                unique_blobs[blob.payload["digest"]] = blob
+        for digest, blob in unique_blobs.items():
+            blob_key = f"{BLOBS_PREFIX}/{digest}"
+            if not self._store.exists(blob_key):
+                self._store.put_bytes(blob_key, blob.content)
+
+        attachment_count = sum(
+            len(example.attachments) for example in serialized_examples
+        )
+        manifest: SnapshotManifestPayload = {
+            "schema_version": REPLICA_SCHEMA_VERSION,
+            "dataset_id": dataset_id,
+            "dataset_name": dataset_payload["name"],
+            "version": version_payload,
+            "dataset_key": dataset_key,
+            "examples_key": examples_key,
+            "example_count": len(serialized_examples),
+            "attachment_count": attachment_count,
+            "published_at": datetime.now(timezone.utc).isoformat(),
+        }
+        self._store.put_text(manifest_key, _json_text(manifest))
+
+        versions = [] if old_head is None else list(old_head["versions"])
+        versions.append(
+            HeadVersionPayload(
+                as_of=version_payload["as_of"],
+                manifest_key=manifest_key,
+                tags=version_payload["tags"],
+            )
+        )
+        versions.sort(key=lambda item: parse_datetime(item["as_of"]))
+        head: DatasetHeadPayload = {
+            "schema_version": REPLICA_SCHEMA_VERSION,
+            "dataset_id": dataset_id,
+            "dataset_name": dataset_payload["name"],
+            "latest_as_of": versions[-1]["as_of"],
+            "versions": versions,
+        }
+        self._store.put_text_if_version(
+            _head_key(dataset_id), _json_text(head), expected_version
+        )
+        return ReplicaWriteResult(
+            dataset_id=dataset_id,
+            dataset_name=dataset_payload["name"],
+            as_of=version.as_of,
+            example_count=len(serialized_examples),
+            attachment_count=attachment_count,
+            already_present=False,
+            destination_uri=self.base_uri,
+        )
+
+    def list_datasets(self) -> list[Dataset]:
+        return [self._read_dataset_from_head(head) for head in self._list_heads()]
+
+    def read_dataset(self, name_or_id: str, as_of: str | None = None) -> Dataset:
+        head = self._resolve_head(name_or_id)
+        manifest = self._resolve_manifest(head, as_of)
+        return self._read_dataset(manifest)
+
+    def list_versions(self, name_or_id: str) -> list[DatasetVersion]:
+        from langsmith.schemas import DatasetVersion
+
+        head = self._resolve_head(name_or_id)
+        versions: list[DatasetVersion] = []
+        for item in reversed(head["versions"]):
+            versions.append(
+                DatasetVersion(tags=item["tags"], as_of=parse_datetime(item["as_of"]))
+            )
+        return versions
+
+    def sync_version_tags(
+        self, dataset_id: str, versions: Iterable[DatasetVersion]
+    ) -> None:
+        """Refresh mutable tag pointers without rewriting immutable snapshots."""
+        head, expected_version = self._read_head_for_update(dataset_id)
+        if head is None:
+            return
+        tags_by_time = {version.as_of.isoformat(): version.tags for version in versions}
+        changed = False
+        for item in head["versions"]:
+            as_of = item["as_of"]
+            if as_of in tags_by_time and item["tags"] != tags_by_time[as_of]:
+                item["tags"] = tags_by_time[as_of]
+                changed = True
+        if changed:
+            self._store.put_text_if_version(
+                _head_key(dataset_id), _json_text(head), expected_version
+            )
+
+    def read_examples(
+        self,
+        name_or_id: str,
+        *,
+        as_of: str | None = None,
+        include_attachments: bool = False,
+    ) -> list[Example]:
+        head = self._resolve_head(name_or_id)
+        manifest = self._resolve_manifest(head, as_of)
+        return self._read_examples(manifest, include_attachments=include_attachments)
+
+    def read_example(
+        self,
+        example_id: str,
+        *,
+        as_of: str | None = None,
+        include_attachments: bool = False,
+    ) -> Example:
+        matches: list[Example] = []
+        for head in self._list_heads():
+            manifest = self._resolve_manifest(head, as_of)
+            for example in self._read_examples(
+                manifest, include_attachments=include_attachments
+            ):
+                if str(example.id) == example_id:
+                    matches.append(example)
+        if not matches:
+            raise DatasetReplicaNotFoundError(f"Example not found: {example_id}")
+        if len(matches) > 1:
+            raise DatasetReplicaAmbiguousError(
+                f"Example ID exists in multiple dataset replicas: {example_id}"
+            )
+        return matches[0]
+
+    def statuses(self) -> list[ReplicaStatus]:
+        return [
+            ReplicaStatus(
+                dataset_id=head["dataset_id"],
+                dataset_name=head["dataset_name"],
+                latest_as_of=parse_datetime(head["latest_as_of"]),
+                versions=len(head["versions"]),
+                source_uri=self.base_uri,
+            )
+            for head in self._list_heads()
+        ]
+
+    def _list_heads(self) -> list[DatasetHeadPayload]:
+        return [
+            _parse_head(self._store.get_text(key))
+            for key in self._store.list_keys(HEADS_PREFIX)
+            if key.endswith(".json")
+        ]
+
+    def _resolve_head(self, name_or_id: str) -> DatasetHeadPayload:
+        heads = [
+            head
+            for head in self._list_heads()
+            if head["dataset_id"] == name_or_id or head["dataset_name"] == name_or_id
+        ]
+        if not heads:
+            raise DatasetReplicaNotFoundError(f"Dataset not found: {name_or_id}")
+        if len(heads) > 1:
+            raise DatasetReplicaAmbiguousError(
+                f"Dataset name is ambiguous; use an ID: {name_or_id}"
+            )
+        return heads[0]
+
+    def _resolve_manifest(
+        self, head: DatasetHeadPayload, as_of: str | None
+    ) -> SnapshotManifestPayload:
+        if as_of is None or as_of == "latest":
+            selected = head["versions"][-1]
+            return self._read_manifest(selected["manifest_key"])
+
+        tag_matches: list[SnapshotManifestPayload] = []
+        try:
+            requested_time = parse_datetime(as_of)
+        except ValueError:
+            requested_time = None
+        for item in reversed(head["versions"]):
+            manifest = self._read_manifest(item["manifest_key"])
+            tags = item["tags"]
+            if tags is not None and as_of in tags:
+                tag_matches.append(manifest)
+            if (
+                requested_time is not None
+                and parse_datetime(item["as_of"]) <= requested_time
+            ):
+                return manifest
+        if len(tag_matches) == 1:
+            return tag_matches[0]
+        if len(tag_matches) > 1:
+            raise DatasetReplicaAmbiguousError(f"Version tag is ambiguous: {as_of}")
+        raise DatasetReplicaNotFoundError(f"Dataset version not found: {as_of}")
+
+    def _read_dataset_from_head(self, head: DatasetHeadPayload) -> Dataset:
+        return self._read_dataset(self._resolve_manifest(head, None))
+
+    def _read_dataset(self, manifest: SnapshotManifestPayload) -> Dataset:
+        from langsmith.schemas import Dataset
+
+        with tempfile.TemporaryDirectory(prefix="langsmith-dataset-read-") as raw:
+            path = Path(raw) / "dataset.parquet"
+            self._store.get_file(manifest["dataset_key"], path)
+            with archive_duckdb_connection() as connection:
+                row = connection.execute(
+                    "SELECT payload_json FROM read_parquet(?)", [str(path)]
+                ).fetchone()
+        if row is None:
+            raise DatasetReplicaError("Dataset Parquet contains no row")
+        return Dataset(**_parse_dataset_payload(row[0]))
+
+    def _read_examples(
+        self,
+        manifest: SnapshotManifestPayload,
+        *,
+        include_attachments: bool,
+    ) -> list[Example]:
+        from langsmith.schemas import Example
+
+        with tempfile.TemporaryDirectory(prefix="langsmith-examples-read-") as raw:
+            path = Path(raw) / "examples.parquet"
+            self._store.get_file(manifest["examples_key"], path)
+            with archive_duckdb_connection() as connection:
+                rows = connection.execute(
+                    "SELECT payload_json, attachments_json "
+                    "FROM read_parquet(?) ORDER BY created_at, id",
+                    [str(path)],
+                ).fetchall()
+        result: list[Example] = []
+        for payload_text, attachments_text in rows:
+            payload = _parse_example_payload(payload_text)
+            attachments_payload = _parse_attachments(attachments_text)
+            attachments = None
+            if include_attachments and attachments_payload:
+                attachments = {
+                    item["name"]: {
+                        "presigned_url": self._store.object_uri(
+                            f"{BLOBS_PREFIX}/{item['digest']}"
+                        ),
+                        "reader": io.BytesIO(
+                            self._store.get_bytes(f"{BLOBS_PREFIX}/{item['digest']}")
+                        ),
+                        "mime_type": item["mime_type"],
+                    }
+                    for item in attachments_payload
+                }
+            result.append(Example(**payload, attachments=attachments))
+        return result
+
+    def _read_manifest(self, key: str) -> SnapshotManifestPayload:
+        return _parse_manifest(self._store.get_text(key))
+
+    def _read_head_for_update(
+        self, dataset_id: str
+    ) -> tuple[DatasetHeadPayload | None, str | None]:
+        key = _head_key(dataset_id)
+        if not self._store.exists(key):
+            return None, None
+        stored = self._store.get_text_with_version(key)
+        return _parse_head(stored.content), stored.version
+
+
+def _serialize_dataset(dataset: Dataset) -> DatasetPayload:
+    data_type = dataset.data_type.value if dataset.data_type is not None else None
+    transformations = (
+        [_serialize_transformation(item) for item in dataset.transformations]
+        if dataset.transformations is not None
+        else None
+    )
+    return {
+        "name": dataset.name,
+        "description": dataset.description,
+        "data_type": data_type,
+        "id": str(dataset.id),
+        "created_at": dataset.created_at.isoformat(),
+        "modified_at": datetime_text(dataset.modified_at),
+        "example_count": dataset.example_count,
+        "session_count": dataset.session_count,
+        "last_session_start_time": datetime_text(dataset.last_session_start_time),
+        "inputs_schema": dataset.inputs_schema,
+        "outputs_schema": dataset.outputs_schema,
+        "transformations": transformations,
+        "metadata": dataset.metadata,
+    }
+
+
+def _serialize_transformation(
+    transformation: DatasetTransformation,
+) -> DatasetTransformationPayload:
+    payload: DatasetTransformationPayload = {}
+    if "path" in transformation:
+        payload["path"] = transformation["path"]
+    if "transformation_type" in transformation:
+        payload["transformation_type"] = transformation["transformation_type"]
+    return payload
+
+
+def _serialize_version(version: DatasetVersion) -> VersionPayload:
+    return {"tags": version.tags, "as_of": version.as_of.isoformat()}
+
+
+def _serialize_example(example: Example) -> SerializedExample:
+    payload: ExamplePayload = {
+        "id": str(example.id),
+        "dataset_id": str(example.dataset_id),
+        "inputs": example.inputs,
+        "outputs": example.outputs,
+        "metadata": example.metadata,
+        "created_at": example.created_at.isoformat(),
+        "modified_at": datetime_text(example.modified_at),
+        "source_run_id": (
+            str(example.source_run_id) if example.source_run_id is not None else None
+        ),
+    }
+    attachments: list[AttachmentPayload] = []
+    blobs: list[AttachmentBlob] = []
+    if example.attachments is not None:
+        for name, attachment in sorted(example.attachments.items()):
+            content = attachment["reader"].read()
+            if not isinstance(content, bytes):
+                raise DatasetReplicaError("Attachment reader must return bytes")
+            digest = hashlib.sha256(content).hexdigest()
+            attachment_payload: AttachmentPayload = {
+                "name": name,
+                "mime_type": attachment["mime_type"],
+                "digest": digest,
+                "size": len(content),
+            }
+            attachments.append(attachment_payload)
+            blobs.append(AttachmentBlob(payload=attachment_payload, content=content))
+    return SerializedExample(payload=payload, attachments=attachments, blobs=blobs)
+
+
+def _write_dataset_parquet(path: Path, payload: DatasetPayload) -> None:
+    with archive_duckdb_connection() as connection:
+        connection.execute("CREATE TABLE dataset (payload_json VARCHAR NOT NULL)")
+        connection.execute("INSERT INTO dataset VALUES (?)", [_json_text(payload)])
+        connection.execute(
+            f"COPY dataset TO {_sql_literal(path)} " + ARCHIVE_PARQUET_COPY_OPTIONS
+        )
+
+
+def _write_examples_parquet(path: Path, examples: list[SerializedExample]) -> None:
+    with archive_duckdb_connection() as connection:
+        connection.execute(
+            "CREATE TABLE examples ("
+            "id UUID NOT NULL, created_at TIMESTAMPTZ NOT NULL, "
+            "payload_json VARCHAR NOT NULL, attachments_json VARCHAR NOT NULL)"
+        )
+        for example in examples:
+            connection.execute(
+                "INSERT INTO examples VALUES (?, ?, ?, ?)",
+                [
+                    example.payload["id"],
+                    example.payload["created_at"],
+                    _json_text(example.payload),
+                    _json_text(example.attachments),
+                ],
+            )
+        connection.execute(
+            f"COPY examples TO {_sql_literal(path)} " + ARCHIVE_PARQUET_COPY_OPTIONS
+        )
+
+
+def _sql_literal(path: Path) -> str:
+    return "'" + str(path).replace("'", "''") + "'"
+
+
+def _json_text(payload: object) -> str:
+    return json.dumps(
+        payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    )
+
+
+def _head_key(dataset_id: str) -> str:
+    return f"{HEADS_PREFIX}/{dataset_id}.json"
+
+
+def _load_object(text: str, kind: str) -> dict[str, Any]:
+    raw = json.loads(text)
+    if not isinstance(raw, dict):
+        raise DatasetReplicaError(f"{kind} must be a JSON object")
+    return raw
+
+
+def _parse_head(text: str) -> DatasetHeadPayload:
+    raw = _load_object(text, "Dataset head")
+    if raw["schema_version"] != REPLICA_SCHEMA_VERSION:
+        raise DatasetReplicaError("Unsupported dataset replica schema")
+    return cast(DatasetHeadPayload, raw)
+
+
+def _parse_manifest(text: str) -> SnapshotManifestPayload:
+    raw = _load_object(text, "Dataset manifest")
+    if raw["schema_version"] != REPLICA_SCHEMA_VERSION:
+        raise DatasetReplicaError("Unsupported dataset replica schema")
+    return cast(SnapshotManifestPayload, raw)
+
+
+def _parse_dataset_payload(text: str) -> DatasetPayload:
+    return cast(DatasetPayload, _load_object(text, "Dataset payload"))
+
+
+def _parse_example_payload(text: str) -> ExamplePayload:
+    return cast(ExamplePayload, _load_object(text, "Example payload"))
+
+
+def _parse_attachments(text: str) -> list[AttachmentPayload]:
+    raw = json.loads(text)
+    if not isinstance(raw, list):
+        raise DatasetReplicaError("Attachment payload must be a JSON array")
+    return cast(list[AttachmentPayload], raw)

--- a/src/langsmith_cli/dataset_replica/repository.py
+++ b/src/langsmith_cli/dataset_replica/repository.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from datetime import datetime, timezone
 import hashlib
 import io
@@ -10,12 +10,13 @@ import json
 from pathlib import Path
 import tempfile
 from typing import TYPE_CHECKING, Any, cast
+from uuid import uuid4
 
 from langsmith_cli.archive.duckdb import (
     ARCHIVE_PARQUET_COPY_OPTIONS,
     archive_duckdb_connection,
 )
-from langsmith_cli.archive.storage import ArchiveStore
+from langsmith_cli.archive.storage import ArchiveStore, ConcurrentArchiveWriteError
 from langsmith_cli.dataset_replica.models import (
     AttachmentBlob,
     AttachmentPayload,
@@ -45,6 +46,92 @@ if TYPE_CHECKING:
 
 HEADS_PREFIX = "datasets/heads"
 BLOBS_PREFIX = "datasets/blobs"
+MAX_HEAD_PUBLICATION_ATTEMPTS = 16
+DUCKDB_INSERT_BATCH_SIZE = 10_000
+HEAD_KEYS = frozenset(
+    {"schema_version", "dataset_id", "dataset_name", "latest_as_of", "versions"}
+)
+HEAD_VERSION_KEYS = frozenset({"as_of", "manifest_key", "tags"})
+MANIFEST_KEYS = frozenset(
+    {
+        "schema_version",
+        "dataset_id",
+        "dataset_name",
+        "version",
+        "dataset_key",
+        "dataset_sha256",
+        "examples_key",
+        "examples_sha256",
+        "content_digest",
+        "example_count",
+        "attachment_count",
+        "published_at",
+    }
+)
+VERSION_KEYS = frozenset({"as_of", "tags"})
+DATASET_PAYLOAD_KEYS = frozenset(
+    {
+        "name",
+        "description",
+        "data_type",
+        "id",
+        "created_at",
+        "modified_at",
+        "example_count",
+        "session_count",
+        "last_session_start_time",
+        "inputs_schema",
+        "outputs_schema",
+        "transformations",
+        "metadata",
+    }
+)
+EXAMPLE_PAYLOAD_KEYS = frozenset(
+    {
+        "id",
+        "dataset_id",
+        "inputs",
+        "outputs",
+        "metadata",
+        "created_at",
+        "modified_at",
+        "source_run_id",
+    }
+)
+ATTACHMENT_KEYS = frozenset({"name", "mime_type", "digest", "size"})
+
+DATASET_SDK_FIELDS = frozenset(
+    {
+        "created_at",
+        "data_type",
+        "description",
+        "example_count",
+        "id",
+        "inputs_schema",
+        "last_session_start_time",
+        "metadata",
+        "modified_at",
+        "name",
+        "outputs_schema",
+        "session_count",
+        "transformations",
+    }
+)
+EXAMPLE_SDK_FIELDS = frozenset(
+    {
+        "attachments",
+        "created_at",
+        "dataset_id",
+        "id",
+        "inputs",
+        "metadata",
+        "modified_at",
+        "outputs",
+        "source_run_id",
+    }
+)
+DATASET_VERSION_SDK_FIELDS = frozenset({"as_of", "tags"})
+DATASET_TRANSFORMATION_SDK_FIELDS = frozenset({"path", "transformation_type"})
 
 
 class DatasetReplicaError(RuntimeError):
@@ -57,6 +144,22 @@ class DatasetReplicaNotFoundError(DatasetReplicaError):
 
 class DatasetReplicaAmbiguousError(DatasetReplicaError):
     """A name resolves to multiple stable dataset identities."""
+
+
+class DatasetReplicaConflictError(DatasetReplicaError):
+    """One immutable dataset version was supplied with different content."""
+
+
+class DatasetReplicaSchemaError(DatasetReplicaError):
+    """The installed LangSmith SDK no longer matches the replica contract."""
+
+
+class DatasetReplicaIntegrityError(DatasetReplicaError):
+    """Published replica bytes do not match their immutable manifest."""
+
+
+class DatasetReplicaConfigurationError(DatasetReplicaError):
+    """A replica location is missing required local/archive configuration."""
 
 
 class DatasetReplicaRepository:
@@ -75,46 +178,35 @@ class DatasetReplicaRepository:
         version: DatasetVersion,
         examples: Iterable[Example],
     ) -> ReplicaWriteResult:
+        _assert_sdk_contract()
         dataset_payload = _serialize_dataset(dataset)
         version_payload = _serialize_version(version)
         dataset_id = dataset_payload["id"]
-        old_head, expected_version = self._read_head_for_update(dataset_id)
-        if old_head is not None:
-            for item in old_head["versions"]:
-                if item["as_of"] == version_payload["as_of"]:
-                    if (
-                        item["tags"] != version_payload["tags"]
-                        or old_head["dataset_name"] != dataset_payload["name"]
-                    ):
-                        item["tags"] = version_payload["tags"]
-                        updated_head: DatasetHeadPayload = {
-                            **old_head,
-                            "dataset_name": dataset_payload["name"],
-                        }
-                        self._store.put_text_if_version(
-                            _head_key(dataset_id),
-                            _json_text(updated_head),
-                            expected_version,
-                        )
-                    manifest = self._read_manifest(item["manifest_key"])
-                    return ReplicaWriteResult(
-                        dataset_id=dataset_id,
-                        dataset_name=dataset_payload["name"],
-                        as_of=version.as_of,
-                        example_count=manifest["example_count"],
-                        attachment_count=manifest["attachment_count"],
-                        already_present=True,
-                        destination_uri=self.base_uri,
-                    )
-
         serialized_examples = [_serialize_example(example) for example in examples]
+        _validate_example_membership(dataset_id, serialized_examples)
+        content_digest = _snapshot_content_digest(dataset_payload, serialized_examples)
+
+        # Fast idempotence path. Content is serialized and hashed before this
+        # check: `(dataset_id, as_of)` is an immutable identity, not merely a
+        # convenient object-store prefix.
+        existing = self._publish_head(
+            dataset_payload=dataset_payload,
+            version=version,
+            version_payload=version_payload,
+            manifest_key=None,
+            content_digest=content_digest,
+            example_count=len(serialized_examples),
+            attachment_count=sum(
+                len(example.attachments) for example in serialized_examples
+            ),
+        )
+        if existing is not None:
+            return existing
+
         version_token = hashlib.sha256(
             version_payload["as_of"].encode("utf-8")
         ).hexdigest()
         version_prefix = f"datasets/{dataset_id}/versions/{version_token}"
-        dataset_key = f"{version_prefix}/dataset.parquet"
-        examples_key = f"{version_prefix}/examples.parquet"
-        manifest_key = f"{version_prefix}/manifest.json"
 
         with tempfile.TemporaryDirectory(prefix="langsmith-dataset-replica-") as raw:
             staging = Path(raw)
@@ -122,8 +214,26 @@ class DatasetReplicaRepository:
             examples_path = staging / "examples.parquet"
             _write_dataset_parquet(dataset_path, dataset_payload)
             _write_examples_parquet(examples_path, serialized_examples)
-            self._store.put_file(dataset_key, dataset_path)
-            self._store.put_file(examples_key, examples_path)
+            dataset_sha256 = _file_sha256(dataset_path)
+            examples_sha256 = _file_sha256(examples_path)
+            dataset_key = f"{version_prefix}/objects/dataset-{dataset_sha256}.parquet"
+            examples_key = (
+                f"{version_prefix}/objects/examples-{examples_sha256}.parquet"
+            )
+            # Content-addressed objects are immutable. Reusing an existing key is
+            # safe because equal SHA-256 keys imply equal publication bytes.
+            self._put_file_if_absent_verified(
+                dataset_key,
+                dataset_path,
+                dataset_sha256,
+                staging / "existing-dataset.parquet",
+            )
+            self._put_file_if_absent_verified(
+                examples_key,
+                examples_path,
+                examples_sha256,
+                staging / "existing-examples.parquet",
+            )
 
         unique_blobs: dict[str, AttachmentBlob] = {}
         for example in serialized_examples:
@@ -131,53 +241,162 @@ class DatasetReplicaRepository:
                 unique_blobs[blob.payload["digest"]] = blob
         for digest, blob in unique_blobs.items():
             blob_key = f"{BLOBS_PREFIX}/{digest}"
-            if not self._store.exists(blob_key):
+            if self._store.exists(blob_key):
+                existing_content = self._store.get_bytes(blob_key)
+                if _bytes_sha256(existing_content) != digest:
+                    raise DatasetReplicaIntegrityError(
+                        f"Replica attachment digest mismatch: {blob_key}"
+                    )
+            else:
                 self._store.put_bytes(blob_key, blob.content)
 
         attachment_count = sum(
             len(example.attachments) for example in serialized_examples
         )
+        # Manifests are immutable and uniquely staged. Only the head CAS below
+        # makes one complete manifest reachable; losing writers leave harmless
+        # unreachable objects rather than mutating a winner's snapshot.
+        manifest_key = f"{version_prefix}/manifests/{uuid4().hex}.json"
         manifest: SnapshotManifestPayload = {
             "schema_version": REPLICA_SCHEMA_VERSION,
             "dataset_id": dataset_id,
             "dataset_name": dataset_payload["name"],
             "version": version_payload,
             "dataset_key": dataset_key,
+            "dataset_sha256": dataset_sha256,
             "examples_key": examples_key,
+            "examples_sha256": examples_sha256,
+            "content_digest": content_digest,
             "example_count": len(serialized_examples),
             "attachment_count": attachment_count,
             "published_at": datetime.now(timezone.utc).isoformat(),
         }
         self._store.put_text(manifest_key, _json_text(manifest))
-
-        versions = [] if old_head is None else list(old_head["versions"])
-        versions.append(
-            HeadVersionPayload(
-                as_of=version_payload["as_of"],
-                manifest_key=manifest_key,
-                tags=version_payload["tags"],
-            )
-        )
-        versions.sort(key=lambda item: parse_datetime(item["as_of"]))
-        head: DatasetHeadPayload = {
-            "schema_version": REPLICA_SCHEMA_VERSION,
-            "dataset_id": dataset_id,
-            "dataset_name": dataset_payload["name"],
-            "latest_as_of": versions[-1]["as_of"],
-            "versions": versions,
-        }
-        self._store.put_text_if_version(
-            _head_key(dataset_id), _json_text(head), expected_version
-        )
-        return ReplicaWriteResult(
-            dataset_id=dataset_id,
-            dataset_name=dataset_payload["name"],
-            as_of=version.as_of,
+        result = self._publish_head(
+            dataset_payload=dataset_payload,
+            version=version,
+            version_payload=version_payload,
+            manifest_key=manifest_key,
+            content_digest=content_digest,
             example_count=len(serialized_examples),
             attachment_count=attachment_count,
-            already_present=False,
-            destination_uri=self.base_uri,
         )
+        if result is None:
+            raise DatasetReplicaError("Dataset head publication made no progress")
+        return result
+
+    def _publish_head(
+        self,
+        *,
+        dataset_payload: DatasetPayload,
+        version: DatasetVersion,
+        version_payload: VersionPayload,
+        manifest_key: str | None,
+        content_digest: str,
+        example_count: int,
+        attachment_count: int,
+    ) -> ReplicaWriteResult | None:
+        """Publish or validate one immutable version through a bounded CAS loop.
+
+        INVARIANT: the head is the sole reachability boundary. Writers may stage
+        immutable objects concurrently, but every retry rereads and merges the
+        newest head before attempting compare-and-swap publication.
+        """
+        dataset_id = dataset_payload["id"]
+        for _attempt in range(MAX_HEAD_PUBLICATION_ATTEMPTS):
+            old_head, expected_version = self._read_head_for_update(dataset_id)
+            if old_head is not None:
+                for item in old_head["versions"]:
+                    if item["as_of"] != version_payload["as_of"]:
+                        continue
+                    existing_manifest = self._read_manifest_for_head(old_head, item)
+                    if existing_manifest["content_digest"] != content_digest:
+                        raise DatasetReplicaConflictError(
+                            "Dataset version already exists with different content: "
+                            f"{dataset_id} at {version_payload['as_of']}"
+                        )
+                    if (
+                        item["tags"] != version_payload["tags"]
+                        or old_head["dataset_name"] != dataset_payload["name"]
+                    ):
+                        versions = [dict(value) for value in old_head["versions"]]
+                        for updated_item in versions:
+                            if updated_item["as_of"] == version_payload["as_of"]:
+                                updated_item["tags"] = version_payload["tags"]
+                        updated_head: DatasetHeadPayload = {
+                            **old_head,
+                            "dataset_name": dataset_payload["name"],
+                            "versions": cast(list[HeadVersionPayload], versions),
+                        }
+                        try:
+                            self._store.put_text_if_version(
+                                _head_key(dataset_id),
+                                _json_text(updated_head),
+                                expected_version,
+                            )
+                        except ConcurrentArchiveWriteError:
+                            continue
+                    return ReplicaWriteResult(
+                        dataset_id=dataset_id,
+                        dataset_name=dataset_payload["name"],
+                        as_of=version.as_of,
+                        example_count=existing_manifest["example_count"],
+                        attachment_count=existing_manifest["attachment_count"],
+                        already_present=True,
+                        destination_uri=self.base_uri,
+                    )
+
+            if manifest_key is None:
+                return None
+            versions = [] if old_head is None else list(old_head["versions"])
+            versions.append(
+                HeadVersionPayload(
+                    as_of=version_payload["as_of"],
+                    manifest_key=manifest_key,
+                    tags=version_payload["tags"],
+                )
+            )
+            versions.sort(key=lambda item: parse_datetime(item["as_of"]))
+            head: DatasetHeadPayload = {
+                "schema_version": REPLICA_SCHEMA_VERSION,
+                "dataset_id": dataset_id,
+                "dataset_name": dataset_payload["name"],
+                "latest_as_of": versions[-1]["as_of"],
+                "versions": versions,
+            }
+            try:
+                self._store.put_text_if_version(
+                    _head_key(dataset_id), _json_text(head), expected_version
+                )
+            except ConcurrentArchiveWriteError:
+                continue
+            return ReplicaWriteResult(
+                dataset_id=dataset_id,
+                dataset_name=dataset_payload["name"],
+                as_of=version.as_of,
+                example_count=example_count,
+                attachment_count=attachment_count,
+                already_present=False,
+                destination_uri=self.base_uri,
+            )
+        raise DatasetReplicaError(
+            f"Dataset head stayed busy after {MAX_HEAD_PUBLICATION_ATTEMPTS} attempts: "
+            f"{dataset_id}"
+        )
+
+    def _put_file_if_absent_verified(
+        self,
+        key: str,
+        source: Path,
+        expected_sha256: str,
+        verification_path: Path,
+    ) -> None:
+        if not self._store.exists(key):
+            self._store.put_file(key, source)
+            return
+        self._store.get_file(key, verification_path)
+        if _file_sha256(verification_path) != expected_sha256:
+            raise DatasetReplicaIntegrityError(f"Replica object digest mismatch: {key}")
 
     def list_datasets(self) -> list[Dataset]:
         return [self._read_dataset_from_head(head) for head in self._list_heads()]
@@ -185,11 +404,15 @@ class DatasetReplicaRepository:
     def read_dataset(self, name_or_id: str, as_of: str | None = None) -> Dataset:
         head = self._resolve_head(name_or_id)
         manifest = self._resolve_manifest(head, as_of)
-        return self._read_dataset(manifest)
+        dataset = self._read_dataset(manifest)
+        # Dataset names are mutable lookup labels in LangSmith, not replica
+        # identities. The head carries the newest label for every exact version.
+        return dataset.model_copy(update={"name": head["dataset_name"]})
 
     def list_versions(self, name_or_id: str) -> list[DatasetVersion]:
         from langsmith.schemas import DatasetVersion
 
+        _assert_sdk_contract()
         head = self._resolve_head(name_or_id)
         versions: list[DatasetVersion] = []
         for item in reversed(head["versions"]):
@@ -202,20 +425,32 @@ class DatasetReplicaRepository:
         self, dataset_id: str, versions: Iterable[DatasetVersion]
     ) -> None:
         """Refresh mutable tag pointers without rewriting immutable snapshots."""
-        head, expected_version = self._read_head_for_update(dataset_id)
-        if head is None:
-            return
         tags_by_time = {version.as_of.isoformat(): version.tags for version in versions}
-        changed = False
-        for item in head["versions"]:
-            as_of = item["as_of"]
-            if as_of in tags_by_time and item["tags"] != tags_by_time[as_of]:
-                item["tags"] = tags_by_time[as_of]
-                changed = True
-        if changed:
-            self._store.put_text_if_version(
-                _head_key(dataset_id), _json_text(head), expected_version
-            )
+        for _attempt in range(MAX_HEAD_PUBLICATION_ATTEMPTS):
+            head, expected_version = self._read_head_for_update(dataset_id)
+            if head is None:
+                return
+            changed = False
+            for item in head["versions"]:
+                as_of = item["as_of"]
+                if as_of in tags_by_time and item["tags"] != tags_by_time[as_of]:
+                    item["tags"] = tags_by_time[as_of]
+                    changed = True
+            if not changed:
+                return
+            try:
+                self._store.put_text_if_version(
+                    _head_key(dataset_id), _json_text(head), expected_version
+                )
+            except ConcurrentArchiveWriteError:
+                # Tags are mutable pointers, but they must never overwrite a
+                # concurrently appended immutable version. Reread and merge.
+                continue
+            return
+        raise DatasetReplicaError(
+            f"Dataset tag head stayed busy after {MAX_HEAD_PUBLICATION_ATTEMPTS} "
+            f"attempts: {dataset_id}"
+        )
 
     def read_examples(
         self,
@@ -237,7 +472,13 @@ class DatasetReplicaRepository:
     ) -> Example:
         matches: list[Example] = []
         for head in self._list_heads():
-            manifest = self._resolve_manifest(head, as_of)
+            try:
+                manifest = self._resolve_manifest(head, as_of)
+            except DatasetReplicaNotFoundError:
+                # A global example ID lookup spans independent dataset histories.
+                # Absence of the requested version in one dataset says nothing
+                # about whether another dataset contains the requested example.
+                continue
             for example in self._read_examples(
                 manifest, include_attachments=include_attachments
             ):
@@ -289,7 +530,7 @@ class DatasetReplicaRepository:
     ) -> SnapshotManifestPayload:
         if as_of is None or as_of == "latest":
             selected = head["versions"][-1]
-            return self._read_manifest(selected["manifest_key"])
+            return self._read_manifest_for_head(head, selected)
 
         tag_matches: list[SnapshotManifestPayload] = []
         try:
@@ -297,7 +538,7 @@ class DatasetReplicaRepository:
         except ValueError:
             requested_time = None
         for item in reversed(head["versions"]):
-            manifest = self._read_manifest(item["manifest_key"])
+            manifest = self._read_manifest_for_head(head, item)
             tags = item["tags"]
             if tags is not None and as_of in tags:
                 tag_matches.append(manifest)
@@ -313,21 +554,36 @@ class DatasetReplicaRepository:
         raise DatasetReplicaNotFoundError(f"Dataset version not found: {as_of}")
 
     def _read_dataset_from_head(self, head: DatasetHeadPayload) -> Dataset:
-        return self._read_dataset(self._resolve_manifest(head, None))
+        dataset = self._read_dataset(self._resolve_manifest(head, None))
+        return dataset.model_copy(update={"name": head["dataset_name"]})
 
     def _read_dataset(self, manifest: SnapshotManifestPayload) -> Dataset:
         from langsmith.schemas import Dataset
 
+        _assert_sdk_contract()
         with tempfile.TemporaryDirectory(prefix="langsmith-dataset-read-") as raw:
             path = Path(raw) / "dataset.parquet"
-            self._store.get_file(manifest["dataset_key"], path)
+            self._download_verified(
+                manifest["dataset_key"], manifest["dataset_sha256"], path
+            )
             with archive_duckdb_connection() as connection:
-                row = connection.execute(
+                rows = connection.execute(
                     "SELECT payload_json FROM read_parquet(?)", [str(path)]
-                ).fetchone()
-        if row is None:
-            raise DatasetReplicaError("Dataset Parquet contains no row")
-        return Dataset(**_parse_dataset_payload(row[0]))
+                ).fetchall()
+        if len(rows) != 1:
+            raise DatasetReplicaIntegrityError(
+                f"Dataset Parquet must contain exactly one row: {manifest['dataset_key']}"
+            )
+        payload = _parse_dataset_payload(rows[0][0])
+        if payload["id"] != manifest["dataset_id"]:
+            raise DatasetReplicaIntegrityError(
+                "Dataset Parquet ID does not match its manifest dataset ID"
+            )
+        if payload["name"] != manifest["dataset_name"]:
+            raise DatasetReplicaIntegrityError(
+                "Dataset Parquet name does not match its immutable manifest"
+            )
+        return Dataset(**payload)
 
     def _read_examples(
         self,
@@ -337,9 +593,12 @@ class DatasetReplicaRepository:
     ) -> list[Example]:
         from langsmith.schemas import Example
 
+        _assert_sdk_contract()
         with tempfile.TemporaryDirectory(prefix="langsmith-examples-read-") as raw:
             path = Path(raw) / "examples.parquet"
-            self._store.get_file(manifest["examples_key"], path)
+            self._download_verified(
+                manifest["examples_key"], manifest["examples_sha256"], path
+            )
             with archive_duckdb_connection() as connection:
                 rows = connection.execute(
                     "SELECT payload_json, attachments_json "
@@ -347,9 +606,15 @@ class DatasetReplicaRepository:
                     [str(path)],
                 ).fetchall()
         result: list[Example] = []
+        attachment_count = 0
         for payload_text, attachments_text in rows:
             payload = _parse_example_payload(payload_text)
+            if payload["dataset_id"] != manifest["dataset_id"]:
+                raise DatasetReplicaIntegrityError(
+                    "Example dataset ID does not match its manifest dataset ID"
+                )
             attachments_payload = _parse_attachments(attachments_text)
+            attachment_count += len(attachments_payload)
             attachments = None
             if include_attachments and attachments_payload:
                 attachments = {
@@ -357,18 +622,58 @@ class DatasetReplicaRepository:
                         "presigned_url": self._store.object_uri(
                             f"{BLOBS_PREFIX}/{item['digest']}"
                         ),
-                        "reader": io.BytesIO(
-                            self._store.get_bytes(f"{BLOBS_PREFIX}/{item['digest']}")
-                        ),
+                        "reader": io.BytesIO(self._read_attachment(item)),
                         "mime_type": item["mime_type"],
                     }
                     for item in attachments_payload
                 }
             result.append(Example(**payload, attachments=attachments))
+        if len(result) != manifest["example_count"]:
+            raise DatasetReplicaIntegrityError(
+                "Replica example count does not match its manifest"
+            )
+        if attachment_count != manifest["attachment_count"]:
+            raise DatasetReplicaIntegrityError(
+                "Replica attachment count does not match its manifest"
+            )
         return result
+
+    def _download_verified(
+        self, key: str, expected_sha256: str, destination: Path
+    ) -> None:
+        self._store.get_file(key, destination)
+        actual_sha256 = _file_sha256(destination)
+        if actual_sha256 != expected_sha256:
+            raise DatasetReplicaIntegrityError(f"Replica object digest mismatch: {key}")
+
+    def _read_attachment(self, payload: AttachmentPayload) -> bytes:
+        key = f"{BLOBS_PREFIX}/{payload['digest']}"
+        content = self._store.get_bytes(key)
+        if (
+            len(content) != payload["size"]
+            or _bytes_sha256(content) != payload["digest"]
+        ):
+            raise DatasetReplicaIntegrityError(
+                f"Replica attachment digest mismatch: {key}"
+            )
+        return content
 
     def _read_manifest(self, key: str) -> SnapshotManifestPayload:
         return _parse_manifest(self._store.get_text(key))
+
+    def _read_manifest_for_head(
+        self, head: DatasetHeadPayload, item: HeadVersionPayload
+    ) -> SnapshotManifestPayload:
+        manifest = self._read_manifest(item["manifest_key"])
+        if manifest["dataset_id"] != head["dataset_id"]:
+            raise DatasetReplicaIntegrityError(
+                "Dataset head references a manifest with a different dataset ID"
+            )
+        if manifest["version"]["as_of"] != item["as_of"]:
+            raise DatasetReplicaIntegrityError(
+                "Dataset head version does not match its manifest version"
+            )
+        return manifest
 
     def _read_head_for_update(
         self, dataset_id: str
@@ -451,6 +756,81 @@ def _serialize_example(example: Example) -> SerializedExample:
     return SerializedExample(payload=payload, attachments=attachments, blobs=blobs)
 
 
+def _assert_sdk_contract() -> None:
+    from langsmith.schemas import (
+        Dataset,
+        DatasetTransformation,
+        DatasetVersion,
+        Example,
+    )
+
+    _assert_sdk_fields("Dataset", Dataset.model_fields, DATASET_SDK_FIELDS)
+    _assert_sdk_fields("Example", Example.model_fields, EXAMPLE_SDK_FIELDS)
+    _assert_sdk_fields(
+        "DatasetVersion", DatasetVersion.model_fields, DATASET_VERSION_SDK_FIELDS
+    )
+    transformation_fields = (
+        DatasetTransformation.__required_keys__
+        | DatasetTransformation.__optional_keys__
+    )
+    if transformation_fields != DATASET_TRANSFORMATION_SDK_FIELDS:
+        raise DatasetReplicaSchemaError(
+            "DatasetTransformation SDK fields changed; update the replica schema "
+            "explicitly"
+        )
+
+
+def _assert_sdk_fields(
+    model_name: str, model_fields: Mapping[str, object], expected: frozenset[str]
+) -> None:
+    actual = frozenset(model_fields)
+    if actual != expected:
+        added = sorted(actual - expected)
+        removed = sorted(expected - actual)
+        raise DatasetReplicaSchemaError(
+            f"{model_name} SDK fields changed; update the replica schema explicitly "
+            f"(added={added}, removed={removed})"
+        )
+
+
+def _validate_example_membership(
+    dataset_id: str, examples: list[SerializedExample]
+) -> None:
+    seen: set[str] = set()
+    for example in examples:
+        example_id = example.payload["id"]
+        if example.payload["dataset_id"] != dataset_id:
+            raise DatasetReplicaConflictError(
+                f"Example {example_id} belongs to dataset "
+                f"{example.payload['dataset_id']}, not {dataset_id}"
+            )
+        if example_id in seen:
+            raise DatasetReplicaConflictError(
+                f"Snapshot contains duplicate example ID: {example_id}"
+            )
+        seen.add(example_id)
+
+
+def _snapshot_content_digest(
+    dataset: DatasetPayload, examples: list[SerializedExample]
+) -> str:
+    # Names are mutable lookup labels. Stable Dataset ID plus the remaining
+    # strict Dataset fields and exact examples define immutable version content.
+    canonical_dataset = {key: value for key, value in dataset.items() if key != "name"}
+    canonical_examples = sorted(
+        (
+            {"payload": example.payload, "attachments": example.attachments}
+            for example in examples
+        ),
+        key=lambda item: item["payload"]["id"],
+    )
+    return _bytes_sha256(
+        _json_text(
+            {"dataset": canonical_dataset, "examples": canonical_examples}
+        ).encode("utf-8")
+    )
+
+
 def _write_dataset_parquet(path: Path, payload: DatasetPayload) -> None:
     with archive_duckdb_connection() as connection:
         connection.execute("CREATE TABLE dataset (payload_json VARCHAR NOT NULL)")
@@ -467,14 +847,23 @@ def _write_examples_parquet(path: Path, examples: list[SerializedExample]) -> No
             "id UUID NOT NULL, created_at TIMESTAMPTZ NOT NULL, "
             "payload_json VARCHAR NOT NULL, attachments_json VARCHAR NOT NULL)"
         )
-        for example in examples:
+        ordered = sorted(
+            examples,
+            key=lambda item: (item.payload["created_at"], item.payload["id"]),
+        )
+        for start in range(0, len(ordered), DUCKDB_INSERT_BATCH_SIZE):
+            batch = ordered[start : start + DUCKDB_INSERT_BATCH_SIZE]
+            # Bind one typed array per column to avoid one Python↔DuckDB call per
+            # Example while bounding each parameter batch's memory footprint.
             connection.execute(
-                "INSERT INTO examples VALUES (?, ?, ?, ?)",
+                "INSERT INTO examples SELECT "
+                "unnest(?::UUID[]), unnest(?::TIMESTAMPTZ[]), "
+                "unnest(?::VARCHAR[]), unnest(?::VARCHAR[])",
                 [
-                    example.payload["id"],
-                    example.payload["created_at"],
-                    _json_text(example.payload),
-                    _json_text(example.attachments),
+                    [example.payload["id"] for example in batch],
+                    [example.payload["created_at"] for example in batch],
+                    [_json_text(example.payload) for example in batch],
+                    [_json_text(example.attachments) for example in batch],
                 ],
             )
         connection.execute(
@@ -484,6 +873,18 @@ def _write_examples_parquet(path: Path, examples: list[SerializedExample]) -> No
 
 def _sql_literal(path: Path) -> str:
     return "'" + str(path).replace("'", "''") + "'"
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _bytes_sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
 
 
 def _json_text(payload: object) -> str:
@@ -505,28 +906,150 @@ def _load_object(text: str, kind: str) -> dict[str, Any]:
 
 def _parse_head(text: str) -> DatasetHeadPayload:
     raw = _load_object(text, "Dataset head")
+    _require_exact_keys(raw, HEAD_KEYS, "Dataset head")
     if raw["schema_version"] != REPLICA_SCHEMA_VERSION:
         raise DatasetReplicaError("Unsupported dataset replica schema")
+    _require_string(raw["dataset_id"], "Dataset head dataset_id")
+    _require_string(raw["dataset_name"], "Dataset head dataset_name")
+    latest_as_of = _require_datetime_text(
+        raw["latest_as_of"], "Dataset head latest_as_of"
+    )
+    raw_versions = raw["versions"]
+    if not isinstance(raw_versions, list) or not raw_versions:
+        raise DatasetReplicaSchemaError(
+            "Dataset head must contain at least one version"
+        )
+    parsed_versions: list[HeadVersionPayload] = []
+    version_times: list[datetime] = []
+    for raw_version in raw_versions:
+        if not isinstance(raw_version, dict):
+            raise DatasetReplicaSchemaError(
+                "Dataset head version must be a JSON object"
+            )
+        _require_exact_keys(raw_version, HEAD_VERSION_KEYS, "Dataset head version")
+        as_of = _require_datetime_text(
+            raw_version["as_of"], "Dataset head version as_of"
+        )
+        _require_string(
+            raw_version["manifest_key"], "Dataset head version manifest_key"
+        )
+        _require_tags(raw_version["tags"], "Dataset head version tags")
+        parsed_versions.append(cast(HeadVersionPayload, raw_version))
+        version_times.append(as_of)
+    if version_times != sorted(version_times) or len(set(version_times)) != len(
+        version_times
+    ):
+        raise DatasetReplicaSchemaError(
+            "Dataset head versions must be unique and sorted by as_of"
+        )
+    if latest_as_of != version_times[-1]:
+        raise DatasetReplicaSchemaError(
+            "Dataset head latest_as_of must equal its newest version"
+        )
+    raw["versions"] = parsed_versions
     return cast(DatasetHeadPayload, raw)
 
 
 def _parse_manifest(text: str) -> SnapshotManifestPayload:
     raw = _load_object(text, "Dataset manifest")
+    _require_exact_keys(raw, MANIFEST_KEYS, "Dataset manifest")
     if raw["schema_version"] != REPLICA_SCHEMA_VERSION:
         raise DatasetReplicaError("Unsupported dataset replica schema")
+    _require_string(raw["dataset_id"], "Dataset manifest dataset_id")
+    _require_string(raw["dataset_name"], "Dataset manifest dataset_name")
+    raw_version = raw["version"]
+    if not isinstance(raw_version, dict):
+        raise DatasetReplicaSchemaError("Dataset manifest version must be an object")
+    _require_exact_keys(raw_version, VERSION_KEYS, "Dataset manifest version")
+    _require_datetime_text(raw_version["as_of"], "Dataset manifest version as_of")
+    _require_tags(raw_version["tags"], "Dataset manifest version tags")
+    for field in ("dataset_key", "examples_key"):
+        _require_string(raw[field], f"Dataset manifest {field}")
+    for field in ("dataset_sha256", "examples_sha256", "content_digest"):
+        _require_sha256(raw[field], f"Dataset manifest {field}")
+    for field in ("example_count", "attachment_count"):
+        value = raw[field]
+        if type(value) is not int or value < 0:
+            raise DatasetReplicaSchemaError(
+                f"Dataset manifest {field} must be a non-negative integer"
+            )
+    _require_datetime_text(raw["published_at"], "Dataset manifest published_at")
     return cast(SnapshotManifestPayload, raw)
 
 
 def _parse_dataset_payload(text: str) -> DatasetPayload:
-    return cast(DatasetPayload, _load_object(text, "Dataset payload"))
+    raw = _load_object(text, "Dataset payload")
+    _require_exact_keys(raw, DATASET_PAYLOAD_KEYS, "Dataset payload")
+    return cast(DatasetPayload, raw)
 
 
 def _parse_example_payload(text: str) -> ExamplePayload:
-    return cast(ExamplePayload, _load_object(text, "Example payload"))
+    raw = _load_object(text, "Example payload")
+    _require_exact_keys(raw, EXAMPLE_PAYLOAD_KEYS, "Example payload")
+    return cast(ExamplePayload, raw)
 
 
 def _parse_attachments(text: str) -> list[AttachmentPayload]:
     raw = json.loads(text)
     if not isinstance(raw, list):
         raise DatasetReplicaError("Attachment payload must be a JSON array")
-    return cast(list[AttachmentPayload], raw)
+    parsed: list[AttachmentPayload] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            raise DatasetReplicaSchemaError("Attachment entry must be a JSON object")
+        _require_exact_keys(item, ATTACHMENT_KEYS, "Attachment entry")
+        _require_string(item["name"], "Attachment name")
+        mime_type = item["mime_type"]
+        if mime_type is not None:
+            _require_string(mime_type, "Attachment mime_type")
+        _require_sha256(item["digest"], "Attachment digest")
+        size = item["size"]
+        if type(size) is not int or size < 0:
+            raise DatasetReplicaSchemaError(
+                "Attachment size must be a non-negative integer"
+            )
+        parsed.append(cast(AttachmentPayload, item))
+    return parsed
+
+
+def _require_exact_keys(
+    raw: Mapping[str, object], expected: frozenset[str], kind: str
+) -> None:
+    actual = frozenset(raw)
+    if actual != expected:
+        raise DatasetReplicaSchemaError(
+            f"{kind} fields changed "
+            f"(missing={sorted(expected - actual)}, extra={sorted(actual - expected)})"
+        )
+
+
+def _require_string(value: object, kind: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise DatasetReplicaSchemaError(f"{kind} must be a non-empty string")
+    return value
+
+
+def _require_datetime_text(value: object, kind: str) -> datetime:
+    text = _require_string(value, kind)
+    try:
+        return parse_datetime(text)
+    except ValueError as exc:
+        raise DatasetReplicaSchemaError(f"{kind} must be an ISO timestamp") from exc
+
+
+def _require_tags(value: object, kind: str) -> None:
+    if value is None:
+        return
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise DatasetReplicaSchemaError(f"{kind} must be a string array or null")
+
+
+def _require_sha256(value: object, kind: str) -> str:
+    text = _require_string(value, kind)
+    if len(text) != 64:
+        raise DatasetReplicaSchemaError(f"{kind} must be a SHA-256 hex digest")
+    try:
+        int(text, 16)
+    except ValueError as exc:
+        raise DatasetReplicaSchemaError(f"{kind} must be a SHA-256 hex digest") from exc
+    return text

--- a/src/langsmith_cli/dataset_replica/repository.py
+++ b/src/langsmith_cli/dataset_replica/repository.py
@@ -7,18 +7,26 @@ from datetime import datetime, timezone
 import hashlib
 import io
 import json
+import os
 from pathlib import Path
 import tempfile
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 from uuid import uuid4
 
 from langsmith_cli.archive.duckdb import (
     ARCHIVE_PARQUET_COPY_OPTIONS,
+    DuckConnection,
     archive_duckdb_connection,
 )
 from langsmith_cli.archive.storage import ArchiveStore, ConcurrentArchiveWriteError
+from langsmith_cli.dataset_replica.contracts import (
+    ReplicaStatus,
+    ReplicaWriteResult,
+    SerializedExample,
+    StagedAttachment,
+    StagedSnapshot,
+)
 from langsmith_cli.dataset_replica.models import (
-    AttachmentBlob,
     AttachmentPayload,
     DatasetHeadPayload,
     DatasetPayload,
@@ -26,9 +34,6 @@ from langsmith_cli.dataset_replica.models import (
     ExamplePayload,
     HeadVersionPayload,
     REPLICA_SCHEMA_VERSION,
-    ReplicaStatus,
-    ReplicaWriteResult,
-    SerializedExample,
     SnapshotManifestPayload,
     VersionPayload,
     datetime_text,
@@ -47,19 +52,20 @@ if TYPE_CHECKING:
 HEADS_PREFIX = "datasets/heads"
 BLOBS_PREFIX = "datasets/blobs"
 MAX_HEAD_PUBLICATION_ATTEMPTS = 16
-DUCKDB_INSERT_BATCH_SIZE = 10_000
-HEAD_KEYS = frozenset(
-    {"schema_version", "dataset_id", "dataset_name", "latest_as_of", "versions"}
+DUCKDB_INSERT_BATCH_SIZE = 1_000
+DATASET_REPLICA_DUCKDB_MEMORY_LIMIT = "256 MiB"
+DATASET_REPLICA_DUCKDB_MEMORY_LIMIT_ENV = (
+    "LANGSMITH_DATASET_REPLICA_DUCKDB_MEMORY_LIMIT"
 )
-HEAD_VERSION_KEYS = frozenset({"as_of", "manifest_key", "tags"})
+HEAD_KEYS = frozenset(
+    {"schema_version", "dataset_id", "dataset", "latest_as_of", "versions"}
+)
+HEAD_VERSION_KEYS = frozenset({"as_of", "manifest_key", "manifest_sha256", "tags"})
 MANIFEST_KEYS = frozenset(
     {
         "schema_version",
         "dataset_id",
-        "dataset_name",
         "version",
-        "dataset_key",
-        "dataset_sha256",
         "examples_key",
         "examples_sha256",
         "content_digest",
@@ -99,6 +105,7 @@ EXAMPLE_PAYLOAD_KEYS = frozenset(
     }
 )
 ATTACHMENT_KEYS = frozenset({"name", "mime_type", "digest", "size"})
+ATTACHMENT_READ_CHUNK_SIZE = 1024 * 1024
 
 DATASET_SDK_FIELDS = frozenset(
     {
@@ -162,6 +169,14 @@ class DatasetReplicaConfigurationError(DatasetReplicaError):
     """A replica location is missing required local/archive configuration."""
 
 
+class _BinaryReader(Protocol):
+    def read(self, size: int = -1) -> bytes: ...
+
+
+class _Digest(Protocol):
+    def update(self, content: bytes, /) -> None: ...
+
+
 class DatasetReplicaRepository:
     """Read and atomically publish exact dataset versions in one object store."""
 
@@ -182,27 +197,6 @@ class DatasetReplicaRepository:
         dataset_payload = _serialize_dataset(dataset)
         version_payload = _serialize_version(version)
         dataset_id = dataset_payload["id"]
-        serialized_examples = [_serialize_example(example) for example in examples]
-        _validate_example_membership(dataset_id, serialized_examples)
-        content_digest = _snapshot_content_digest(dataset_payload, serialized_examples)
-
-        # Fast idempotence path. Content is serialized and hashed before this
-        # check: `(dataset_id, as_of)` is an immutable identity, not merely a
-        # convenient object-store prefix.
-        existing = self._publish_head(
-            dataset_payload=dataset_payload,
-            version=version,
-            version_payload=version_payload,
-            manifest_key=None,
-            content_digest=content_digest,
-            example_count=len(serialized_examples),
-            attachment_count=sum(
-                len(example.attachments) for example in serialized_examples
-            ),
-        )
-        if existing is not None:
-            return existing
-
         version_token = hashlib.sha256(
             version_payload["as_of"].encode("utf-8")
         ).hexdigest()
@@ -210,80 +204,81 @@ class DatasetReplicaRepository:
 
         with tempfile.TemporaryDirectory(prefix="langsmith-dataset-replica-") as raw:
             staging = Path(raw)
-            dataset_path = staging / "dataset.parquet"
             examples_path = staging / "examples.parquet"
-            _write_dataset_parquet(dataset_path, dataset_payload)
-            _write_examples_parquet(examples_path, serialized_examples)
-            dataset_sha256 = _file_sha256(dataset_path)
+            staged = _write_examples_parquet(
+                examples_path,
+                examples,
+                dataset_id=dataset_id,
+                attachment_directory=staging / "attachments",
+            )
+
+            # Idempotence is decided only after the streamed input has one
+            # canonical digest. Dataset catalog fields deliberately do not
+            # participate: LangSmith versions Example state, not Dataset metadata.
+            existing = self._publish_head(
+                dataset_payload=dataset_payload,
+                version=version,
+                version_payload=version_payload,
+                manifest_key=None,
+                manifest_sha256=None,
+                content_digest=staged.content_digest,
+                example_count=staged.example_count,
+                attachment_count=staged.attachment_count,
+            )
+            if existing is not None:
+                return existing
+
             examples_sha256 = _file_sha256(examples_path)
-            dataset_key = f"{version_prefix}/objects/dataset-{dataset_sha256}.parquet"
             examples_key = (
                 f"{version_prefix}/objects/examples-{examples_sha256}.parquet"
             )
             # Content-addressed objects are immutable. Reusing an existing key is
             # safe because equal SHA-256 keys imply equal publication bytes.
             self._put_file_if_absent_verified(
-                dataset_key,
-                dataset_path,
-                dataset_sha256,
-                staging / "existing-dataset.parquet",
-            )
-            self._put_file_if_absent_verified(
                 examples_key,
                 examples_path,
                 examples_sha256,
                 staging / "existing-examples.parquet",
             )
+            for digest, attachment in staged.attachments.items():
+                self._put_file_if_absent_verified(
+                    f"{BLOBS_PREFIX}/{digest}",
+                    attachment.path,
+                    digest,
+                    staging / f"existing-attachment-{digest}",
+                )
 
-        unique_blobs: dict[str, AttachmentBlob] = {}
-        for example in serialized_examples:
-            for blob in example.blobs:
-                unique_blobs[blob.payload["digest"]] = blob
-        for digest, blob in unique_blobs.items():
-            blob_key = f"{BLOBS_PREFIX}/{digest}"
-            if self._store.exists(blob_key):
-                existing_content = self._store.get_bytes(blob_key)
-                if _bytes_sha256(existing_content) != digest:
-                    raise DatasetReplicaIntegrityError(
-                        f"Replica attachment digest mismatch: {blob_key}"
-                    )
-            else:
-                self._store.put_bytes(blob_key, blob.content)
-
-        attachment_count = sum(
-            len(example.attachments) for example in serialized_examples
-        )
-        # Manifests are immutable and uniquely staged. Only the head CAS below
-        # makes one complete manifest reachable; losing writers leave harmless
-        # unreachable objects rather than mutating a winner's snapshot.
-        manifest_key = f"{version_prefix}/manifests/{uuid4().hex}.json"
-        manifest: SnapshotManifestPayload = {
-            "schema_version": REPLICA_SCHEMA_VERSION,
-            "dataset_id": dataset_id,
-            "dataset_name": dataset_payload["name"],
-            "version": version_payload,
-            "dataset_key": dataset_key,
-            "dataset_sha256": dataset_sha256,
-            "examples_key": examples_key,
-            "examples_sha256": examples_sha256,
-            "content_digest": content_digest,
-            "example_count": len(serialized_examples),
-            "attachment_count": attachment_count,
-            "published_at": datetime.now(timezone.utc).isoformat(),
-        }
-        self._store.put_text(manifest_key, _json_text(manifest))
-        result = self._publish_head(
-            dataset_payload=dataset_payload,
-            version=version,
-            version_payload=version_payload,
-            manifest_key=manifest_key,
-            content_digest=content_digest,
-            example_count=len(serialized_examples),
-            attachment_count=attachment_count,
-        )
-        if result is None:
-            raise DatasetReplicaError("Dataset head publication made no progress")
-        return result
+            # The CAS head authenticates these immutable manifest bytes. A valid
+            # Parquet object cannot be substituted into another version by editing
+            # only its manifest.
+            manifest_key = f"{version_prefix}/manifests/{uuid4().hex}.json"
+            manifest: SnapshotManifestPayload = {
+                "schema_version": REPLICA_SCHEMA_VERSION,
+                "dataset_id": dataset_id,
+                "version": version_payload,
+                "examples_key": examples_key,
+                "examples_sha256": examples_sha256,
+                "content_digest": staged.content_digest,
+                "example_count": staged.example_count,
+                "attachment_count": staged.attachment_count,
+                "published_at": datetime.now(timezone.utc).isoformat(),
+            }
+            manifest_text = _json_text(manifest)
+            manifest_sha256 = _bytes_sha256(manifest_text.encode("utf-8"))
+            self._store.put_text(manifest_key, manifest_text)
+            result = self._publish_head(
+                dataset_payload=dataset_payload,
+                version=version,
+                version_payload=version_payload,
+                manifest_key=manifest_key,
+                manifest_sha256=manifest_sha256,
+                content_digest=staged.content_digest,
+                example_count=staged.example_count,
+                attachment_count=staged.attachment_count,
+            )
+            if result is None:
+                raise DatasetReplicaError("Dataset head publication made no progress")
+            return result
 
     def _publish_head(
         self,
@@ -292,6 +287,7 @@ class DatasetReplicaRepository:
         version: DatasetVersion,
         version_payload: VersionPayload,
         manifest_key: str | None,
+        manifest_sha256: str | None,
         content_digest: str,
         example_count: int,
         attachment_count: int,
@@ -317,16 +313,21 @@ class DatasetReplicaRepository:
                         )
                     if (
                         item["tags"] != version_payload["tags"]
-                        or old_head["dataset_name"] != dataset_payload["name"]
+                        or old_head["dataset"] != dataset_payload
                     ):
-                        versions = [dict(value) for value in old_head["versions"]]
-                        for updated_item in versions:
-                            if updated_item["as_of"] == version_payload["as_of"]:
-                                updated_item["tags"] = version_payload["tags"]
+                        versions = [
+                            cast(HeadVersionPayload, dict(value))
+                            for value in old_head["versions"]
+                        ]
+                        _set_version_tags(
+                            versions,
+                            version_payload["as_of"],
+                            version_payload["tags"],
+                        )
                         updated_head: DatasetHeadPayload = {
                             **old_head,
-                            "dataset_name": dataset_payload["name"],
-                            "versions": cast(list[HeadVersionPayload], versions),
+                            "dataset": dataset_payload,
+                            "versions": versions,
                         }
                         try:
                             self._store.put_text_if_version(
@@ -348,19 +349,32 @@ class DatasetReplicaRepository:
 
             if manifest_key is None:
                 return None
-            versions = [] if old_head is None else list(old_head["versions"])
+            if manifest_sha256 is None:
+                raise DatasetReplicaError("New manifest publication requires a digest")
+            versions: list[HeadVersionPayload] = (
+                []
+                if old_head is None
+                else [
+                    cast(HeadVersionPayload, dict(value))
+                    for value in old_head["versions"]
+                ]
+            )
             versions.append(
                 HeadVersionPayload(
                     as_of=version_payload["as_of"],
                     manifest_key=manifest_key,
-                    tags=version_payload["tags"],
+                    manifest_sha256=manifest_sha256,
+                    tags=None,
                 )
+            )
+            _set_version_tags(
+                versions, version_payload["as_of"], version_payload["tags"]
             )
             versions.sort(key=lambda item: parse_datetime(item["as_of"]))
             head: DatasetHeadPayload = {
                 "schema_version": REPLICA_SCHEMA_VERSION,
                 "dataset_id": dataset_id,
-                "dataset_name": dataset_payload["name"],
+                "dataset": dataset_payload,
                 "latest_as_of": versions[-1]["as_of"],
                 "versions": versions,
             }
@@ -403,11 +417,11 @@ class DatasetReplicaRepository:
 
     def read_dataset(self, name_or_id: str, as_of: str | None = None) -> Dataset:
         head = self._resolve_head(name_or_id)
-        manifest = self._resolve_manifest(head, as_of)
-        dataset = self._read_dataset(manifest)
-        # Dataset names are mutable lookup labels in LangSmith, not replica
-        # identities. The head carries the newest label for every exact version.
-        return dataset.model_copy(update={"name": head["dataset_name"]})
+        # Dataset metadata is mutable catalog state in LangSmith. `as_of` selects
+        # and validates Example-version availability but never invents historical
+        # Dataset-envelope semantics that the cloud API does not provide.
+        self._resolve_manifest(head, as_of)
+        return self._read_dataset_from_head(head)
 
     def list_versions(self, name_or_id: str) -> list[DatasetVersion]:
         from langsmith.schemas import DatasetVersion
@@ -425,7 +439,10 @@ class DatasetReplicaRepository:
         self, dataset_id: str, versions: Iterable[DatasetVersion]
     ) -> None:
         """Refresh mutable tag pointers without rewriting immutable snapshots."""
-        tags_by_time = {version.as_of.isoformat(): version.tags for version in versions}
+        tags_by_time = {
+            _datetime_text_required(version.as_of): version.tags for version in versions
+        }
+        _validate_unique_tag_mapping(tags_by_time)
         for _attempt in range(MAX_HEAD_PUBLICATION_ATTEMPTS):
             head, expected_version = self._read_head_for_update(dataset_id)
             if head is None:
@@ -435,6 +452,20 @@ class DatasetReplicaRepository:
                 as_of = item["as_of"]
                 if as_of in tags_by_time and item["tags"] != tags_by_time[as_of]:
                     item["tags"] = tags_by_time[as_of]
+                    changed = True
+            source_tags = {
+                tag
+                for tags in tags_by_time.values()
+                if tags is not None
+                for tag in tags
+            }
+            for item in head["versions"]:
+                if item["as_of"] in tags_by_time or item["tags"] is None:
+                    continue
+                retained = [tag for tag in item["tags"] if tag not in source_tags]
+                next_tags = retained or None
+                if next_tags != item["tags"]:
+                    item["tags"] = next_tags
                     changed = True
             if not changed:
                 return
@@ -459,9 +490,25 @@ class DatasetReplicaRepository:
         as_of: str | None = None,
         include_attachments: bool = False,
     ) -> list[Example]:
+        return list(
+            self.iter_examples(
+                name_or_id,
+                as_of=as_of,
+                include_attachments=include_attachments,
+            )
+        )
+
+    def iter_examples(
+        self,
+        name_or_id: str,
+        *,
+        as_of: str | None = None,
+        include_attachments: bool = False,
+    ) -> Iterable[Example]:
+        """Validate one immutable snapshot, then stream its SDK Examples."""
         head = self._resolve_head(name_or_id)
         manifest = self._resolve_manifest(head, as_of)
-        return self._read_examples(manifest, include_attachments=include_attachments)
+        return self._iter_examples(manifest, include_attachments=include_attachments)
 
     def read_example(
         self,
@@ -479,7 +526,7 @@ class DatasetReplicaRepository:
                 # Absence of the requested version in one dataset says nothing
                 # about whether another dataset contains the requested example.
                 continue
-            for example in self._read_examples(
+            for example in self._iter_examples(
                 manifest, include_attachments=include_attachments
             ):
                 if str(example.id) == example_id:
@@ -496,7 +543,7 @@ class DatasetReplicaRepository:
         return [
             ReplicaStatus(
                 dataset_id=head["dataset_id"],
-                dataset_name=head["dataset_name"],
+                dataset_name=head["dataset"]["name"],
                 latest_as_of=parse_datetime(head["latest_as_of"]),
                 versions=len(head["versions"]),
                 source_uri=self.base_uri,
@@ -515,7 +562,7 @@ class DatasetReplicaRepository:
         heads = [
             head
             for head in self._list_heads()
-            if head["dataset_id"] == name_or_id or head["dataset_name"] == name_or_id
+            if head["dataset_id"] == name_or_id or head["dataset"]["name"] == name_or_id
         ]
         if not heads:
             raise DatasetReplicaNotFoundError(f"Dataset not found: {name_or_id}")
@@ -554,43 +601,17 @@ class DatasetReplicaRepository:
         raise DatasetReplicaNotFoundError(f"Dataset version not found: {as_of}")
 
     def _read_dataset_from_head(self, head: DatasetHeadPayload) -> Dataset:
-        dataset = self._read_dataset(self._resolve_manifest(head, None))
-        return dataset.model_copy(update={"name": head["dataset_name"]})
-
-    def _read_dataset(self, manifest: SnapshotManifestPayload) -> Dataset:
         from langsmith.schemas import Dataset
 
         _assert_sdk_contract()
-        with tempfile.TemporaryDirectory(prefix="langsmith-dataset-read-") as raw:
-            path = Path(raw) / "dataset.parquet"
-            self._download_verified(
-                manifest["dataset_key"], manifest["dataset_sha256"], path
-            )
-            with archive_duckdb_connection() as connection:
-                rows = connection.execute(
-                    "SELECT payload_json FROM read_parquet(?)", [str(path)]
-                ).fetchall()
-        if len(rows) != 1:
-            raise DatasetReplicaIntegrityError(
-                f"Dataset Parquet must contain exactly one row: {manifest['dataset_key']}"
-            )
-        payload = _parse_dataset_payload(rows[0][0])
-        if payload["id"] != manifest["dataset_id"]:
-            raise DatasetReplicaIntegrityError(
-                "Dataset Parquet ID does not match its manifest dataset ID"
-            )
-        if payload["name"] != manifest["dataset_name"]:
-            raise DatasetReplicaIntegrityError(
-                "Dataset Parquet name does not match its immutable manifest"
-            )
-        return Dataset(**payload)
+        return Dataset(**head["dataset"])
 
-    def _read_examples(
+    def _iter_examples(
         self,
         manifest: SnapshotManifestPayload,
         *,
         include_attachments: bool,
-    ) -> list[Example]:
+    ) -> Iterable[Example]:
         from langsmith.schemas import Example
 
         _assert_sdk_contract()
@@ -600,43 +621,28 @@ class DatasetReplicaRepository:
                 manifest["examples_key"], manifest["examples_sha256"], path
             )
             with archive_duckdb_connection() as connection:
-                rows = connection.execute(
+                _validate_examples_relation(connection, path, manifest)
+                cursor = connection.execute(
                     "SELECT payload_json, attachments_json "
                     "FROM read_parquet(?) ORDER BY created_at, id",
                     [str(path)],
-                ).fetchall()
-        result: list[Example] = []
-        attachment_count = 0
-        for payload_text, attachments_text in rows:
-            payload = _parse_example_payload(payload_text)
-            if payload["dataset_id"] != manifest["dataset_id"]:
-                raise DatasetReplicaIntegrityError(
-                    "Example dataset ID does not match its manifest dataset ID"
                 )
-            attachments_payload = _parse_attachments(attachments_text)
-            attachment_count += len(attachments_payload)
-            attachments = None
-            if include_attachments and attachments_payload:
-                attachments = {
-                    item["name"]: {
-                        "presigned_url": self._store.object_uri(
-                            f"{BLOBS_PREFIX}/{item['digest']}"
-                        ),
-                        "reader": io.BytesIO(self._read_attachment(item)),
-                        "mime_type": item["mime_type"],
-                    }
-                    for item in attachments_payload
-                }
-            result.append(Example(**payload, attachments=attachments))
-        if len(result) != manifest["example_count"]:
-            raise DatasetReplicaIntegrityError(
-                "Replica example count does not match its manifest"
-            )
-        if attachment_count != manifest["attachment_count"]:
-            raise DatasetReplicaIntegrityError(
-                "Replica attachment count does not match its manifest"
-            )
-        return result
+                for payload_text, attachments_text in _fetch_example_rows(cursor):
+                    payload = _parse_example_payload(payload_text)
+                    attachments_payload = _parse_attachments(attachments_text)
+                    attachments = None
+                    if include_attachments and attachments_payload:
+                        attachments = {
+                            attachment["name"]: {
+                                "presigned_url": self._store.object_uri(
+                                    f"{BLOBS_PREFIX}/{attachment['digest']}"
+                                ),
+                                "reader": io.BytesIO(self._read_attachment(attachment)),
+                                "mime_type": attachment["mime_type"],
+                            }
+                            for attachment in attachments_payload
+                        }
+                    yield Example(**payload, attachments=attachments)
 
     def _download_verified(
         self, key: str, expected_sha256: str, destination: Path
@@ -658,13 +664,15 @@ class DatasetReplicaRepository:
             )
         return content
 
-    def _read_manifest(self, key: str) -> SnapshotManifestPayload:
-        return _parse_manifest(self._store.get_text(key))
-
     def _read_manifest_for_head(
         self, head: DatasetHeadPayload, item: HeadVersionPayload
     ) -> SnapshotManifestPayload:
-        manifest = self._read_manifest(item["manifest_key"])
+        manifest_text = self._store.get_text(item["manifest_key"])
+        if _bytes_sha256(manifest_text.encode("utf-8")) != item["manifest_sha256"]:
+            raise DatasetReplicaIntegrityError(
+                f"Replica manifest digest mismatch: {item['manifest_key']}"
+            )
+        manifest = _parse_manifest(manifest_text)
         if manifest["dataset_id"] != head["dataset_id"]:
             raise DatasetReplicaIntegrityError(
                 "Dataset head references a manifest with a different dataset ID"
@@ -697,7 +705,7 @@ def _serialize_dataset(dataset: Dataset) -> DatasetPayload:
         "description": dataset.description,
         "data_type": data_type,
         "id": str(dataset.id),
-        "created_at": dataset.created_at.isoformat(),
+        "created_at": _datetime_text_required(dataset.created_at),
         "modified_at": datetime_text(dataset.modified_at),
         "example_count": dataset.example_count,
         "session_count": dataset.session_count,
@@ -721,39 +729,80 @@ def _serialize_transformation(
 
 
 def _serialize_version(version: DatasetVersion) -> VersionPayload:
-    return {"tags": version.tags, "as_of": version.as_of.isoformat()}
+    return {"tags": version.tags, "as_of": _datetime_text_required(version.as_of)}
 
 
-def _serialize_example(example: Example) -> SerializedExample:
+def _serialize_example(
+    example: Example,
+    attachment_directory: Path,
+) -> tuple[SerializedExample, dict[str, StagedAttachment]]:
     payload: ExamplePayload = {
         "id": str(example.id),
         "dataset_id": str(example.dataset_id),
         "inputs": example.inputs,
         "outputs": example.outputs,
         "metadata": example.metadata,
-        "created_at": example.created_at.isoformat(),
+        "created_at": _datetime_text_required(example.created_at),
         "modified_at": datetime_text(example.modified_at),
         "source_run_id": (
             str(example.source_run_id) if example.source_run_id is not None else None
         ),
     }
     attachments: list[AttachmentPayload] = []
-    blobs: list[AttachmentBlob] = []
+    blobs: dict[str, StagedAttachment] = {}
     if example.attachments is not None:
         for name, attachment in sorted(example.attachments.items()):
-            content = attachment["reader"].read()
-            if not isinstance(content, bytes):
-                raise DatasetReplicaError("Attachment reader must return bytes")
-            digest = hashlib.sha256(content).hexdigest()
+            digest, size, path = _stage_attachment(
+                cast(_BinaryReader, attachment["reader"]), attachment_directory
+            )
             attachment_payload: AttachmentPayload = {
                 "name": name,
                 "mime_type": attachment["mime_type"],
                 "digest": digest,
-                "size": len(content),
+                "size": size,
             }
             attachments.append(attachment_payload)
-            blobs.append(AttachmentBlob(payload=attachment_payload, content=content))
-    return SerializedExample(payload=payload, attachments=attachments, blobs=blobs)
+            blobs[digest] = StagedAttachment(
+                path=path,
+            )
+    return SerializedExample(payload=payload, attachments=attachments), blobs
+
+
+def _stage_attachment(reader: _BinaryReader, directory: Path) -> tuple[str, int, Path]:
+    """Spool one attachment with RAM bounded by the fixed read chunk."""
+    directory.mkdir(parents=True, exist_ok=True)
+    temporary_path: Path | None = None
+    digest = hashlib.sha256()
+    size = 0
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w+b",
+            dir=directory,
+            prefix="attachment-",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            temporary_path = Path(temporary.name)
+            while True:
+                chunk = reader.read(ATTACHMENT_READ_CHUNK_SIZE)
+                if not isinstance(chunk, bytes):
+                    raise DatasetReplicaError("Attachment reader must return bytes")
+                if not chunk:
+                    break
+                temporary.write(chunk)
+                digest.update(chunk)
+                size += len(chunk)
+        digest_text = digest.hexdigest()
+        final_path = directory / digest_text
+        if final_path.exists():
+            temporary_path.unlink()
+        else:
+            os.replace(temporary_path, final_path)
+        temporary_path = None
+        return digest_text, size, final_path
+    finally:
+        if temporary_path is not None and temporary_path.exists():
+            temporary_path.unlink()
 
 
 def _assert_sdk_contract() -> None:
@@ -793,82 +842,210 @@ def _assert_sdk_fields(
         )
 
 
-def _validate_example_membership(
-    dataset_id: str, examples: list[SerializedExample]
-) -> None:
-    seen: set[str] = set()
-    for example in examples:
-        example_id = example.payload["id"]
-        if example.payload["dataset_id"] != dataset_id:
-            raise DatasetReplicaConflictError(
-                f"Example {example_id} belongs to dataset "
-                f"{example.payload['dataset_id']}, not {dataset_id}"
-            )
-        if example_id in seen:
-            raise DatasetReplicaConflictError(
-                f"Snapshot contains duplicate example ID: {example_id}"
-            )
-        seen.add(example_id)
-
-
-def _snapshot_content_digest(
-    dataset: DatasetPayload, examples: list[SerializedExample]
-) -> str:
-    # Names are mutable lookup labels. Stable Dataset ID plus the remaining
-    # strict Dataset fields and exact examples define immutable version content.
-    canonical_dataset = {key: value for key, value in dataset.items() if key != "name"}
-    canonical_examples = sorted(
-        (
-            {"payload": example.payload, "attachments": example.attachments}
-            for example in examples
-        ),
-        key=lambda item: item["payload"]["id"],
-    )
-    return _bytes_sha256(
-        _json_text(
-            {"dataset": canonical_dataset, "examples": canonical_examples}
-        ).encode("utf-8")
-    )
-
-
-def _write_dataset_parquet(path: Path, payload: DatasetPayload) -> None:
-    with archive_duckdb_connection() as connection:
-        connection.execute("CREATE TABLE dataset (payload_json VARCHAR NOT NULL)")
-        connection.execute("INSERT INTO dataset VALUES (?)", [_json_text(payload)])
+def _write_examples_parquet(
+    path: Path,
+    examples: Iterable[Example],
+    *,
+    dataset_id: str,
+    attachment_directory: Path,
+) -> StagedSnapshot:
+    with archive_duckdb_connection(
+        path.parent,
+        database_path=path.parent / "dataset-replica.duckdb",
+    ) as connection:
+        # Dataset ingestion is a streaming CLI workload, not the wide trace
+        # canonicalization workload that needs the archive-wide 1 GiB default.
+        # A smaller, independently configurable cap keeps local pulls practical.
         connection.execute(
-            f"COPY dataset TO {_sql_literal(path)} " + ARCHIVE_PARQUET_COPY_OPTIONS
+            "SET memory_limit = ?", [_dataset_replica_duckdb_memory_limit()]
         )
-
-
-def _write_examples_parquet(path: Path, examples: list[SerializedExample]) -> None:
-    with archive_duckdb_connection() as connection:
         connection.execute(
             "CREATE TABLE examples ("
-            "id UUID NOT NULL, created_at TIMESTAMPTZ NOT NULL, "
+            "id UUID PRIMARY KEY, created_at TIMESTAMPTZ NOT NULL, "
             "payload_json VARCHAR NOT NULL, attachments_json VARCHAR NOT NULL)"
         )
-        ordered = sorted(
-            examples,
-            key=lambda item: (item.payload["created_at"], item.payload["id"]),
-        )
-        for start in range(0, len(ordered), DUCKDB_INSERT_BATCH_SIZE):
-            batch = ordered[start : start + DUCKDB_INSERT_BATCH_SIZE]
-            # Bind one typed array per column to avoid one Python↔DuckDB call per
-            # Example while bounding each parameter batch's memory footprint.
-            connection.execute(
-                "INSERT INTO examples SELECT "
-                "unnest(?::UUID[]), unnest(?::TIMESTAMPTZ[]), "
-                "unnest(?::VARCHAR[]), unnest(?::VARCHAR[])",
-                [
-                    [example.payload["id"] for example in batch],
-                    [example.payload["created_at"] for example in batch],
-                    [_json_text(example.payload) for example in batch],
-                    [_json_text(example.attachments) for example in batch],
-                ],
+        batch: list[SerializedExample] = []
+        attachments: dict[str, StagedAttachment] = {}
+        example_count = 0
+        attachment_count = 0
+        for example in examples:
+            serialized, staged_attachments = _serialize_example(
+                example, attachment_directory
             )
+            example_id = serialized.payload["id"]
+            if serialized.payload["dataset_id"] != dataset_id:
+                raise DatasetReplicaConflictError(
+                    f"Example {example_id} belongs to dataset "
+                    f"{serialized.payload['dataset_id']}, not {dataset_id}"
+                )
+            batch.append(serialized)
+            attachments.update(staged_attachments)
+            example_count += 1
+            attachment_count += len(serialized.attachments)
+            if len(batch) == DUCKDB_INSERT_BATCH_SIZE:
+                _insert_example_batch(connection, batch)
+                batch.clear()
+        if batch:
+            _insert_example_batch(connection, batch)
         connection.execute(
             f"COPY examples TO {_sql_literal(path)} " + ARCHIVE_PARQUET_COPY_OPTIONS
         )
+        cursor = connection.execute(
+            "SELECT payload_json, attachments_json FROM examples ORDER BY id"
+        )
+        content_digest = _snapshot_content_digest_from_rows(
+            dataset_id, _fetch_example_rows(cursor)
+        )
+    return StagedSnapshot(
+        example_count=example_count,
+        attachment_count=attachment_count,
+        content_digest=content_digest,
+        attachments=attachments,
+    )
+
+
+def _insert_example_batch(
+    connection: DuckConnection, batch: list[SerializedExample]
+) -> None:
+    from duckdb import ConstraintException
+
+    try:
+        connection.execute(
+            "INSERT INTO examples SELECT "
+            "unnest(?::UUID[]), unnest(?::TIMESTAMPTZ[]), "
+            "unnest(?::VARCHAR[]), unnest(?::VARCHAR[])",
+            [
+                [example.payload["id"] for example in batch],
+                [example.payload["created_at"] for example in batch],
+                [_json_text(example.payload) for example in batch],
+                [_json_text(example.attachments) for example in batch],
+            ],
+        )
+    except ConstraintException as exc:
+        raise DatasetReplicaConflictError(
+            "Snapshot contains duplicate example ID"
+        ) from exc
+
+
+def _fetch_example_rows(cursor: DuckConnection) -> Iterable[tuple[str, str]]:
+    while rows := cursor.fetchmany(DUCKDB_INSERT_BATCH_SIZE):
+        yield from cast(list[tuple[str, str]], rows)
+
+
+def _validate_examples_relation(
+    connection: DuckConnection,
+    path: Path,
+    manifest: SnapshotManifestPayload,
+) -> None:
+    """Validate all version invariants before yielding any SDK Example."""
+    cursor = connection.execute(
+        "SELECT payload_json, attachments_json FROM read_parquet(?) ORDER BY id",
+        [str(path)],
+    )
+    digest = hashlib.sha256()
+    _update_digest_part(digest, manifest["dataset_id"])
+    example_count = 0
+    attachment_count = 0
+    previous_id: str | None = None
+    for payload_text, attachments_text in _fetch_example_rows(cursor):
+        payload = _parse_example_payload(payload_text)
+        if payload["dataset_id"] != manifest["dataset_id"]:
+            raise DatasetReplicaIntegrityError(
+                "Example dataset ID does not match its manifest dataset ID"
+            )
+        if payload["id"] == previous_id:
+            raise DatasetReplicaIntegrityError(
+                f"Replica contains duplicate example ID: {payload['id']}"
+            )
+        previous_id = payload["id"]
+        attachments = _parse_attachments(attachments_text)
+        _update_digest_part(digest, _json_text(payload))
+        _update_digest_part(digest, _json_text(attachments))
+        example_count += 1
+        attachment_count += len(attachments)
+    if example_count != manifest["example_count"]:
+        raise DatasetReplicaIntegrityError(
+            "Replica example count does not match its manifest"
+        )
+    if attachment_count != manifest["attachment_count"]:
+        raise DatasetReplicaIntegrityError(
+            "Replica attachment count does not match its manifest"
+        )
+    if digest.hexdigest() != manifest["content_digest"]:
+        raise DatasetReplicaIntegrityError(
+            "Replica canonical content digest does not match its manifest"
+        )
+
+
+def _snapshot_content_digest_from_rows(
+    dataset_id: str, rows: Iterable[tuple[str, str]]
+) -> str:
+    digest = hashlib.sha256()
+    _update_digest_part(digest, dataset_id)
+    for payload_text, attachments_text in rows:
+        _update_digest_part(digest, payload_text)
+        _update_digest_part(digest, attachments_text)
+    return digest.hexdigest()
+
+
+def _update_digest_part(digest: _Digest, value: str) -> None:
+    encoded = value.encode("utf-8")
+    digest.update(len(encoded).to_bytes(8, "big"))
+    digest.update(encoded)
+
+
+def _datetime_text_required(value: datetime) -> str:
+    text = datetime_text(value)
+    if text is None:
+        raise ValueError("Replica timestamp is required")
+    return text
+
+
+def _dataset_replica_duckdb_memory_limit() -> str:
+    if DATASET_REPLICA_DUCKDB_MEMORY_LIMIT_ENV in os.environ:
+        configured = os.environ[DATASET_REPLICA_DUCKDB_MEMORY_LIMIT_ENV].strip()
+        if configured:
+            return configured
+    return DATASET_REPLICA_DUCKDB_MEMORY_LIMIT
+
+
+def _set_version_tags(
+    versions: list[HeadVersionPayload],
+    selected_as_of: str,
+    tags: list[str] | None,
+) -> None:
+    """Move incoming tag pointers atomically within one candidate head.
+
+    INVARIANT: each LangSmith tag resolves to at most one exact version. The
+    candidate head is still private here; the enclosing CAS publishes the tag
+    moves and version append as one metadata transition.
+    """
+    if tags is not None and len(tags) != len(set(tags)):
+        raise DatasetReplicaConflictError(
+            "Dataset version tags must not contain duplicates"
+        )
+    normalized_tags = None if not tags else list(tags)
+    incoming = set(normalized_tags or [])
+    for item in versions:
+        current = item["tags"] or []
+        if item["as_of"] == selected_as_of:
+            item["tags"] = normalized_tags
+            continue
+        retained = [tag for tag in current if tag not in incoming]
+        item["tags"] = retained or None
+
+
+def _validate_unique_tag_mapping(
+    tags_by_time: Mapping[str, list[str] | None],
+) -> None:
+    owner_by_tag: dict[str, str] = {}
+    for as_of, tags in tags_by_time.items():
+        for tag in tags or []:
+            if tag in owner_by_tag and owner_by_tag[tag] != as_of:
+                raise DatasetReplicaConflictError(
+                    f"Dataset version tag resolves to multiple versions: {tag}"
+                )
+            owner_by_tag[tag] = as_of
 
 
 def _sql_literal(path: Path) -> str:
@@ -909,8 +1086,15 @@ def _parse_head(text: str) -> DatasetHeadPayload:
     _require_exact_keys(raw, HEAD_KEYS, "Dataset head")
     if raw["schema_version"] != REPLICA_SCHEMA_VERSION:
         raise DatasetReplicaError("Unsupported dataset replica schema")
-    _require_string(raw["dataset_id"], "Dataset head dataset_id")
-    _require_string(raw["dataset_name"], "Dataset head dataset_name")
+    dataset_id = _require_string(raw["dataset_id"], "Dataset head dataset_id")
+    raw_dataset = raw["dataset"]
+    if not isinstance(raw_dataset, dict):
+        raise DatasetReplicaSchemaError("Dataset head dataset must be a JSON object")
+    dataset = _parse_dataset_payload_object(raw_dataset)
+    if dataset["id"] != dataset_id:
+        raise DatasetReplicaIntegrityError(
+            "Dataset head payload ID does not match its catalog identity"
+        )
     latest_as_of = _require_datetime_text(
         raw["latest_as_of"], "Dataset head latest_as_of"
     )
@@ -933,6 +1117,10 @@ def _parse_head(text: str) -> DatasetHeadPayload:
         _require_string(
             raw_version["manifest_key"], "Dataset head version manifest_key"
         )
+        _require_sha256(
+            raw_version["manifest_sha256"],
+            "Dataset head version manifest_sha256",
+        )
         _require_tags(raw_version["tags"], "Dataset head version tags")
         parsed_versions.append(cast(HeadVersionPayload, raw_version))
         version_times.append(as_of)
@@ -946,6 +1134,13 @@ def _parse_head(text: str) -> DatasetHeadPayload:
         raise DatasetReplicaSchemaError(
             "Dataset head latest_as_of must equal its newest version"
         )
+    try:
+        _validate_unique_tag_mapping(
+            {item["as_of"]: item["tags"] for item in parsed_versions}
+        )
+    except DatasetReplicaConflictError as exc:
+        raise DatasetReplicaSchemaError(str(exc)) from exc
+    raw["dataset"] = dataset
     raw["versions"] = parsed_versions
     return cast(DatasetHeadPayload, raw)
 
@@ -956,16 +1151,15 @@ def _parse_manifest(text: str) -> SnapshotManifestPayload:
     if raw["schema_version"] != REPLICA_SCHEMA_VERSION:
         raise DatasetReplicaError("Unsupported dataset replica schema")
     _require_string(raw["dataset_id"], "Dataset manifest dataset_id")
-    _require_string(raw["dataset_name"], "Dataset manifest dataset_name")
     raw_version = raw["version"]
     if not isinstance(raw_version, dict):
         raise DatasetReplicaSchemaError("Dataset manifest version must be an object")
     _require_exact_keys(raw_version, VERSION_KEYS, "Dataset manifest version")
     _require_datetime_text(raw_version["as_of"], "Dataset manifest version as_of")
     _require_tags(raw_version["tags"], "Dataset manifest version tags")
-    for field in ("dataset_key", "examples_key"):
+    for field in ("examples_key",):
         _require_string(raw[field], f"Dataset manifest {field}")
-    for field in ("dataset_sha256", "examples_sha256", "content_digest"):
+    for field in ("examples_sha256", "content_digest"):
         _require_sha256(raw[field], f"Dataset manifest {field}")
     for field in ("example_count", "attachment_count"):
         value = raw[field]
@@ -977,9 +1171,10 @@ def _parse_manifest(text: str) -> SnapshotManifestPayload:
     return cast(SnapshotManifestPayload, raw)
 
 
-def _parse_dataset_payload(text: str) -> DatasetPayload:
-    raw = _load_object(text, "Dataset payload")
+def _parse_dataset_payload_object(raw: dict[str, Any]) -> DatasetPayload:
     _require_exact_keys(raw, DATASET_PAYLOAD_KEYS, "Dataset payload")
+    _require_string(raw["id"], "Dataset payload id")
+    _require_string(raw["name"], "Dataset payload name")
     return cast(DatasetPayload, raw)
 
 
@@ -1032,9 +1227,14 @@ def _require_string(value: object, kind: str) -> str:
 def _require_datetime_text(value: object, kind: str) -> datetime:
     text = _require_string(value, kind)
     try:
-        return parse_datetime(text)
+        parsed = parse_datetime(text)
     except ValueError as exc:
-        raise DatasetReplicaSchemaError(f"{kind} must be an ISO timestamp") from exc
+        raise DatasetReplicaSchemaError(
+            f"{kind} must be a timezone-aware ISO timestamp"
+        ) from exc
+    if text != parsed.isoformat():
+        raise DatasetReplicaSchemaError(f"{kind} must use canonical UTC spelling")
+    return parsed
 
 
 def _require_tags(value: object, kind: str) -> None:
@@ -1042,6 +1242,8 @@ def _require_tags(value: object, kind: str) -> None:
         return
     if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
         raise DatasetReplicaSchemaError(f"{kind} must be a string array or null")
+    if len(value) != len(set(value)):
+        raise DatasetReplicaSchemaError(f"{kind} must not contain duplicate tags")
 
 
 def _require_sha256(value: object, kind: str) -> str:

--- a/src/langsmith_cli/dataset_replica/repository.py
+++ b/src/langsmith_cli/dataset_replica/repository.py
@@ -575,30 +575,29 @@ class DatasetReplicaRepository:
     def _resolve_manifest(
         self, head: DatasetHeadPayload, as_of: str | None
     ) -> SnapshotManifestPayload:
-        if as_of is None or as_of == "latest":
-            selected = head["versions"][-1]
-            return self._read_manifest_for_head(head, selected)
+        from langsmith_cli.dataset_replica.versioning import (
+            NoVersionsError,
+            SelectableVersion,
+            VersionAmbiguousError,
+            VersionNotFoundError,
+            select_version,
+        )
 
-        tag_matches: list[SnapshotManifestPayload] = []
+        selectable = [
+            SelectableVersion(
+                position=position,
+                as_of=parse_datetime(item["as_of"]),
+                tags=tuple(item["tags"] or ()),
+            )
+            for position, item in enumerate(head["versions"])
+        ]
         try:
-            requested_time = parse_datetime(as_of)
-        except ValueError:
-            requested_time = None
-        for item in reversed(head["versions"]):
-            manifest = self._read_manifest_for_head(head, item)
-            tags = item["tags"]
-            if tags is not None and as_of in tags:
-                tag_matches.append(manifest)
-            if (
-                requested_time is not None
-                and parse_datetime(item["as_of"]) <= requested_time
-            ):
-                return manifest
-        if len(tag_matches) == 1:
-            return tag_matches[0]
-        if len(tag_matches) > 1:
-            raise DatasetReplicaAmbiguousError(f"Version tag is ambiguous: {as_of}")
-        raise DatasetReplicaNotFoundError(f"Dataset version not found: {as_of}")
+            selected = select_version(selectable, as_of)
+        except VersionAmbiguousError as exc:
+            raise DatasetReplicaAmbiguousError(str(exc)) from exc
+        except (NoVersionsError, VersionNotFoundError) as exc:
+            raise DatasetReplicaNotFoundError(str(exc)) from exc
+        return self._read_manifest_for_head(head, head["versions"][selected.position])
 
     def _read_dataset_from_head(self, head: DatasetHeadPayload) -> Dataset:
         from langsmith.schemas import Dataset

--- a/src/langsmith_cli/dataset_replica/service.py
+++ b/src/langsmith_cli/dataset_replica/service.py
@@ -1,0 +1,176 @@
+"""Pure orchestration for cloud, archive, and local dataset replication."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, TypedDict
+
+from langsmith_cli.archive.storage import create_store
+from langsmith_cli.dataset_replica.models import (
+    ReplicaDestination,
+    ReplicaSource,
+    ReplicaWriteResult,
+)
+from langsmith_cli.dataset_replica.repository import DatasetReplicaRepository
+
+if TYPE_CHECKING:
+    from langsmith import Client
+    from langsmith.schemas import DatasetVersion
+
+
+class ReplicaWritePayload(TypedDict):
+    dataset_id: str
+    dataset_name: str
+    as_of: str
+    example_count: int
+    attachment_count: int
+    already_present: bool
+    destination: str
+
+
+def default_local_dataset_directory() -> Path:
+    from platformdirs import user_cache_dir
+
+    return Path(user_cache_dir("langsmith-cli", appauthor=False)) / "datasets"
+
+
+def repository_for(
+    source: ReplicaSource | ReplicaDestination,
+    *,
+    archive_uri: str | None,
+    local_directory: str | None,
+) -> DatasetReplicaRepository:
+    if source in (ReplicaSource.LOCAL, ReplicaDestination.LOCAL):
+        uri = local_directory or str(default_local_dataset_directory())
+    else:
+        uri = archive_uri or os.environ["LANGSMITH_ARCHIVE_URI"]
+    return DatasetReplicaRepository(create_store(uri))
+
+
+def pull_dataset(
+    *,
+    client: Client | None,
+    dataset_name_or_id: str,
+    source: ReplicaSource,
+    destination: ReplicaDestination,
+    as_of: str,
+    all_versions: bool,
+    archive_uri: str | None,
+    local_directory: str | None,
+) -> list[ReplicaWriteResult]:
+    if source.value == destination.value:
+        raise ValueError("Dataset source and destination must differ")
+    target = repository_for(
+        destination,
+        archive_uri=archive_uri,
+        local_directory=local_directory,
+    )
+    if source is ReplicaSource.CLOUD:
+        if client is None:
+            raise ValueError("Cloud replication requires a LangSmith client")
+        return _pull_from_cloud(
+            client=client,
+            target=target,
+            dataset_name_or_id=dataset_name_or_id,
+            as_of=as_of,
+            all_versions=all_versions,
+        )
+    source_repository = repository_for(
+        source,
+        archive_uri=archive_uri,
+        local_directory=local_directory,
+    )
+    versions = source_repository.list_versions(dataset_name_or_id)
+    selected = versions if all_versions else [_select_version(versions, as_of)]
+    results: list[ReplicaWriteResult] = []
+    for version in reversed(selected):
+        version_text = version.as_of.isoformat()
+        dataset = source_repository.read_dataset(dataset_name_or_id, version_text)
+        examples = source_repository.read_examples(
+            dataset_name_or_id,
+            as_of=version_text,
+            include_attachments=True,
+        )
+        results.append(target.write_snapshot(dataset, version, examples))
+    return results
+
+
+def write_result_payload(result: ReplicaWriteResult) -> ReplicaWritePayload:
+    return {
+        "dataset_id": result.dataset_id,
+        "dataset_name": result.dataset_name,
+        "as_of": result.as_of.isoformat(),
+        "example_count": result.example_count,
+        "attachment_count": result.attachment_count,
+        "already_present": result.already_present,
+        "destination": result.destination_uri,
+    }
+
+
+def resolve_cloud_version(
+    client: Client, dataset_id: str, requested: str
+) -> DatasetVersion:
+    try:
+        requested_time = datetime.fromisoformat(requested.replace("Z", "+00:00"))
+    except ValueError:
+        return client.read_dataset_version(dataset_id=dataset_id, tag=requested)
+    return client.read_dataset_version(dataset_id=dataset_id, as_of=requested_time)
+
+
+def _pull_from_cloud(
+    *,
+    client: Client,
+    target: DatasetReplicaRepository,
+    dataset_name_or_id: str,
+    as_of: str,
+    all_versions: bool,
+) -> list[ReplicaWriteResult]:
+    from langsmith_cli.commands.datasets import resolve_dataset
+
+    dataset = resolve_dataset(client, dataset_name_or_id)
+    available_versions = list(client.list_dataset_versions(dataset_id=dataset.id))
+    versions = (
+        available_versions
+        if all_versions
+        else [resolve_cloud_version(client, str(dataset.id), as_of)]
+    )
+    versions.sort(key=lambda item: item.as_of)
+    results: list[ReplicaWriteResult] = []
+    for version in versions:
+        # INVARIANT: every page is read against one server-resolved exact version.
+        # Without this bound, concurrent cloud edits could create a mixed snapshot.
+        examples = list(
+            client.list_examples(
+                dataset_id=dataset.id,
+                as_of=version.as_of,
+                include_attachments=True,
+                inline_s3_urls=False,
+            )
+        )
+        results.append(target.write_snapshot(dataset, version, examples))
+    target.sync_version_tags(str(dataset.id), available_versions)
+    return results
+
+
+def _select_version(versions: list[DatasetVersion], requested: str) -> DatasetVersion:
+    if not versions:
+        raise ValueError("Dataset replica has no versions")
+    if requested == "latest":
+        return versions[0]
+    try:
+        requested_time = datetime.fromisoformat(requested.replace("Z", "+00:00"))
+    except ValueError:
+        matching = [
+            version
+            for version in versions
+            if version.tags is not None and requested in version.tags
+        ]
+        if len(matching) != 1:
+            raise ValueError(f"Dataset version tag not found or ambiguous: {requested}")
+        return matching[0]
+    eligible = [version for version in versions if version.as_of <= requested_time]
+    if not eligible:
+        raise ValueError(f"No dataset version exists at or before {requested}")
+    return max(eligible, key=lambda item: item.as_of)

--- a/src/langsmith_cli/dataset_replica/service.py
+++ b/src/langsmith_cli/dataset_replica/service.py
@@ -2,17 +2,17 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 
 from langsmith_cli.archive.storage import create_store
 from langsmith_cli.dataset_resolution import resolve_dataset
+from langsmith_cli.dataset_replica.contracts import ReplicaWriteResult
 from langsmith_cli.dataset_replica.models import (
     ReplicaDestination,
     ReplicaSource,
-    ReplicaWriteResult,
 )
 from langsmith_cli.dataset_replica.repository import (
     DatasetReplicaConfigurationError,
@@ -107,16 +107,17 @@ def pull_dataset(
     )
     versions = source_repository.list_versions(dataset_name_or_id)
     selected = versions if all_versions else [_select_version(versions, as_of)]
+    dataset = source_repository.read_dataset(dataset_name_or_id)
     results: list[ReplicaWriteResult] = []
     for version in reversed(selected):
-        version_text = version.as_of.isoformat()
-        dataset = source_repository.read_dataset(dataset_name_or_id, version_text)
-        examples = source_repository.read_examples(
+        version_text = version.as_of.astimezone(timezone.utc).isoformat()
+        examples = source_repository.iter_examples(
             dataset_name_or_id,
             as_of=version_text,
             include_attachments=True,
         )
         results.append(target.write_snapshot(dataset, version, examples))
+    target.sync_version_tags(str(dataset.id), versions)
     return results
 
 
@@ -162,13 +163,11 @@ def _pull_from_cloud(
     for version in versions:
         # INVARIANT: every page is read against one server-resolved exact version.
         # Without this bound, concurrent cloud edits could create a mixed snapshot.
-        examples = list(
-            client.list_examples(
-                dataset_id=dataset.id,
-                as_of=version.as_of,
-                include_attachments=True,
-                inline_s3_urls=False,
-            )
+        examples = client.list_examples(
+            dataset_id=dataset.id,
+            as_of=version.as_of,
+            include_attachments=True,
+            inline_s3_urls=False,
         )
         results.append(target.write_snapshot(dataset, version, examples))
     target.sync_version_tags(str(dataset.id), available_versions)

--- a/src/langsmith_cli/dataset_replica/service.py
+++ b/src/langsmith_cli/dataset_replica/service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import timezone
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
@@ -13,6 +13,7 @@ from langsmith_cli.dataset_replica.contracts import ReplicaWriteResult
 from langsmith_cli.dataset_replica.models import (
     ReplicaDestination,
     ReplicaSource,
+    parse_datetime,
 )
 from langsmith_cli.dataset_replica.repository import (
     DatasetReplicaConfigurationError,
@@ -81,6 +82,8 @@ def pull_dataset(
     archive_uri: str | None,
     local_directory: str | None,
 ) -> list[ReplicaWriteResult]:
+    if all_versions and as_of != "latest":
+        raise ValueError("--all-versions cannot be combined with --as-of")
     if (
         source is ReplicaSource.ARCHIVE and destination is ReplicaDestination.ARCHIVE
     ) or (source is ReplicaSource.LOCAL and destination is ReplicaDestination.LOCAL):
@@ -105,11 +108,15 @@ def pull_dataset(
         archive_uri=archive_uri,
         local_directory=local_directory,
     )
+    if source_repository.base_uri == target.base_uri:
+        raise ValueError(
+            "Dataset source and destination resolve to the same repository"
+        )
     versions = source_repository.list_versions(dataset_name_or_id)
     selected = versions if all_versions else [_select_version(versions, as_of)]
     dataset = source_repository.read_dataset(dataset_name_or_id)
     results: list[ReplicaWriteResult] = []
-    for version in reversed(selected):
+    for version in sorted(selected, key=lambda item: item.as_of):
         version_text = version.as_of.astimezone(timezone.utc).isoformat()
         examples = source_repository.iter_examples(
             dataset_name_or_id,
@@ -137,7 +144,7 @@ def resolve_cloud_version(
     client: Client, dataset_id: str, requested: str
 ) -> DatasetVersion:
     try:
-        requested_time = datetime.fromisoformat(requested.replace("Z", "+00:00"))
+        requested_time = parse_datetime(requested)
     except ValueError:
         return client.read_dataset_version(dataset_id=dataset_id, tag=requested)
     return client.read_dataset_version(dataset_id=dataset_id, as_of=requested_time)
@@ -175,22 +182,22 @@ def _pull_from_cloud(
 
 
 def _select_version(versions: list[DatasetVersion], requested: str) -> DatasetVersion:
-    if not versions:
-        raise ValueError("Dataset replica has no versions")
-    if requested == "latest":
-        return versions[0]
+    from langsmith_cli.dataset_replica.versioning import (
+        SelectableVersion,
+        VersionSelectionError,
+        select_version,
+    )
+
+    selectable = [
+        SelectableVersion(
+            position=position,
+            as_of=version.as_of,
+            tags=tuple(version.tags or ()),
+        )
+        for position, version in enumerate(versions)
+    ]
     try:
-        requested_time = datetime.fromisoformat(requested.replace("Z", "+00:00"))
-    except ValueError:
-        matching = [
-            version
-            for version in versions
-            if version.tags is not None and requested in version.tags
-        ]
-        if len(matching) != 1:
-            raise ValueError(f"Dataset version tag not found or ambiguous: {requested}")
-        return matching[0]
-    eligible = [version for version in versions if version.as_of <= requested_time]
-    if not eligible:
-        raise ValueError(f"No dataset version exists at or before {requested}")
-    return max(eligible, key=lambda item: item.as_of)
+        selected = select_version(selectable, requested)
+    except VersionSelectionError as exc:
+        raise ValueError(str(exc)) from exc
+    return versions[selected.position]

--- a/src/langsmith_cli/dataset_replica/service.py
+++ b/src/langsmith_cli/dataset_replica/service.py
@@ -8,12 +8,16 @@ from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 
 from langsmith_cli.archive.storage import create_store
+from langsmith_cli.dataset_resolution import resolve_dataset
 from langsmith_cli.dataset_replica.models import (
     ReplicaDestination,
     ReplicaSource,
     ReplicaWriteResult,
 )
-from langsmith_cli.dataset_replica.repository import DatasetReplicaRepository
+from langsmith_cli.dataset_replica.repository import (
+    DatasetReplicaConfigurationError,
+    DatasetReplicaRepository,
+)
 
 if TYPE_CHECKING:
     from langsmith import Client
@@ -42,11 +46,28 @@ def repository_for(
     archive_uri: str | None,
     local_directory: str | None,
 ) -> DatasetReplicaRepository:
-    if source in (ReplicaSource.LOCAL, ReplicaDestination.LOCAL):
+    if source is ReplicaSource.LOCAL or source is ReplicaDestination.LOCAL:
         uri = local_directory or str(default_local_dataset_directory())
+    elif source is ReplicaSource.ARCHIVE or source is ReplicaDestination.ARCHIVE:
+        if archive_uri is not None:
+            uri = archive_uri
+        elif "LANGSMITH_ARCHIVE_URI" in os.environ:
+            uri = os.environ["LANGSMITH_ARCHIVE_URI"]
+        else:
+            raise DatasetReplicaConfigurationError(
+                "Archive operations require --archive-uri or LANGSMITH_ARCHIVE_URI"
+            )
     else:
-        uri = archive_uri or os.environ["LANGSMITH_ARCHIVE_URI"]
-    return DatasetReplicaRepository(create_store(uri))
+        raise DatasetReplicaConfigurationError(
+            "Cloud is not a readable replica repository"
+        )
+    try:
+        store = create_store(uri)
+    except (OSError, ValueError) as exc:
+        raise DatasetReplicaConfigurationError(
+            f"Invalid {source.value} replica location"
+        ) from exc
+    return DatasetReplicaRepository(store)
 
 
 def pull_dataset(
@@ -60,7 +81,9 @@ def pull_dataset(
     archive_uri: str | None,
     local_directory: str | None,
 ) -> list[ReplicaWriteResult]:
-    if source.value == destination.value:
+    if (
+        source is ReplicaSource.ARCHIVE and destination is ReplicaDestination.ARCHIVE
+    ) or (source is ReplicaSource.LOCAL and destination is ReplicaDestination.LOCAL):
         raise ValueError("Dataset source and destination must differ")
     target = repository_for(
         destination,
@@ -127,8 +150,6 @@ def _pull_from_cloud(
     as_of: str,
     all_versions: bool,
 ) -> list[ReplicaWriteResult]:
-    from langsmith_cli.commands.datasets import resolve_dataset
-
     dataset = resolve_dataset(client, dataset_name_or_id)
     available_versions = list(client.list_dataset_versions(dataset_id=dataset.id))
     versions = (

--- a/src/langsmith_cli/dataset_replica/versioning.py
+++ b/src/langsmith_cli/dataset_replica/versioning.py
@@ -1,0 +1,69 @@
+"""One version-selection contract for repository reads and transfers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from langsmith_cli.dataset_replica.models import parse_datetime
+
+
+class SelectableVersion(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    position: int
+    as_of: datetime
+    tags: tuple[str, ...] = ()
+
+    @field_validator("as_of")
+    @classmethod
+    def require_aware_timestamp(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("Dataset version timestamps must be timezone-aware")
+        return value
+
+
+class VersionSelectionError(ValueError):
+    """Base error for an absent or ambiguous version reference."""
+
+
+class NoVersionsError(VersionSelectionError):
+    pass
+
+
+class VersionNotFoundError(VersionSelectionError):
+    pass
+
+
+class VersionAmbiguousError(VersionSelectionError):
+    pass
+
+
+def select_version(
+    versions: list[SelectableVersion], requested: str | None
+) -> SelectableVersion:
+    """Resolve latest, an exact tag, or the newest timestamp at/before a bound."""
+    if not versions:
+        raise NoVersionsError("Dataset replica has no versions")
+    if requested is None or requested == "latest":
+        return max(versions, key=lambda item: item.as_of)
+
+    try:
+        requested_time = parse_datetime(requested)
+    except ValueError:
+        matching = [item for item in versions if requested in item.tags]
+        if not matching:
+            raise VersionNotFoundError(f"Dataset version tag not found: {requested}")
+        if len(matching) > 1:
+            raise VersionAmbiguousError(
+                f"Dataset version tag is ambiguous: {requested}"
+            )
+        return matching[0]
+
+    eligible = [item for item in versions if item.as_of <= requested_time]
+    if not eligible:
+        raise VersionNotFoundError(
+            f"No dataset version exists at or before {requested}"
+        )
+    return max(eligible, key=lambda item: item.as_of)

--- a/src/langsmith_cli/dataset_resolution.py
+++ b/src/langsmith_cli/dataset_resolution.py
@@ -1,0 +1,32 @@
+"""Shared dataset identity resolution without command-layer dependencies."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+if TYPE_CHECKING:
+    from langsmith import Client
+    from langsmith.schemas import Dataset
+
+
+class DatasetResolutionError(ValueError):
+    """A cloud Dataset identity cannot be resolved from the supplied reference."""
+
+
+def resolve_dataset(client: Client, name_or_id: str) -> Dataset:
+    """Resolve one cloud Dataset by stable UUID or human-facing name.
+
+    Syntactic identity selection happens before the SDK call, so authorization,
+    transport, and server failures propagate with their original typed errors.
+    """
+    from langsmith.utils import LangSmithNotFoundError
+
+    try:
+        UUID(name_or_id)
+    except ValueError:
+        try:
+            return client.read_dataset(dataset_name=name_or_id)
+        except LangSmithNotFoundError as exc:
+            raise DatasetResolutionError(f"Dataset '{name_or_id}' not found.") from exc
+    return client.read_dataset(dataset_id=name_or_id)

--- a/src/langsmith_cli/filtering.py
+++ b/src/langsmith_cli/filtering.py
@@ -390,21 +390,14 @@ def apply_name_filters(
     Returns:
         Filtered list of items
     """
-    import fnmatch
-
     if not name_pattern and not name_regex:
         return items
 
     filtered = items
     if name_pattern:
-        filtered = [
-            item
-            for item in filtered
-            if fnmatch.fnmatch(name_getter(item), name_pattern)
-        ]
+        filtered = apply_wildcard_filter(filtered, name_pattern, name_getter)
     if name_regex:
-        compiled = re.compile(name_regex)
-        filtered = [item for item in filtered if compiled.search(name_getter(item))]
+        filtered = apply_regex_filter(filtered, name_regex, name_getter)
 
     return filtered
 
@@ -422,8 +415,10 @@ def sort_by_option(
     Returns:
         Click option decorator
     """
+    example_field = fields.split(",", maxsplit=1)[0].strip()
     default_help = (
-        f"Sort by field ({fields}). Prefix with - for descending (e.g., '-name')."
+        f"Sort by field ({fields}). Prefix with - for descending "
+        f"(e.g., '-{example_field}')."
     )
     return click.option(
         "--sort-by",
@@ -527,23 +522,14 @@ def apply_wildcard_filter(
     if not wildcard_pattern:
         return items
 
-    # Convert wildcards to regex
-    pattern = wildcard_pattern.replace("*", ".*").replace("?", ".")
+    import fnmatch
 
-    # Add anchors if pattern doesn't use wildcards at edges
-    if not wildcard_pattern.startswith("*"):
-        pattern = "^" + pattern
-    if not wildcard_pattern.endswith("*"):
-        pattern = pattern + "$"
-
-    regex_pattern = re.compile(pattern)
-
-    filtered = []
-    for item in items:
-        field_value = field_getter(item)
-        if field_value and regex_pattern.search(field_value):
-            filtered.append(item)
-    return filtered
+    return [
+        item
+        for item in items
+        if (field_value := field_getter(item))
+        and fnmatch.fnmatchcase(field_value, wildcard_pattern)
+    ]
 
 
 def parse_json_string(
@@ -566,9 +552,12 @@ def parse_json_string(
         return None
 
     try:
-        return json.loads(json_str)
+        parsed = json.loads(json_str)
     except json.JSONDecodeError as e:
         raise click.BadParameter(f"Invalid JSON in {field_name}: {e}")
+    if not isinstance(parsed, dict):
+        raise click.BadParameter(f"{field_name} must be a JSON object")
+    return parsed
 
 
 def parse_comma_separated_list(input_str: str | None) -> list[str] | None:

--- a/src/langsmith_cli/main.py
+++ b/src/langsmith_cli/main.py
@@ -301,6 +301,9 @@ class LangSmithCLIGroup(click.Group):
 
             else:
                 # Non-LangSmith error (Click exceptions, Python exceptions, etc.)
+                from langsmith_cli.dataset_replica.repository import (
+                    DatasetReplicaError,
+                )
                 from langsmith_cli.utils import CLIFetchError
 
                 if json_mode:
@@ -323,6 +326,12 @@ class LangSmithCLIGroup(click.Group):
                             "message": e.format_message(),
                         }
                         exit_code = e.exit_code
+                    elif isinstance(e, DatasetReplicaError):
+                        error_data = {
+                            "error": type(e).__name__,
+                            "message": str(e),
+                        }
+                        exit_code = 1
                     else:
                         error_data = {
                             "error": type(e).__name__,
@@ -333,6 +342,8 @@ class LangSmithCLIGroup(click.Group):
                     sys.exit(exit_code)
                 else:
                     # In human mode, re-raise for Click's default formatting
+                    if isinstance(e, DatasetReplicaError):
+                        raise click.ClickException(str(e)) from e
                     raise
         finally:
             try:

--- a/tests/test_archive_invariants.py
+++ b/tests/test_archive_invariants.py
@@ -486,6 +486,10 @@ def test_s3_store_supports_complete_object_contract(
 
         def upload_file(self, source: str, bucket: str, key: str) -> None:
             self.upload = (source, bucket, key)
+            self.objects[key] = Path(source).read_bytes()
+
+        def download_file(self, bucket: str, key: str, destination: str) -> None:
+            Path(destination).write_bytes(self.objects[key])
 
         def put_object(self, **kwargs: object) -> None:
             body = kwargs["Body"]
@@ -514,7 +518,10 @@ def test_s3_store_supports_complete_object_contract(
     source.write_bytes(b"PAR1")
 
     store.put_file("raw/run.parquet", source)
+    store.put_bytes("blobs/attachment", b"attachment")
     store.put_text("projects/project.json", "{}")
+    destination = tmp_path / "downloaded.parquet"
+    store.get_file("raw/run.parquet", destination)
 
     assert client.upload == (
         str(source),
@@ -522,6 +529,8 @@ def test_s3_store_supports_complete_object_contract(
         "langsmith/raw/run.parquet",
     )
     assert store.get_text("projects/project.json") == "{}"
+    assert store.get_bytes("blobs/attachment") == b"attachment"
+    assert destination.read_bytes() == b"PAR1"
     assert store.exists("projects/project.json") is True
     assert store.exists("projects/missing.json") is False
     assert store.object_uri("raw/run.parquet") == (

--- a/tests/test_archive_invariants.py
+++ b/tests/test_archive_invariants.py
@@ -7,7 +7,7 @@ from datetime import date, datetime, time, timedelta, timezone
 from io import BytesIO
 import json
 from pathlib import Path
-from threading import Barrier, Thread
+from threading import Barrier, Event, Thread
 from typing import Any, Iterator
 
 import pytest
@@ -368,6 +368,38 @@ def test_local_store_lists_backend_neutral_posix_object_keys(tmp_path: Path) -> 
     assert store.list_keys("projects") == ["projects/project_id=one.json"]
 
 
+def test_local_object_replacement_never_exposes_staged_bytes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """INVARIANT: readers see the old object until the complete replacement commits."""
+    import os
+
+    store = create_store(str(tmp_path / "archive"))
+    store.put_bytes("datasets/object", b"old-complete-object")
+    replace_entered = Event()
+    allow_replace = Event()
+    real_replace = os.replace
+
+    def controlled_replace(source: str | Path, destination: str | Path) -> None:
+        replace_entered.set()
+        assert allow_replace.wait(timeout=2)
+        real_replace(source, destination)
+
+    monkeypatch.setattr(os, "replace", controlled_replace)
+    writer = Thread(
+        target=store.put_bytes,
+        args=("datasets/object", b"new-complete-object"),
+    )
+    writer.start()
+    assert replace_entered.wait(timeout=2)
+    assert store.get_bytes("datasets/object") == b"old-complete-object"
+    allow_replace.set()
+    writer.join(timeout=2)
+
+    assert writer.is_alive() is False
+    assert store.get_bytes("datasets/object") == b"new-complete-object"
+
+
 def test_windows_drive_paths_are_not_uri_schemes() -> None:
     assert _is_windows_drive_path(r"C:\archive\traces") is True
     assert _is_windows_drive_path("s3://bucket/traces") is False
@@ -396,6 +428,52 @@ def test_s3_conditional_publication_uses_etag_preconditions(
     assert client.calls[0]["IfNoneMatch"] == "*"
     assert client.calls[1]["IfMatch"] == '"etag"'
     assert client.calls[0]["Key"] == "langsmith/manifests/day.json"
+
+
+def test_s3_binary_methods_use_the_same_normalized_object_contract(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """INVARIANT: Parquet/blob methods preserve exact bytes and prefixed keys."""
+    import boto3
+
+    class BinaryS3Client:
+        def __init__(self) -> None:
+            self.objects: dict[tuple[str, str], bytes] = {}
+
+        def upload_file(self, source: str, bucket: str, key: str) -> None:
+            self.objects[(bucket, key)] = Path(source).read_bytes()
+
+        def download_file(self, bucket: str, key: str, destination: str) -> None:
+            Path(destination).write_bytes(self.objects[(bucket, key)])
+
+        def put_object(
+            self, *, Bucket: str, Key: str, Body: bytes, **_: object
+        ) -> None:
+            self.objects[(Bucket, Key)] = Body
+
+        def get_object(self, *, Bucket: str, Key: str) -> dict[str, object]:
+            return {"Body": BytesIO(self.objects[(Bucket, Key)])}
+
+    client = BinaryS3Client()
+    monkeypatch.setattr(boto3, "client", lambda service: client)
+    store = S3ArchiveStore(
+        bucket="archive-bucket",
+        prefix="langsmith",
+        base_uri="s3://archive-bucket/langsmith",
+    )
+    source = tmp_path / "source.parquet"
+    source.write_bytes(b"parquet-bytes")
+    destination = tmp_path / "nested" / "download.parquet"
+
+    store.put_file("datasets/object.parquet", source)
+    store.put_bytes("datasets/blob", b"attachment-bytes")
+    store.get_file("datasets/object.parquet", destination)
+
+    assert destination.read_bytes() == b"parquet-bytes"
+    assert store.get_bytes("datasets/blob") == b"attachment-bytes"
+    assert client.objects[("archive-bucket", "langsmith/datasets/blob")] == (
+        b"attachment-bytes"
+    )
 
 
 def test_s3_stale_write_is_a_typed_concurrency_error(

--- a/tests/test_dataset_replicas.py
+++ b/tests/test_dataset_replicas.py
@@ -409,6 +409,26 @@ def test_repository_configuration_failures_are_typed(
         )
 
 
+def test_cli_replica_errors_are_structured_for_agents_and_humans(
+    runner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """INVARIANT: typed replica errors cross the shared CLI boundary cleanly."""
+    monkeypatch.delenv("LANGSMITH_ARCHIVE_URI", raising=False)
+
+    json_result = runner.invoke(
+        cli, ["--json", "datasets", "status", "--source", "archive"]
+    )
+    human_result = runner.invoke(cli, ["datasets", "status", "--source", "archive"])
+
+    assert json_result.exit_code == 1
+    assert json.loads(json_result.output)["error"] == (
+        "DatasetReplicaConfigurationError"
+    )
+    assert human_result.exit_code == 1
+    assert "Error:" in human_result.output
+    assert "--archive-uri" in human_result.output
+
+
 def test_historical_example_lookup_skips_datasets_without_that_version(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_dataset_replicas.py
+++ b/tests/test_dataset_replicas.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
+import hashlib
 import io
 import json
 from pathlib import Path
+from threading import Barrier
 from unittest.mock import MagicMock, patch
 from uuid import UUID
 
@@ -16,12 +19,21 @@ from langsmith_cli.archive.storage import create_store
 from langsmith_cli.dataset_replica.models import ReplicaDestination, ReplicaSource
 from langsmith_cli.dataset_replica.repository import (
     DatasetReplicaAmbiguousError,
+    DatasetReplicaConflictError,
+    DatasetReplicaConfigurationError,
+    DatasetReplicaError,
+    DatasetReplicaIntegrityError,
     DatasetReplicaRepository,
+    DatasetReplicaSchemaError,
+    _parse_attachments,
+    _parse_head,
+    _parse_manifest,
 )
 from langsmith_cli.dataset_replica.service import (
     _select_version,
     default_local_dataset_directory,
     pull_dataset,
+    repository_for,
     resolve_cloud_version,
 )
 from langsmith_cli.main import cli
@@ -57,6 +69,8 @@ def replica_dataset() -> Dataset:
 def replica_example(
     example_id: UUID = EXAMPLE_ID,
     *,
+    dataset_id: UUID = DATASET_ID,
+    input_value: str = "why?",
     attachment: bytes | None = b"diagram-bytes",
 ) -> Example:
     attachments = None
@@ -70,8 +84,8 @@ def replica_example(
         }
     return Example(
         id=example_id,
-        dataset_id=DATASET_ID,
-        inputs={"question": "why?"},
+        dataset_id=dataset_id,
+        inputs={"question": input_value},
         outputs={"answer": "because"},
         metadata={"dataset_split": ["test"], "difficulty": "hard"},
         created_at=VERSION_ONE - timedelta(hours=1),
@@ -118,7 +132,7 @@ def test_repository_is_idempotent_and_reads_historical_versions(tmp_path: Path):
     repeated = repository.write_snapshot(
         dataset,
         DatasetVersion(tags=["renamed-baseline"], as_of=VERSION_ONE),
-        [replica_example(attachment=None)],
+        [replica_example(attachment=None), replica_example(SECOND_EXAMPLE_ID)],
     )
     repository.write_snapshot(dataset, second, [replica_example(attachment=None)])
     repository.sync_version_tags(
@@ -143,6 +157,395 @@ def test_repository_is_idempotent_and_reads_historical_versions(tmp_path: Path):
     assert versions[0].tags == ["prod", "latest"]
     assert versions[1].tags is None
     assert len(repository.read_examples(str(DATASET_ID), as_of="prod")) == 1
+
+    renamed = dataset.model_copy(update={"name": "renamed-evaluation-set"})
+    rename_result = repository.write_snapshot(
+        renamed,
+        second,
+        [replica_example(attachment=None)],
+    )
+    assert rename_result.already_present is True
+    assert repository.read_dataset(str(DATASET_ID)).name == renamed.name
+
+
+def test_same_timestamp_rejects_different_snapshot_content(tmp_path: Path) -> None:
+    """INVARIANT: one dataset timestamp identifies exactly one snapshot."""
+    repository = DatasetReplicaRepository(create_store(str(tmp_path)))
+    version = DatasetVersion(tags=["baseline"], as_of=VERSION_ONE)
+    repository.write_snapshot(
+        replica_dataset(), version, [replica_example(input_value="first")]
+    )
+
+    with pytest.raises(DatasetReplicaConflictError, match="different content"):
+        repository.write_snapshot(
+            replica_dataset(), version, [replica_example(input_value="changed")]
+        )
+
+    restored = repository.read_examples(str(DATASET_ID))
+    assert restored[0].inputs == {"question": "first"}
+
+
+def test_snapshot_rejects_example_from_another_dataset(tmp_path: Path) -> None:
+    """INVARIANT: every example in a snapshot belongs to its dataset ID."""
+    repository = DatasetReplicaRepository(create_store(str(tmp_path)))
+    other_dataset_id = UUID("e4970850-07ca-460c-a1b9-5ea1ea2a60de")
+
+    with pytest.raises(DatasetReplicaConflictError, match="belongs to dataset"):
+        repository.write_snapshot(
+            replica_dataset(),
+            DatasetVersion(as_of=VERSION_ONE),
+            [replica_example(dataset_id=other_dataset_id, attachment=None)],
+        )
+
+    assert repository.statuses() == []
+
+    duplicate = replica_example(attachment=None)
+    with pytest.raises(DatasetReplicaConflictError, match="duplicate example ID"):
+        repository.write_snapshot(
+            replica_dataset(),
+            DatasetVersion(as_of=VERSION_ONE),
+            [duplicate, duplicate],
+        )
+
+
+def test_corrupt_snapshot_artifact_fails_integrity_check(tmp_path: Path) -> None:
+    """INVARIANT: readers never deserialize bytes that fail the manifest digest."""
+    store = create_store(str(tmp_path))
+    repository = DatasetReplicaRepository(store)
+    repository.write_snapshot(replica_dataset(), DatasetVersion(as_of=VERSION_ONE), [])
+    head = json.loads(store.get_text(f"datasets/heads/{DATASET_ID}.json"))
+    manifest = json.loads(store.get_text(head["versions"][0]["manifest_key"]))
+    store.put_bytes(manifest["dataset_key"], b"not parquet")
+
+    with pytest.raises(DatasetReplicaIntegrityError, match="digest mismatch"):
+        repository.read_dataset(str(DATASET_ID))
+
+
+def test_corrupt_attachment_fails_before_reader_is_returned(tmp_path: Path) -> None:
+    """INVARIANT: attachment content is verified against its content address."""
+    store = create_store(str(tmp_path))
+    repository = DatasetReplicaRepository(store)
+    repository.write_snapshot(
+        replica_dataset(),
+        DatasetVersion(as_of=VERSION_ONE),
+        [replica_example()],
+    )
+    digest = hashlib.sha256(b"diagram-bytes").hexdigest()
+    store.put_bytes(f"datasets/blobs/{digest}", b"corrupt")
+
+    with pytest.raises(DatasetReplicaIntegrityError, match="attachment digest"):
+        repository.read_examples(str(DATASET_ID), include_attachments=True)
+
+
+def test_manifest_cross_references_and_counts_are_enforced(tmp_path: Path) -> None:
+    """INVARIANT: a head cannot redirect a version to another dataset or row count."""
+    store = create_store(str(tmp_path))
+    repository = DatasetReplicaRepository(store)
+    repository.write_snapshot(
+        replica_dataset(),
+        DatasetVersion(as_of=VERSION_ONE),
+        [replica_example(attachment=None)],
+    )
+    head_key = f"datasets/heads/{DATASET_ID}.json"
+    head = json.loads(store.get_text(head_key))
+    manifest_key = head["versions"][0]["manifest_key"]
+    manifest = json.loads(store.get_text(manifest_key))
+    manifest["example_count"] = 2
+    store.put_text(manifest_key, json.dumps(manifest))
+
+    with pytest.raises(DatasetReplicaIntegrityError, match="example count"):
+        repository.read_examples(str(DATASET_ID))
+
+    manifest["dataset_id"] = "e4970850-07ca-460c-a1b9-5ea1ea2a60de"
+    store.put_text(manifest_key, json.dumps(manifest))
+    with pytest.raises(DatasetReplicaIntegrityError, match="dataset ID"):
+        repository.read_dataset(str(DATASET_ID))
+
+    manifest["dataset_id"] = str(DATASET_ID)
+    manifest["version"]["as_of"] = VERSION_TWO.isoformat()
+    store.put_text(manifest_key, json.dumps(manifest))
+    with pytest.raises(DatasetReplicaIntegrityError, match="manifest version"):
+        repository.read_dataset(str(DATASET_ID))
+
+    manifest["version"]["as_of"] = VERSION_ONE.isoformat()
+    manifest["example_count"] = 1
+    manifest["attachment_count"] = 1
+    store.put_text(manifest_key, json.dumps(manifest))
+    with pytest.raises(DatasetReplicaIntegrityError, match="attachment count"):
+        repository.read_examples(str(DATASET_ID))
+
+
+def test_malformed_head_fails_as_typed_schema_error(tmp_path: Path) -> None:
+    """INVARIANT: untrusted catalog JSON is validated before typed access."""
+    store = create_store(str(tmp_path))
+    store.put_text(
+        f"datasets/heads/{DATASET_ID}.json",
+        json.dumps(
+            {
+                "schema_version": 1,
+                "dataset_id": str(DATASET_ID),
+                "dataset_name": "broken",
+                "latest_as_of": VERSION_ONE.isoformat(),
+                "versions": [],
+            }
+        ),
+    )
+
+    with pytest.raises(DatasetReplicaSchemaError, match="at least one version"):
+        DatasetReplicaRepository(store).read_dataset(str(DATASET_ID))
+
+
+def test_untrusted_catalog_payload_shapes_fail_fast() -> None:
+    """INVARIANT: every dynamic JSON envelope is checked before TypedDict casts."""
+    version = {
+        "as_of": VERSION_ONE.isoformat(),
+        "manifest_key": "datasets/manifest.json",
+        "tags": ["latest"],
+    }
+    valid_head = {
+        "schema_version": 1,
+        "dataset_id": str(DATASET_ID),
+        "dataset_name": "evaluation-set",
+        "latest_as_of": VERSION_ONE.isoformat(),
+        "versions": [version],
+    }
+    with pytest.raises(DatasetReplicaError, match="JSON object"):
+        _parse_head("[]")
+    with pytest.raises(DatasetReplicaSchemaError, match="fields changed"):
+        _parse_head("{}")
+    with pytest.raises(DatasetReplicaError, match="Unsupported"):
+        _parse_head(json.dumps({**valid_head, "schema_version": 2}))
+    with pytest.raises(DatasetReplicaSchemaError, match="JSON object"):
+        _parse_head(json.dumps({**valid_head, "versions": [1]}))
+    with pytest.raises(DatasetReplicaSchemaError, match="unique and sorted"):
+        _parse_head(
+            json.dumps(
+                {
+                    **valid_head,
+                    "versions": [
+                        {**version, "as_of": VERSION_TWO.isoformat()},
+                        version,
+                    ],
+                    "latest_as_of": VERSION_TWO.isoformat(),
+                }
+            )
+        )
+    with pytest.raises(DatasetReplicaSchemaError, match="newest version"):
+        _parse_head(json.dumps({**valid_head, "latest_as_of": VERSION_TWO.isoformat()}))
+    with pytest.raises(DatasetReplicaSchemaError, match="string array"):
+        _parse_head(json.dumps({**valid_head, "versions": [{**version, "tags": [1]}]}))
+
+    valid_manifest = {
+        "schema_version": 1,
+        "dataset_id": str(DATASET_ID),
+        "dataset_name": "evaluation-set",
+        "version": {"as_of": VERSION_ONE.isoformat(), "tags": None},
+        "dataset_key": "datasets/dataset.parquet",
+        "dataset_sha256": "a" * 64,
+        "examples_key": "datasets/examples.parquet",
+        "examples_sha256": "b" * 64,
+        "content_digest": "c" * 64,
+        "example_count": 1,
+        "attachment_count": 0,
+        "published_at": VERSION_ONE.isoformat(),
+    }
+    with pytest.raises(DatasetReplicaSchemaError, match="version must be an object"):
+        _parse_manifest(json.dumps({**valid_manifest, "version": 1}))
+    with pytest.raises(DatasetReplicaSchemaError, match="SHA-256"):
+        _parse_manifest(json.dumps({**valid_manifest, "content_digest": "short"}))
+    with pytest.raises(DatasetReplicaSchemaError, match="non-negative integer"):
+        _parse_manifest(json.dumps({**valid_manifest, "example_count": -1}))
+    with pytest.raises(DatasetReplicaSchemaError, match="ISO timestamp"):
+        _parse_manifest(json.dumps({**valid_manifest, "published_at": "yesterday"}))
+
+    with pytest.raises(DatasetReplicaError, match="JSON array"):
+        _parse_attachments("{}")
+    with pytest.raises(DatasetReplicaSchemaError, match="JSON object"):
+        _parse_attachments("[1]")
+    with pytest.raises(DatasetReplicaSchemaError, match="fields changed"):
+        _parse_attachments('[{"name":"file"}]')
+    with pytest.raises(DatasetReplicaSchemaError, match="SHA-256"):
+        _parse_attachments(
+            json.dumps(
+                [
+                    {
+                        "name": "file",
+                        "mime_type": None,
+                        "digest": "z" * 64,
+                        "size": 1,
+                    }
+                ]
+            )
+        )
+    with pytest.raises(DatasetReplicaSchemaError, match="non-negative integer"):
+        _parse_attachments(
+            json.dumps(
+                [
+                    {
+                        "name": "file",
+                        "mime_type": None,
+                        "digest": "a" * 64,
+                        "size": -1,
+                    }
+                ]
+            )
+        )
+
+
+def test_repository_configuration_failures_are_typed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """INVARIANT: location failures are actionable and never raw KeyErrors."""
+    monkeypatch.delenv("LANGSMITH_ARCHIVE_URI", raising=False)
+    with pytest.raises(DatasetReplicaConfigurationError, match="--archive-uri"):
+        repository_for(ReplicaSource.ARCHIVE, archive_uri=None, local_directory=None)
+    with pytest.raises(DatasetReplicaConfigurationError, match="not a readable"):
+        repository_for(ReplicaSource.CLOUD, archive_uri=None, local_directory=None)
+    with pytest.raises(DatasetReplicaConfigurationError, match="Invalid archive"):
+        repository_for(
+            ReplicaSource.ARCHIVE,
+            archive_uri="ftp://invalid.example/archive",
+            local_directory=str(tmp_path),
+        )
+
+
+def test_historical_example_lookup_skips_datasets_without_that_version(
+    tmp_path: Path,
+) -> None:
+    """INVARIANT: unrelated dataset history cannot hide a matching example."""
+    repository = DatasetReplicaRepository(create_store(str(tmp_path)))
+    repository.write_snapshot(
+        replica_dataset(),
+        DatasetVersion(as_of=VERSION_ONE),
+        [replica_example(attachment=None)],
+    )
+    unrelated_id = UUID("e4970850-07ca-460c-a1b9-5ea1ea2a60de")
+    unrelated = replica_dataset().model_copy(
+        update={"id": unrelated_id, "name": "newer-dataset"}
+    )
+    repository.write_snapshot(unrelated, DatasetVersion(as_of=VERSION_TWO), [])
+
+    restored = repository.read_example(str(EXAMPLE_ID), as_of=VERSION_ONE.isoformat())
+
+    assert restored.id == EXAMPLE_ID
+
+
+class _CoordinatedRepository(DatasetReplicaRepository):
+    """Align the first head read while retaining the real local store and CAS."""
+
+    def __init__(self, root: Path, barrier: Barrier) -> None:
+        super().__init__(create_store(str(root)))
+        self._barrier = barrier
+        self._first_head_read = True
+
+    def _read_head_for_update(self, dataset_id: str):
+        result = super()._read_head_for_update(dataset_id)
+        if self._first_head_read:
+            self._first_head_read = False
+            self._barrier.wait()
+        return result
+
+
+def test_concurrent_different_versions_are_both_published(tmp_path: Path) -> None:
+    """INVARIANT: head CAS retries merge independent concurrent versions."""
+    barrier = Barrier(2)
+
+    def publish(as_of: datetime) -> None:
+        repository = _CoordinatedRepository(tmp_path, barrier)
+        repository.write_snapshot(
+            replica_dataset(),
+            DatasetVersion(as_of=as_of),
+            [replica_example(input_value=as_of.isoformat(), attachment=None)],
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(publish, value) for value in (VERSION_ONE, VERSION_TWO)]
+        for future in futures:
+            future.result()
+
+    versions = DatasetReplicaRepository(create_store(str(tmp_path))).list_versions(
+        str(DATASET_ID)
+    )
+    assert {version.as_of for version in versions} == {VERSION_ONE, VERSION_TWO}
+
+
+def test_concurrent_identical_version_is_idempotent(tmp_path: Path) -> None:
+    """INVARIANT: identical concurrent publications produce one head, not conflict."""
+    barrier = Barrier(2)
+
+    def publish():
+        return _CoordinatedRepository(tmp_path, barrier).write_snapshot(
+            replica_dataset(),
+            DatasetVersion(tags=["latest"], as_of=VERSION_ONE),
+            [replica_example(attachment=None)],
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = [
+            future.result() for future in [pool.submit(publish), pool.submit(publish)]
+        ]
+
+    assert sorted(result.already_present for result in results) == [False, True]
+    repository = DatasetReplicaRepository(create_store(str(tmp_path)))
+    assert len(repository.list_versions(str(DATASET_ID))) == 1
+    assert len(repository.read_examples(str(DATASET_ID))) == 1
+
+
+def test_concurrent_divergent_same_version_cannot_publish_mixed_data(
+    tmp_path: Path,
+) -> None:
+    """INVARIANT: the winning head references only its writer's immutable data."""
+    barrier = Barrier(2)
+
+    def publish(label: str):
+        repository = _CoordinatedRepository(tmp_path, barrier)
+        result = repository.write_snapshot(
+            replica_dataset().model_copy(update={"name": label}),
+            DatasetVersion(as_of=VERSION_ONE),
+            [
+                replica_example(
+                    input_value=label * (250_000 if label == "A" else 2),
+                    attachment=None,
+                )
+            ],
+        )
+        return label, result
+
+    successes = []
+    conflicts = []
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(publish, label) for label in ("A", "B")]
+        for future in futures:
+            try:
+                successes.append(future.result())
+            except DatasetReplicaConflictError as exc:
+                conflicts.append(exc)
+
+    assert len(successes) == 1
+    assert len(conflicts) == 1
+    winner = successes[0][0]
+    repository = DatasetReplicaRepository(create_store(str(tmp_path)))
+    assert repository.read_dataset(str(DATASET_ID)).name == winner
+    stored_inputs = repository.read_examples(str(DATASET_ID))[0].inputs
+    assert stored_inputs is not None
+    stored_value = stored_inputs["question"]
+    assert stored_value == winner * (250_000 if winner == "A" else 2)
+
+
+def test_sdk_contract_drift_fails_before_snapshot_publication(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """INVARIANT: a new SDK field is never silently dropped from a replica."""
+    drifted_fields = {**Dataset.model_fields, "future_field": object()}
+    monkeypatch.setattr(Dataset, "model_fields", drifted_fields)
+    repository = DatasetReplicaRepository(create_store(str(tmp_path)))
+
+    with pytest.raises(DatasetReplicaSchemaError, match="Dataset SDK fields changed"):
+        repository.write_snapshot(
+            replica_dataset(), DatasetVersion(as_of=VERSION_ONE), []
+        )
+
+    assert repository.statuses() == []
 
 
 def test_cli_pull_then_offline_list_uses_no_cloud_client(runner, tmp_path: Path):
@@ -357,6 +760,43 @@ def test_cli_pull_then_offline_list_uses_no_cloud_client(runner, tmp_path: Path)
     assert "available only" in unsupported_filter.output
     assert same_source.exit_code == 1
     assert "must differ" in same_source.output
+
+
+def test_source_specific_options_fail_instead_of_being_silently_ignored(
+    runner, tmp_path: Path
+) -> None:
+    """INVARIANT: the uniform facade rejects unsupported source semantics."""
+    with patch("langsmith.Client") as client_class:
+        cloud_as_of = runner.invoke(
+            cli,
+            [
+                "datasets",
+                "get",
+                str(DATASET_ID),
+                "--source",
+                "cloud",
+                "--as-of",
+                VERSION_ONE.isoformat(),
+            ],
+        )
+        client_class.assert_not_called()
+    offline_inline = runner.invoke(
+        cli,
+        [
+            "examples",
+            "list",
+            "--source",
+            "local",
+            "--local-dir",
+            str(tmp_path),
+            "--inline-s3-urls",
+        ],
+    )
+
+    assert cloud_as_of.exit_code == 1
+    assert "only supported" in cloud_as_of.output
+    assert offline_inline.exit_code == 1
+    assert "only supported" in offline_inline.output
 
 
 def test_archive_snapshot_can_be_pulled_to_local(tmp_path: Path):

--- a/tests/test_dataset_replicas.py
+++ b/tests/test_dataset_replicas.py
@@ -1,0 +1,438 @@
+"""End-to-end invariants for exact, read-only dataset replicas."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import io
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+import pytest
+from langsmith.schemas import Dataset, DatasetVersion, Example
+
+from langsmith_cli.archive.storage import create_store
+from langsmith_cli.dataset_replica.models import ReplicaDestination, ReplicaSource
+from langsmith_cli.dataset_replica.repository import (
+    DatasetReplicaAmbiguousError,
+    DatasetReplicaRepository,
+)
+from langsmith_cli.dataset_replica.service import (
+    _select_version,
+    default_local_dataset_directory,
+    pull_dataset,
+    resolve_cloud_version,
+)
+from langsmith_cli.main import cli
+
+
+DATASET_ID = UUID("ae99b6fa-a6db-4f1c-8868-bc6764f4c29e")
+EXAMPLE_ID = UUID("3442bd7c-27a2-437a-a38c-f278e455d87b")
+SECOND_EXAMPLE_ID = UUID("05da0305-224c-4b3c-9662-671146ee94a5")
+VERSION_ONE = datetime(2026, 8, 20, 10, tzinfo=timezone.utc)
+VERSION_TWO = VERSION_ONE + timedelta(days=1)
+
+
+def replica_dataset() -> Dataset:
+    return Dataset(
+        id=DATASET_ID,
+        name="evaluation-set",
+        description="Strict replica fixture",
+        data_type="kv",
+        created_at=VERSION_ONE - timedelta(days=1),
+        modified_at=VERSION_TWO,
+        example_count=2,
+        session_count=3,
+        last_session_start_time=VERSION_TWO,
+        inputs_schema={"type": "object", "required": ["question"]},
+        outputs_schema={"type": "object", "required": ["answer"]},
+        transformations=[
+            {"path": ["inputs"], "transformation_type": "remove_extra_fields"}
+        ],
+        metadata={"owner": "evals"},
+    )
+
+
+def replica_example(
+    example_id: UUID = EXAMPLE_ID,
+    *,
+    attachment: bytes | None = b"diagram-bytes",
+) -> Example:
+    attachments = None
+    if attachment is not None:
+        attachments = {
+            "diagram.png": {
+                "presigned_url": "https://cloud.invalid/expiring",
+                "reader": io.BytesIO(attachment),
+                "mime_type": "image/png",
+            }
+        }
+    return Example(
+        id=example_id,
+        dataset_id=DATASET_ID,
+        inputs={"question": "why?"},
+        outputs={"answer": "because"},
+        metadata={"dataset_split": ["test"], "difficulty": "hard"},
+        created_at=VERSION_ONE - timedelta(hours=1),
+        modified_at=VERSION_ONE,
+        source_run_id=UUID("6db22a4b-bbb7-45cb-90af-33d4f08a1870"),
+        attachments=attachments,
+    )
+
+
+def test_repository_round_trips_sdk_models_and_attachment_bytes(tmp_path: Path):
+    """INVARIANT: a replica preserves SDK fields and durable attachment bytes."""
+    repository = DatasetReplicaRepository(create_store(str(tmp_path)))
+    dataset = replica_dataset()
+    version = DatasetVersion(tags=["baseline"], as_of=VERSION_ONE)
+
+    result = repository.write_snapshot(dataset, version, [replica_example()])
+    restored_dataset = repository.read_dataset(str(DATASET_ID))
+    restored = repository.read_examples(str(DATASET_ID), include_attachments=True)[0]
+
+    assert result.example_count == 1
+    assert result.attachment_count == 1
+    assert restored_dataset.model_dump(mode="json") == dataset.model_dump(mode="json")
+    assert restored.model_dump(mode="json", exclude={"attachments"}) == replica_example(
+        attachment=None
+    ).model_dump(mode="json", exclude={"attachments"})
+    assert restored.attachments is not None
+    assert restored.attachments["diagram.png"]["mime_type"] == "image/png"
+    assert restored.attachments["diagram.png"]["reader"].read() == b"diagram-bytes"
+    assert "expiring" not in restored.attachments["diagram.png"]["presigned_url"]
+
+
+def test_repository_is_idempotent_and_reads_historical_versions(tmp_path: Path):
+    """INVARIANT: exact versions are immutable and latest can fast-forward."""
+    repository = DatasetReplicaRepository(create_store(str(tmp_path)))
+    dataset = replica_dataset()
+    first = DatasetVersion(tags=["baseline"], as_of=VERSION_ONE)
+    second = DatasetVersion(tags=["latest"], as_of=VERSION_TWO)
+
+    repository.write_snapshot(
+        dataset,
+        first,
+        [replica_example(attachment=None), replica_example(SECOND_EXAMPLE_ID)],
+    )
+    repeated = repository.write_snapshot(
+        dataset,
+        DatasetVersion(tags=["renamed-baseline"], as_of=VERSION_ONE),
+        [replica_example(attachment=None)],
+    )
+    repository.write_snapshot(dataset, second, [replica_example(attachment=None)])
+    repository.sync_version_tags(
+        str(DATASET_ID),
+        [
+            DatasetVersion(tags=None, as_of=VERSION_ONE),
+            DatasetVersion(tags=["prod", "latest"], as_of=VERSION_TWO),
+        ],
+    )
+
+    assert repeated.already_present is True
+    assert len(repository.read_examples(str(DATASET_ID))) == 1
+    assert (
+        len(repository.read_examples(str(DATASET_ID), as_of=VERSION_ONE.isoformat()))
+        == 2
+    )
+    versions = repository.list_versions(str(DATASET_ID))
+    assert [version.as_of for version in versions] == [
+        VERSION_TWO,
+        VERSION_ONE,
+    ]
+    assert versions[0].tags == ["prod", "latest"]
+    assert versions[1].tags is None
+    assert len(repository.read_examples(str(DATASET_ID), as_of="prod")) == 1
+
+
+def test_cli_pull_then_offline_list_uses_no_cloud_client(runner, tmp_path: Path):
+    """INVARIANT: local reads do not instantiate the LangSmith client."""
+    dataset = replica_dataset()
+    version = DatasetVersion(tags=["latest"], as_of=VERSION_ONE)
+    with patch("langsmith.Client") as client_class:
+        client = client_class.return_value
+        client.read_dataset.return_value = dataset
+        client.read_dataset_version.return_value = version
+        client.list_examples.return_value = iter([replica_example()])
+        pulled = runner.invoke(
+            cli,
+            [
+                "--json",
+                "datasets",
+                "pull",
+                dataset.name,
+                "--to",
+                "local",
+                "--local-dir",
+                str(tmp_path),
+            ],
+        )
+    assert pulled.exit_code == 0, pulled.output
+    assert json.loads(pulled.output)[0]["example_count"] == 1
+    assert client.list_examples.call_args.kwargs["as_of"] == VERSION_ONE
+
+    with patch("langsmith.Client") as client_class:
+        listed = runner.invoke(
+            cli,
+            [
+                "--json",
+                "datasets",
+                "list",
+                "--source",
+                "local",
+                "--local-dir",
+                str(tmp_path),
+            ],
+        )
+        filtered_datasets = runner.invoke(
+            cli,
+            [
+                "--json",
+                "datasets",
+                "list",
+                "--source",
+                "local",
+                "--local-dir",
+                str(tmp_path),
+                "--dataset-ids",
+                str(DATASET_ID),
+                "--data-type",
+                "kv",
+                "--name",
+                dataset.name,
+                "--name-contains",
+                "evaluation",
+                "--metadata",
+                '{"owner":"evals"}',
+            ],
+        )
+        examples = runner.invoke(
+            cli,
+            [
+                "--json",
+                "examples",
+                "list",
+                "--dataset",
+                dataset.name,
+                "--source",
+                "local",
+                "--local-dir",
+                str(tmp_path),
+            ],
+        )
+        filtered_examples = runner.invoke(
+            cli,
+            [
+                "--json",
+                "examples",
+                "list",
+                "--dataset",
+                dataset.name,
+                "--source",
+                "local",
+                "--local-dir",
+                str(tmp_path),
+                "--example-ids",
+                str(EXAMPLE_ID),
+                "--metadata",
+                '{"difficulty":"hard"}',
+                "--splits",
+                "test",
+            ],
+        )
+        dataset_details = runner.invoke(
+            cli,
+            [
+                "--json",
+                "datasets",
+                "get",
+                dataset.name,
+                "--source",
+                "local",
+                "--local-dir",
+                str(tmp_path),
+            ],
+        )
+        versions = runner.invoke(
+            cli,
+            [
+                "--json",
+                "datasets",
+                "versions",
+                dataset.name,
+                "--source",
+                "local",
+                "--local-dir",
+                str(tmp_path),
+            ],
+        )
+        status = runner.invoke(
+            cli,
+            [
+                "--json",
+                "datasets",
+                "status",
+                "--source",
+                "local",
+                "--local-dir",
+                str(tmp_path),
+            ],
+        )
+        example_details = runner.invoke(
+            cli,
+            [
+                "--json",
+                "examples",
+                "get",
+                str(EXAMPLE_ID),
+                "--source",
+                "local",
+                "--local-dir",
+                str(tmp_path),
+                "--include-attachments",
+                "--fields",
+                "id,attachments",
+            ],
+        )
+        human_status = runner.invoke(
+            cli,
+            [
+                "datasets",
+                "status",
+                "--source",
+                "local",
+                "--local-dir",
+                str(tmp_path),
+            ],
+        )
+        unsupported_filter = runner.invoke(
+            cli,
+            [
+                "--json",
+                "examples",
+                "list",
+                "--source",
+                "local",
+                "--local-dir",
+                str(tmp_path),
+                "--filter",
+                'eq(id, "x")',
+            ],
+        )
+        same_source = runner.invoke(
+            cli,
+            [
+                "--json",
+                "datasets",
+                "pull",
+                dataset.name,
+                "--source",
+                "local",
+                "--to",
+                "local",
+                "--local-dir",
+                str(tmp_path),
+            ],
+        )
+        client_class.assert_not_called()
+    assert listed.exit_code == 0, listed.output
+    assert json.loads(listed.output)[0]["name"] == dataset.name
+    assert filtered_datasets.exit_code == 0, filtered_datasets.output
+    assert len(json.loads(filtered_datasets.output)) == 1
+    assert examples.exit_code == 0, examples.output
+    assert json.loads(examples.output)[0]["inputs"] == {"question": "why?"}
+    assert filtered_examples.exit_code == 0, filtered_examples.output
+    assert len(json.loads(filtered_examples.output)) == 1
+    assert dataset_details.exit_code == 0, dataset_details.output
+    assert json.loads(dataset_details.output)["id"] == str(DATASET_ID)
+    assert versions.exit_code == 0, versions.output
+    assert json.loads(versions.output)[0]["tags"] == ["latest"]
+    assert status.exit_code == 0, status.output
+    assert json.loads(status.output)[0]["versions"] == 1
+    assert example_details.exit_code == 0, example_details.output
+    assert "diagram.png" in json.loads(example_details.output)["attachments"]
+    assert human_status.exit_code == 0, human_status.output
+    assert "evaluation-set" in human_status.output
+    assert unsupported_filter.exit_code == 1
+    assert "available only" in unsupported_filter.output
+    assert same_source.exit_code == 1
+    assert "must differ" in same_source.output
+
+
+def test_archive_snapshot_can_be_pulled_to_local(tmp_path: Path):
+    """INVARIANT: archive-to-local uses the same public SDK contracts."""
+    archive = tmp_path / "archive"
+    local = tmp_path / "local"
+    source = DatasetReplicaRepository(create_store(str(archive)))
+    source.write_snapshot(
+        replica_dataset(),
+        DatasetVersion(tags=["prod"], as_of=VERSION_ONE),
+        [replica_example()],
+    )
+
+    results = pull_dataset(
+        client=None,
+        dataset_name_or_id=str(DATASET_ID),
+        source=ReplicaSource.ARCHIVE,
+        destination=ReplicaDestination.LOCAL,
+        as_of="prod",
+        all_versions=False,
+        archive_uri=str(archive),
+        local_directory=str(local),
+    )
+    restored = DatasetReplicaRepository(create_store(str(local))).read_examples(
+        str(DATASET_ID), include_attachments=True
+    )[0]
+
+    assert results[0].already_present is False
+    assert restored.attachments is not None
+    assert restored.attachments["diagram.png"]["reader"].read() == b"diagram-bytes"
+
+
+def test_same_name_datasets_are_ambiguous_instead_of_overwriting(tmp_path: Path):
+    """INVARIANT: names are labels; stable dataset IDs are storage identities."""
+    repository = DatasetReplicaRepository(create_store(str(tmp_path)))
+    first = replica_dataset()
+    second = first.model_copy(
+        update={"id": UUID("e4970850-07ca-460c-a1b9-5ea1ea2a60de")}
+    )
+    repository.write_snapshot(first, DatasetVersion(as_of=VERSION_ONE), [])
+    repository.write_snapshot(second, DatasetVersion(as_of=VERSION_ONE), [])
+
+    with pytest.raises(DatasetReplicaAmbiguousError, match="ambiguous"):
+        repository.read_dataset(first.name)
+
+
+def test_version_selection_and_cloud_requirements_fail_fast(tmp_path: Path):
+    """INVARIANT: version selection never silently falls back to another head."""
+    old = DatasetVersion(tags=["baseline"], as_of=VERSION_ONE)
+    latest = DatasetVersion(tags=["latest"], as_of=VERSION_TWO)
+    versions = [latest, old]
+
+    assert default_local_dataset_directory().name == "datasets"
+    assert _select_version(versions, "latest") is latest
+    assert _select_version(versions, VERSION_ONE.isoformat()) is old
+    assert _select_version(versions, "baseline") is old
+    with pytest.raises(ValueError, match="no versions"):
+        _select_version([], "latest")
+    with pytest.raises(ValueError, match="not found or ambiguous"):
+        _select_version(versions, "missing")
+    with pytest.raises(ValueError, match="at or before"):
+        _select_version(versions, "2020-01-01T00:00:00+00:00")
+    with pytest.raises(ValueError, match="requires a LangSmith client"):
+        pull_dataset(
+            client=None,
+            dataset_name_or_id=str(DATASET_ID),
+            source=ReplicaSource.CLOUD,
+            destination=ReplicaDestination.LOCAL,
+            as_of="latest",
+            all_versions=False,
+            archive_uri=None,
+            local_directory=str(tmp_path),
+        )
+
+    client = MagicMock()
+    client.read_dataset_version.return_value = old
+    selected = resolve_cloud_version(client, str(DATASET_ID), VERSION_ONE.isoformat())
+    assert selected is old
+    assert client.read_dataset_version.call_args.kwargs["as_of"] == VERSION_ONE

--- a/tests/test_dataset_replicas.py
+++ b/tests/test_dataset_replicas.py
@@ -182,6 +182,36 @@ def test_repository_is_idempotent_and_reads_historical_versions(tmp_path: Path):
     assert repository.read_dataset(str(DATASET_ID)).name == renamed.name
 
 
+def test_version_selection_reads_only_the_selected_authenticated_manifest(
+    tmp_path: Path,
+) -> None:
+    """INVARIANT: selecting one version never scans unrelated manifests."""
+    store = create_store(str(tmp_path))
+    repository = DatasetReplicaRepository(store)
+    for offset, tag in enumerate(("oldest", "middle", "newest")):
+        repository.write_snapshot(
+            replica_dataset(),
+            DatasetVersion(as_of=VERSION_ONE + timedelta(days=offset), tags=[tag]),
+            [replica_example(input_value=tag, attachment=None)],
+        )
+    head = json.loads(store.get_text(f"datasets/heads/{DATASET_ID}.json"))
+    selected_manifest_key = head["versions"][0]["manifest_key"]
+    guarded_store = MagicMock(wraps=store)
+
+    def read_selected_object(key: str) -> str:
+        if "/manifests/" in key and key != selected_manifest_key:
+            raise AssertionError("version selection read an unrelated manifest")
+        return store.get_text(key)
+
+    guarded_store.get_text.side_effect = read_selected_object
+
+    restored = DatasetReplicaRepository(guarded_store).read_dataset(
+        str(DATASET_ID), as_of="oldest"
+    )
+
+    assert restored.id == DATASET_ID
+
+
 def test_same_timestamp_rejects_different_snapshot_content(tmp_path: Path) -> None:
     """INVARIANT: one dataset timestamp identifies exactly one snapshot."""
     repository = DatasetReplicaRepository(create_store(str(tmp_path)))
@@ -1082,7 +1112,7 @@ def test_version_selection_and_cloud_requirements_fail_fast(tmp_path: Path):
     assert _select_version(versions, "baseline") is old
     with pytest.raises(ValueError, match="no versions"):
         _select_version([], "latest")
-    with pytest.raises(ValueError, match="not found or ambiguous"):
+    with pytest.raises(ValueError, match="tag not found"):
         _select_version(versions, "missing")
     with pytest.raises(ValueError, match="at or before"):
         _select_version(versions, "2020-01-01T00:00:00+00:00")
@@ -1103,3 +1133,302 @@ def test_version_selection_and_cloud_requirements_fail_fast(tmp_path: Path):
     selected = resolve_cloud_version(client, str(DATASET_ID), VERSION_ONE.isoformat())
     assert selected is old
     assert client.read_dataset_version.call_args.kwargs["as_of"] == VERSION_ONE
+
+
+@pytest.mark.parametrize("source", [ReplicaSource.ARCHIVE, ReplicaSource.LOCAL])
+def test_replica_list_filters_and_sorts_before_pagination(
+    runner, tmp_path: Path, source: ReplicaSource
+) -> None:
+    """INVARIANT: source-independent list semantics page the final result set."""
+    root = tmp_path / source.value
+    repository = DatasetReplicaRepository(create_store(str(root)))
+    first = replica_example(attachment=None)
+    second = replica_example(SECOND_EXAMPLE_ID, attachment=None).model_copy(
+        update={"created_at": first.created_at + timedelta(hours=1)}
+    )
+    repository.write_snapshot(
+        replica_dataset(), DatasetVersion(as_of=VERSION_ONE), [first, second]
+    )
+    zeta_id = UUID("ffffffff-ffff-4fff-8fff-ffffffffffff")
+    repository.write_snapshot(
+        replica_dataset().model_copy(update={"id": zeta_id, "name": "zeta"}),
+        DatasetVersion(as_of=VERSION_ONE),
+        [],
+    )
+    location_options = (
+        ["--archive-uri", str(root)]
+        if source is ReplicaSource.ARCHIVE
+        else ["--local-dir", str(root)]
+    )
+
+    sorted_datasets = runner.invoke(
+        cli,
+        [
+            "--json",
+            "datasets",
+            "list",
+            "--source",
+            source.value,
+            *location_options,
+            "--sort-by",
+            "-name",
+            "--limit",
+            "1",
+        ],
+    )
+    matching_dataset = runner.invoke(
+        cli,
+        [
+            "--json",
+            "datasets",
+            "list",
+            "--source",
+            source.value,
+            *location_options,
+            "--name-pattern",
+            "z*",
+            "--limit",
+            "1",
+        ],
+    )
+    sorted_examples = runner.invoke(
+        cli,
+        [
+            "--json",
+            "examples",
+            "list",
+            "--dataset",
+            str(DATASET_ID),
+            "--source",
+            source.value,
+            *location_options,
+            "--sort-by",
+            "-created_at",
+            "--offset",
+            "1",
+            "--limit",
+            "1",
+        ],
+    )
+    excluded_examples = runner.invoke(
+        cli,
+        [
+            "--json",
+            "examples",
+            "list",
+            "--dataset",
+            str(DATASET_ID),
+            "--source",
+            source.value,
+            *location_options,
+            "--exclude",
+            str(EXAMPLE_ID),
+            "--limit",
+            "1",
+        ],
+    )
+
+    assert sorted_datasets.exit_code == 0, sorted_datasets.output
+    assert [item["name"] for item in json.loads(sorted_datasets.output)] == ["zeta"]
+    assert matching_dataset.exit_code == 0, matching_dataset.output
+    assert [item["name"] for item in json.loads(matching_dataset.output)] == ["zeta"]
+    assert sorted_examples.exit_code == 0, sorted_examples.output
+    assert [item["id"] for item in json.loads(sorted_examples.output)] == [
+        str(EXAMPLE_ID)
+    ]
+    assert excluded_examples.exit_code == 0, excluded_examples.output
+    assert [item["id"] for item in json.loads(excluded_examples.output)] == [
+        str(SECOND_EXAMPLE_ID)
+    ]
+
+
+def test_cloud_list_defers_pagination_for_client_side_operations(runner) -> None:
+    """INVARIANT: cloud and replica sources page the same final ordering."""
+    first_dataset = replica_dataset()
+    second_dataset = first_dataset.model_copy(
+        update={
+            "id": UUID("ffffffff-ffff-4fff-8fff-ffffffffffff"),
+            "name": "zeta",
+        }
+    )
+    first_example = replica_example(attachment=None)
+    second_example = replica_example(SECOND_EXAMPLE_ID, attachment=None).model_copy(
+        update={"created_at": first_example.created_at + timedelta(hours=1)}
+    )
+    with patch("langsmith.Client") as client_class:
+        client = client_class.return_value
+        client.list_datasets.return_value = iter([first_dataset, second_dataset])
+        client.list_examples.return_value = iter([first_example, second_example])
+
+        datasets_result = runner.invoke(
+            cli,
+            [
+                "--json",
+                "datasets",
+                "list",
+                "--sort-by",
+                "-name",
+                "--limit",
+                "1",
+            ],
+        )
+        examples_result = runner.invoke(
+            cli,
+            [
+                "--json",
+                "examples",
+                "list",
+                "--dataset",
+                str(DATASET_ID),
+                "--sort-by",
+                "-created_at",
+                "--offset",
+                "1",
+                "--limit",
+                "1",
+            ],
+        )
+
+    assert datasets_result.exit_code == 0, datasets_result.output
+    assert [item["name"] for item in json.loads(datasets_result.output)] == ["zeta"]
+    assert client.list_datasets.call_args.kwargs["limit"] is None
+    assert examples_result.exit_code == 0, examples_result.output
+    assert [item["id"] for item in json.loads(examples_result.output)] == [
+        str(EXAMPLE_ID)
+    ]
+    assert client.list_examples.call_args.kwargs["limit"] is None
+    assert client.list_examples.call_args.kwargs["offset"] == 0
+
+
+def test_cloud_filter_only_page_stops_after_enough_survivors(runner) -> None:
+    """INVARIANT: only global sorting may require full cloud materialization."""
+    excluded = replica_example(attachment=None)
+    included = replica_example(SECOND_EXAMPLE_ID, attachment=None)
+
+    def examples():
+        yield excluded
+        yield included
+        raise AssertionError("filter-only pagination consumed beyond its final page")
+
+    with patch("langsmith.Client") as client_class:
+        client = client_class.return_value
+        client.list_examples.return_value = examples()
+
+        result = runner.invoke(
+            cli,
+            [
+                "--json",
+                "examples",
+                "list",
+                "--exclude",
+                str(EXAMPLE_ID),
+                "--limit",
+                "1",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert [item["id"] for item in json.loads(result.output)] == [
+        str(SECOND_EXAMPLE_ID)
+    ]
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        ["datasets", "list", "--limit", "0"],
+        ["datasets", "list", "--limit", "-1"],
+        ["examples", "list", "--limit", "0"],
+        ["examples", "list", "--limit", "-1"],
+        ["examples", "list", "--offset", "-1"],
+    ],
+)
+def test_replica_list_rejects_invalid_page_bounds(
+    runner, tmp_path: Path, arguments: list[str]
+) -> None:
+    """INVARIANT: pagination bounds cannot acquire backend-specific meanings."""
+    result = runner.invoke(
+        cli,
+        [
+            "--json",
+            *arguments,
+            "--source",
+            "local",
+            "--local-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "Invalid value" in result.output
+
+
+def test_pull_rejects_conflicting_version_selectors_and_same_repository(
+    runner, tmp_path: Path
+) -> None:
+    """INVARIANT: a transfer names one selection and two distinct stores."""
+    repository = DatasetReplicaRepository(create_store(str(tmp_path)))
+    repository.write_snapshot(replica_dataset(), DatasetVersion(as_of=VERSION_ONE), [])
+
+    conflicting_selection = runner.invoke(
+        cli,
+        [
+            "--json",
+            "datasets",
+            "pull",
+            str(DATASET_ID),
+            "--source",
+            "archive",
+            "--to",
+            "local",
+            "--archive-uri",
+            str(tmp_path),
+            "--local-dir",
+            str(tmp_path / "local"),
+            "--all-versions",
+            "--as-of",
+            VERSION_ONE.isoformat(),
+        ],
+    )
+    same_repository = runner.invoke(
+        cli,
+        [
+            "--json",
+            "datasets",
+            "pull",
+            str(DATASET_ID),
+            "--source",
+            "archive",
+            "--to",
+            "local",
+            "--archive-uri",
+            str(tmp_path),
+            "--local-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert conflicting_selection.exit_code == 1
+    assert "cannot be combined" in conflicting_selection.output
+    assert same_repository.exit_code == 1
+    assert "same repository" in same_repository.output
+
+
+@pytest.mark.parametrize(
+    "versions",
+    [
+        [
+            DatasetVersion(tags=["old"], as_of=VERSION_ONE),
+            DatasetVersion(tags=["new"], as_of=VERSION_TWO),
+        ],
+        [
+            DatasetVersion(tags=["new"], as_of=VERSION_TWO),
+            DatasetVersion(tags=["old"], as_of=VERSION_ONE),
+        ],
+    ],
+)
+def test_latest_version_selection_is_independent_of_backend_order(
+    versions: list[DatasetVersion],
+) -> None:
+    """INVARIANT: latest means max(as_of), not the backend's first row."""
+    assert _select_version(versions, "latest").as_of == VERSION_TWO

--- a/tests/test_dataset_replicas.py
+++ b/tests/test_dataset_replicas.py
@@ -95,6 +95,20 @@ def replica_example(
     )
 
 
+def _replace_manifest_and_head_digest(
+    store, head_key: str, manifest_index: int, manifest: dict
+) -> None:
+    """Test helper for reaching validation below the authenticated manifest."""
+    head = json.loads(store.get_text(head_key))
+    manifest_key = head["versions"][manifest_index]["manifest_key"]
+    manifest_text = json.dumps(manifest, sort_keys=True, separators=(",", ":"))
+    store.put_text(manifest_key, manifest_text)
+    head["versions"][manifest_index]["manifest_sha256"] = hashlib.sha256(
+        manifest_text.encode("utf-8")
+    ).hexdigest()
+    store.put_text(head_key, json.dumps(head, sort_keys=True, separators=(",", ":")))
+
+
 def test_repository_round_trips_sdk_models_and_attachment_bytes(tmp_path: Path):
     """INVARIANT: a replica preserves SDK fields and durable attachment bytes."""
     repository = DatasetReplicaRepository(create_store(str(tmp_path)))
@@ -185,6 +199,37 @@ def test_same_timestamp_rejects_different_snapshot_content(tmp_path: Path) -> No
     assert restored[0].inputs == {"question": "first"}
 
 
+def test_dataset_catalog_metadata_is_mutable_outside_version_identity(
+    tmp_path: Path,
+) -> None:
+    """INVARIANT: Dataset catalog state may change without rewriting a version."""
+    repository = DatasetReplicaRepository(create_store(str(tmp_path)))
+    version = DatasetVersion(tags=["prod"], as_of=VERSION_ONE)
+    repository.write_snapshot(
+        replica_dataset(), version, [replica_example(attachment=None)]
+    )
+    changed = replica_dataset().model_copy(
+        update={
+            "description": "Updated mutable catalog description",
+            "modified_at": VERSION_TWO + timedelta(days=1),
+        }
+    )
+
+    repeated = repository.write_snapshot(
+        changed, version, [replica_example(attachment=None)]
+    )
+
+    assert repeated.already_present is True
+    assert repository.read_dataset(str(DATASET_ID)).description == changed.description
+    assert (
+        repository.read_dataset(
+            str(DATASET_ID), as_of=VERSION_ONE.isoformat()
+        ).modified_at
+        == changed.modified_at
+    )
+    assert repository.read_examples(str(DATASET_ID))[0].inputs == {"question": "why?"}
+
+
 def test_snapshot_rejects_example_from_another_dataset(tmp_path: Path) -> None:
     """INVARIANT: every example in a snapshot belongs to its dataset ID."""
     repository = DatasetReplicaRepository(create_store(str(tmp_path)))
@@ -215,10 +260,10 @@ def test_corrupt_snapshot_artifact_fails_integrity_check(tmp_path: Path) -> None
     repository.write_snapshot(replica_dataset(), DatasetVersion(as_of=VERSION_ONE), [])
     head = json.loads(store.get_text(f"datasets/heads/{DATASET_ID}.json"))
     manifest = json.loads(store.get_text(head["versions"][0]["manifest_key"]))
-    store.put_bytes(manifest["dataset_key"], b"not parquet")
+    store.put_bytes(manifest["examples_key"], b"not parquet")
 
     with pytest.raises(DatasetReplicaIntegrityError, match="digest mismatch"):
-        repository.read_dataset(str(DATASET_ID))
+        repository.read_examples(str(DATASET_ID))
 
 
 def test_corrupt_attachment_fails_before_reader_is_returned(tmp_path: Path) -> None:
@@ -251,28 +296,55 @@ def test_manifest_cross_references_and_counts_are_enforced(tmp_path: Path) -> No
     manifest_key = head["versions"][0]["manifest_key"]
     manifest = json.loads(store.get_text(manifest_key))
     manifest["example_count"] = 2
-    store.put_text(manifest_key, json.dumps(manifest))
+    _replace_manifest_and_head_digest(store, head_key, 0, manifest)
 
     with pytest.raises(DatasetReplicaIntegrityError, match="example count"):
         repository.read_examples(str(DATASET_ID))
 
     manifest["dataset_id"] = "e4970850-07ca-460c-a1b9-5ea1ea2a60de"
-    store.put_text(manifest_key, json.dumps(manifest))
+    _replace_manifest_and_head_digest(store, head_key, 0, manifest)
     with pytest.raises(DatasetReplicaIntegrityError, match="dataset ID"):
         repository.read_dataset(str(DATASET_ID))
 
     manifest["dataset_id"] = str(DATASET_ID)
     manifest["version"]["as_of"] = VERSION_TWO.isoformat()
-    store.put_text(manifest_key, json.dumps(manifest))
+    _replace_manifest_and_head_digest(store, head_key, 0, manifest)
     with pytest.raises(DatasetReplicaIntegrityError, match="manifest version"):
         repository.read_dataset(str(DATASET_ID))
 
     manifest["version"]["as_of"] = VERSION_ONE.isoformat()
     manifest["example_count"] = 1
     manifest["attachment_count"] = 1
-    store.put_text(manifest_key, json.dumps(manifest))
+    _replace_manifest_and_head_digest(store, head_key, 0, manifest)
     with pytest.raises(DatasetReplicaIntegrityError, match="attachment count"):
         repository.read_examples(str(DATASET_ID))
+
+
+def test_head_authenticates_manifest_bytes(tmp_path: Path) -> None:
+    """INVARIANT: a version head authenticates the exact manifest it selected."""
+    store = create_store(str(tmp_path))
+    repository = DatasetReplicaRepository(store)
+    repository.write_snapshot(
+        replica_dataset(),
+        DatasetVersion(as_of=VERSION_ONE),
+        [replica_example(input_value="v1", attachment=None)],
+    )
+    repository.write_snapshot(
+        replica_dataset(),
+        DatasetVersion(as_of=VERSION_TWO),
+        [replica_example(input_value="v2", attachment=None)],
+    )
+    head = json.loads(store.get_text(f"datasets/heads/{DATASET_ID}.json"))
+    first_manifest_key = head["versions"][0]["manifest_key"]
+    second_manifest_key = head["versions"][1]["manifest_key"]
+    first_manifest = json.loads(store.get_text(first_manifest_key))
+    second_manifest = json.loads(store.get_text(second_manifest_key))
+    first_manifest["examples_key"] = second_manifest["examples_key"]
+    first_manifest["examples_sha256"] = second_manifest["examples_sha256"]
+    store.put_text(first_manifest_key, json.dumps(first_manifest))
+
+    with pytest.raises(DatasetReplicaIntegrityError, match="manifest digest"):
+        repository.read_examples(str(DATASET_ID), as_of=VERSION_ONE.isoformat())
 
 
 def test_malformed_head_fails_as_typed_schema_error(tmp_path: Path) -> None:
@@ -282,9 +354,9 @@ def test_malformed_head_fails_as_typed_schema_error(tmp_path: Path) -> None:
         f"datasets/heads/{DATASET_ID}.json",
         json.dumps(
             {
-                "schema_version": 1,
+                "schema_version": 2,
                 "dataset_id": str(DATASET_ID),
-                "dataset_name": "broken",
+                "dataset": replica_dataset().model_dump(mode="json"),
                 "latest_as_of": VERSION_ONE.isoformat(),
                 "versions": [],
             }
@@ -300,12 +372,13 @@ def test_untrusted_catalog_payload_shapes_fail_fast() -> None:
     version = {
         "as_of": VERSION_ONE.isoformat(),
         "manifest_key": "datasets/manifest.json",
+        "manifest_sha256": "d" * 64,
         "tags": ["latest"],
     }
     valid_head = {
-        "schema_version": 1,
+        "schema_version": 2,
         "dataset_id": str(DATASET_ID),
-        "dataset_name": "evaluation-set",
+        "dataset": replica_dataset().model_dump(mode="json"),
         "latest_as_of": VERSION_ONE.isoformat(),
         "versions": [version],
     }
@@ -314,7 +387,7 @@ def test_untrusted_catalog_payload_shapes_fail_fast() -> None:
     with pytest.raises(DatasetReplicaSchemaError, match="fields changed"):
         _parse_head("{}")
     with pytest.raises(DatasetReplicaError, match="Unsupported"):
-        _parse_head(json.dumps({**valid_head, "schema_version": 2}))
+        _parse_head(json.dumps({**valid_head, "schema_version": 3}))
     with pytest.raises(DatasetReplicaSchemaError, match="JSON object"):
         _parse_head(json.dumps({**valid_head, "versions": [1]}))
     with pytest.raises(DatasetReplicaSchemaError, match="unique and sorted"):
@@ -336,12 +409,9 @@ def test_untrusted_catalog_payload_shapes_fail_fast() -> None:
         _parse_head(json.dumps({**valid_head, "versions": [{**version, "tags": [1]}]}))
 
     valid_manifest = {
-        "schema_version": 1,
+        "schema_version": 2,
         "dataset_id": str(DATASET_ID),
-        "dataset_name": "evaluation-set",
         "version": {"as_of": VERSION_ONE.isoformat(), "tags": None},
-        "dataset_key": "datasets/dataset.parquet",
-        "dataset_sha256": "a" * 64,
         "examples_key": "datasets/examples.parquet",
         "examples_sha256": "b" * 64,
         "content_digest": "c" * 64,
@@ -550,6 +620,63 @@ def test_concurrent_divergent_same_version_cannot_publish_mixed_data(
     assert stored_inputs is not None
     stored_value = stored_inputs["question"]
     assert stored_value == winner * (250_000 if winner == "A" else 2)
+
+
+def test_equivalent_timestamp_offsets_have_one_canonical_identity(
+    tmp_path: Path,
+) -> None:
+    """INVARIANT: version identity is an instant, never timestamp spelling."""
+    repository = DatasetReplicaRepository(create_store(str(tmp_path)))
+    utc_version = DatasetVersion(as_of=VERSION_ONE)
+    offset_version = DatasetVersion(
+        as_of=VERSION_ONE.astimezone(timezone(timedelta(hours=2)))
+    )
+
+    first = repository.write_snapshot(
+        replica_dataset(), utc_version, [replica_example(attachment=None)]
+    )
+    repeated = repository.write_snapshot(
+        replica_dataset(), offset_version, [replica_example(attachment=None)]
+    )
+
+    assert first.already_present is False
+    assert repeated.already_present is True
+    assert [item.as_of for item in repository.list_versions(str(DATASET_ID))] == [
+        VERSION_ONE
+    ]
+
+
+class _ChunkOnlyAttachmentReader(io.BytesIO):
+    """Fail if publication tries to materialize an attachment in one read."""
+
+    def read(self, size: int | None = -1) -> bytes:
+        if size is None or size < 0:
+            raise AssertionError("attachment reads must be chunk bounded")
+        return super().read(size)
+
+
+def test_attachment_publication_streams_bounded_chunks(tmp_path: Path) -> None:
+    """INVARIANT: attachment size does not become an equivalent RAM allocation."""
+    example = replica_example(attachment=None).model_copy(
+        update={
+            "attachments": {
+                "large.bin": {
+                    "presigned_url": "https://cloud.invalid/large",
+                    "reader": _ChunkOnlyAttachmentReader(b"bounded-stream"),
+                    "mime_type": "application/octet-stream",
+                }
+            }
+        }
+    )
+    repository = DatasetReplicaRepository(create_store(str(tmp_path)))
+
+    repository.write_snapshot(
+        replica_dataset(), DatasetVersion(as_of=VERSION_ONE), [example]
+    )
+
+    restored = repository.read_examples(str(DATASET_ID), include_attachments=True)[0]
+    assert restored.attachments is not None
+    assert restored.attachments["large.bin"]["reader"].read() == b"bounded-stream"
 
 
 def test_sdk_contract_drift_fails_before_snapshot_publication(
@@ -847,6 +974,86 @@ def test_archive_snapshot_can_be_pulled_to_local(tmp_path: Path):
     assert results[0].already_present is False
     assert restored.attachments is not None
     assert restored.attachments["diagram.png"]["reader"].read() == b"diagram-bytes"
+
+
+def test_selected_version_transfer_synchronizes_unique_tag_pointers(
+    tmp_path: Path,
+) -> None:
+    """INVARIANT: a LangSmith version tag resolves to at most one local version."""
+    archive = tmp_path / "archive"
+    local = tmp_path / "local"
+    source = DatasetReplicaRepository(create_store(str(archive)))
+    destination = DatasetReplicaRepository(create_store(str(local)))
+    destination.write_snapshot(
+        replica_dataset(),
+        DatasetVersion(tags=["prod"], as_of=VERSION_ONE),
+        [replica_example(input_value="v1", attachment=None)],
+    )
+    source.write_snapshot(
+        replica_dataset(),
+        DatasetVersion(tags=None, as_of=VERSION_ONE),
+        [replica_example(input_value="v1", attachment=None)],
+    )
+    source.write_snapshot(
+        replica_dataset(),
+        DatasetVersion(tags=["prod"], as_of=VERSION_TWO),
+        [replica_example(input_value="v2", attachment=None)],
+    )
+
+    pull_dataset(
+        client=None,
+        dataset_name_or_id=str(DATASET_ID),
+        source=ReplicaSource.ARCHIVE,
+        destination=ReplicaDestination.LOCAL,
+        as_of="prod",
+        all_versions=False,
+        archive_uri=str(archive),
+        local_directory=str(local),
+    )
+
+    versions = destination.list_versions(str(DATASET_ID))
+    assert [(item.as_of, item.tags) for item in versions] == [
+        (VERSION_TWO, ["prod"]),
+        (VERSION_ONE, None),
+    ]
+    assert destination.read_examples(str(DATASET_ID), as_of="prod")[0].inputs == {
+        "question": "v2"
+    }
+
+
+def test_global_offline_list_skips_histories_without_requested_version(
+    runner, tmp_path: Path
+) -> None:
+    """INVARIANT: independent histories cannot abort a global as-of query."""
+    repository = DatasetReplicaRepository(create_store(str(tmp_path)))
+    repository.write_snapshot(
+        replica_dataset(),
+        DatasetVersion(as_of=VERSION_ONE),
+        [replica_example(attachment=None)],
+    )
+    unrelated_id = UUID("e4970850-07ca-460c-a1b9-5ea1ea2a60de")
+    unrelated = replica_dataset().model_copy(
+        update={"id": unrelated_id, "name": "only-newer"}
+    )
+    repository.write_snapshot(unrelated, DatasetVersion(as_of=VERSION_TWO), [])
+
+    result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "examples",
+            "list",
+            "--source",
+            "local",
+            "--local-dir",
+            str(tmp_path),
+            "--as-of",
+            VERSION_ONE.isoformat(),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert [item["id"] for item in json.loads(result.output)] == [str(EXAMPLE_ID)]
 
 
 def test_same_name_datasets_are_ambiguous_instead_of_overwriting(tmp_path: Path):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -246,6 +246,18 @@ def test_datasets_get_json(runner):
         assert "id" in data
 
 
+def test_datasets_get_cloud_name_uses_the_same_identity_facade(runner):
+    """INVARIANT: cloud and replica dataset get both accept ID or name."""
+    with patch("langsmith.Client") as client_class:
+        client = client_class.return_value
+        client.read_dataset.return_value = create_dataset(name="my-dataset")
+
+        result = runner.invoke(cli, ["--json", "datasets", "get", "my-dataset"])
+
+    assert result.exit_code == 0
+    client.read_dataset.assert_called_once_with(dataset_name="my-dataset")
+
+
 def test_datasets_get_with_fields(runner):
     """INVARIANT: --fields should limit returned fields."""
     with patch("langsmith.Client") as MockClient:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -8,10 +8,12 @@ All test data is created using real LangSmith Pydantic model instances from
 langsmith.schemas, ensuring compatibility with the actual SDK.
 """
 
-from langsmith_cli.main import cli
-from unittest.mock import patch
+from datetime import datetime, timezone
 import json
+from unittest.mock import patch
+
 from conftest import create_example, create_run, strip_ansi
+from langsmith_cli.main import cli
 
 
 def test_examples_list(runner):
@@ -417,7 +419,7 @@ def test_examples_get_with_output(runner, tmp_path):
 
 
 def test_examples_get_with_as_of(runner):
-    """INVARIANT: --as-of should be passed to the SDK."""
+    """INVARIANT: cloud --as-of is parsed to the SDK's datetime contract."""
     with patch("langsmith.Client") as MockClient:
         mock_client = MockClient.return_value
 
@@ -440,8 +442,28 @@ def test_examples_get_with_as_of(runner):
         )
         assert result.exit_code == 0
         mock_client.read_example.assert_called_once_with(
-            "3442bd7c-27a2-437b-a38c-f278e455d87b", as_of="2024-01-01T00:00:00Z"
+            "3442bd7c-27a2-437b-a38c-f278e455d87b",
+            as_of=datetime(2024, 1, 1, tzinfo=timezone.utc),
         )
+
+
+def test_examples_get_rejects_cloud_version_tag_without_dataset_context(runner):
+    """INVARIANT: a tag is never passed to an SDK parameter requiring datetime."""
+    with patch("langsmith.Client") as client_class:
+        result = runner.invoke(
+            cli,
+            [
+                "examples",
+                "get",
+                "3442bd7c-27a2-437b-a38c-f278e455d87b",
+                "--as-of",
+                "production",
+            ],
+        )
+        client_class.assert_not_called()
+
+    assert result.exit_code == 1
+    assert "ISO timestamp" in result.output
 
 
 def test_examples_create(runner):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -16,6 +16,15 @@ from conftest import create_example, create_run, strip_ansi
 from langsmith_cli.main import cli
 
 
+def test_examples_list_help_uses_a_valid_sort_example(runner):
+    """INVARIANT: shared option help never recommends an invalid field."""
+    result = runner.invoke(cli, ["examples", "list", "--help"])
+
+    assert result.exit_code == 0
+    assert "'-created_at'" in result.output
+    assert "'-name'" not in result.output
+
+
 def test_examples_list(runner):
     """INVARIANT: Examples list should return examples with correct structure."""
     with patch("langsmith.Client") as MockClient:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -479,6 +479,12 @@ class TestParseJsonString:
             parse_json_string("invalid", "custom_field")
         assert "custom_field" in str(exc_info.value)
 
+    @pytest.mark.parametrize("value", ["[]", '"text"', "42", "null"])
+    def test_rejects_non_object_json(self, value):
+        """INVARIANT: SDK object options never carry an arbitrary JSON root."""
+        with pytest.raises(click.BadParameter, match="must be a JSON object"):
+            parse_json_string(value, "metadata")
+
 
 class TestParseCommaSeparatedList:
     """Tests for parse_comma_separated_list function."""


### PR DESCRIPTION
Today, LangSmith Dataset workflows stop at the cloud boundary: users cannot preserve an exact evaluation version in S3 or keep a disposable offline working copy behind the same CLI. This PR adds read-only Dataset replicas for archive and local sources, so the same Dataset IDs, Examples, versions, tags, schemas, metadata, and attachment bytes can be transferred and queried without inventing a parallel collection model.

Linear: [ENG-6997](https://linear.app/tapinlive/issue/ENG-6997/unify-langsmith-datasets-and-traces-across-cloud-archive-and-local)

## Why this is needed

A trace archive alone cannot reproduce an evaluation workflow. Exact Example membership, deletions, splits, reference outputs, schemas, transformations, version tags, and attachment bytes must move together. Before this PR, offline work required backend-specific scripts whose identity and version semantics could drift from LangSmith.

| Capability | Before | After |
|---|---|---|
| Dataset reads | Cloud only | `--source cloud|archive|local` |
| Transfer | One-off export/import scripts | `datasets pull --source … --to …` |
| Local work | No Dataset backend | Disposable DuckDB-over-Parquet replica |
| Durable retention | No exact Dataset archive | Immutable Example-version manifests and attachment blobs |
| Identity | Script/name dependent | Stable LangSmith Dataset and Example IDs; names remain labels |
| Version selection | Cloud API only | `latest`, tag, ISO timestamp, or all versions |
| Concurrency | Undefined | Content-addressed objects plus CAS head |
| Automation | Backend-specific glue | One sparse `--json` CLI facade |

## Product and data model

Cloud remains the sole mutation authority. Archive is the durable replica; local is an accumulating, disposable working cache.

```text
                    mutate
                      │
                      ▼
            ┌──────────────────┐
            │ LangSmith cloud  │
            │ source authority │
            └────────┬─────────┘
                     │ exact DatasetVersion pull
            ┌────────┴────────┐
            ▼                 ▼
   ┌────────────────┐  ┌────────────────┐
   │ archive / S3   │─▶│ local cache    │
   │ durable replica│  │ intermediate   │
   └────────────────┘  └────────────────┘
```

The implementation follows LangSmith’s model wholesale:

- `DatasetVersion` freezes exact Example membership/content and attachments.
- The complete `Dataset` envelope—name, description, schemas, metadata, counts, and timestamps—is mutable catalog state in the CAS head. It is not falsely treated as historical version content.
- Version tags are movable pointers and may have at most one owner.
- Dataset/Example SDK models and operation-specific contracts are strict Pydantic models. Wire envelopes are validated typed schemas.
- `source_run_id` remains optional lineage; linked trace transfer is separate and cannot invalidate a Dataset replica.

Archive/local `datasets get --as-of` validates that the requested version exists, then returns the current Dataset envelope, matching the cloud API’s lack of historical Dataset-metadata reads.

## User-facing capability

```bash
# Freeze the latest cloud Dataset for offline work
langsmith-cli --json datasets pull my-evals --to local

# Preserve complete history in the archive
langsmith-cli --json datasets pull my-evals --to archive --all-versions

# Hydrate local work without contacting LangSmith
langsmith-cli --json datasets pull my-evals \
  --source archive --to local --as-of baseline

# Query through the same facade
langsmith-cli --json datasets get my-evals --source local --as-of baseline
langsmith-cli --json examples list --dataset my-evals --source local
langsmith-cli --json datasets versions my-evals --source local
langsmith-cli --json datasets status --source local
```

Existing commands still default to cloud. Unsupported source-specific behavior fails explicitly instead of being ignored.

## Schema-v2 storage and publication

```text
<replica-root>/
  datasets/
    heads/<dataset-id>.json          # current Dataset + version pointers
    <dataset-id>/versions/<sha256(canonical-UTC-as-of)>/
      objects/examples-<sha256>.parquet
      manifests/<publication-uuid>.json
    blobs/<attachment-sha256>
  .locks/<head-key-sha256>.lock     # local only
```

Examples stream through 1,000-row Pydantic batches into a temporary disk-backed DuckDB database with a dataset-specific 256 MiB memory limit, then into Zstd Parquet. Attachments stream in fixed 1 MiB chunks into content-addressed files; expiring signed URLs are never retained as content.

Only the CAS head makes a version reachable. Each version pointer authenticates the exact manifest bytes by SHA-256. Readers verify the manifest, Parquet/blob digests, row counts, Dataset/Example cross-references, duplicate IDs, and the canonical Example/attachment digest before yielding any SDK Example.

Schema v2 intentionally replaces the draft schema-v1 layout; preserving unpublished local caches was explicitly out of scope.

## Explicit invariants

| Invariant | Enforcement point | Falsifying test |
|---|---|---|
| `(Dataset ID, canonical UTC as_of)` identifies one Example/attachment snapshot | Canonical streamed digest before idempotent return | Same instant/different spelling collapses; different content conflicts |
| Dataset metadata remains mutable catalog state | Pydantic Dataset payload in CAS head, excluded from version digest | Metadata-only refresh is idempotent and visible |
| One tag resolves to at most one version | Atomic tag movement inside candidate head plus source tag sync | Selected-version transfer moves `prod` from V1 to V2 |
| A head authenticates its exact manifest | `manifest_sha256` in each head version | Redirecting V1 manifest to valid V2 Parquet fails |
| Independent concurrent versions are never lost | Reread/merge bounded CAS loop | Concurrent T1/T2 both remain addressable |
| Winning head cannot expose losing bytes | Content-addressed Parquet, unique manifests, CAS | Real two-writer divergent race |
| Every Example belongs to its Dataset and IDs are unique | DuckDB primary key plus pre/read cross-reference validation | Foreign and duplicate IDs fail |
| Reads never yield partially validated data | Complete relation validation before generator yield | Corrupt digest/count/cross-reference tests |
| Publication memory is bounded by configured staging | Streaming iterators, fixed batches/chunks, disk-backed DuckDB | Chunk-only reader and 50k RSS measurement |
| Global offline history queries are independent | Missing-version skip only for global list | Unrelated newer Dataset cannot abort matching history |
| SDK fields cannot drift silently | Runtime exact field-set assertion | Injected future SDK field fails before publication |

## Red-team failures fixed

| Reproduced failure | Before | After |
|---|---|---|
| Metadata-only cloud refresh | Same version raised `DatasetReplicaConflictError` | Mutable head refresh; version remains idempotent |
| Selected transfer after tag move | V1 and V2 both owned `prod`; lookup ambiguous | V1 cleared, V2 uniquely owns `prod` |
| Manifest substitution | Requesting V1 returned valid V2 content | Manifest digest mismatch fails before read |
| Equivalent timestamp offsets | Second write succeeded, then head became unreadable | One canonical aware-UTC identity |
| Global `examples list --as-of` | Unrelated history aborted the query | Ineligible histories are skipped |
| Eager publication memory | Cloud iterator plus serialized list plus attachment bytes | Streamed pages, Pydantic batches, disk staging, chunked blobs |

## Uniform CLI semantics and DRY hardening

A final public-CLI red-team pass found that the storage protocol was exact but list behavior could still drift by backend. Archive/local applied `limit` or `offset` before generic filtering and sorting; cloud did the same through SDK pagination. A valid later match could disappear, sorting only reordered one arbitrary page, and exclusions could return a short page.

This strengthens existing facade invariants rather than adding a second query language:

```text
cloud:   SDK predicates ─┐
                        ├─> shared client operations ─> offset/limit once
replica: typed predicates┘
```

| Concern | Before | After |
|---|---|---|
| Dataset/example option logic | Parallel command branches with repeated metadata/split/paging code | Strict Pydantic `DatasetListQuery` / `ExampleListQuery` over one generic pipeline |
| Client-side filtering | Applied after source page | Applied before the final page on every source |
| Cloud filter-only scans | Entire eligible iterator materialized | Stops after `offset + limit` survivors |
| Global sort | Sorted only the fetched page | Sorts the complete eligible set, then pages |
| Version selection | Repository and transfer had separate algorithms; transfer assumed newest-first | One Pydantic selector; `latest = max(as_of)` independent of backend order |
| Historical tag read | Could authenticate up to V manifests to select one | Select from authenticated head metadata, then read exactly 1 manifest |
| Invalid bounds | Zero/negative values acquired SDK/slice-specific meanings | `limit >= 1`, `offset >= 0` at the Click boundary |
| Transfer selectors | `--all-versions` silently ignored a non-default `--as-of` | Mutually exclusive; same physical source/target also fails |
| JSON object options | Arrays/scalars reached SDK or local dictionary logic | Non-object roots fail as a structured CLI parameter error |
| Shared glob/regex help | Two implementations and `examples --sort-by` advertised invalid `-name` | One glob/regex implementation; help derives a valid field example |

### Additional enforced invariants

| Invariant | Enforcement point | Falsifying test |
|---|---|---|
| Filter → sort → offset/limit exactly once | Generic `ReplicaListQuery` pipeline | Archive/local and cloud commands select the same final page |
| Only global sort materializes all cloud rows | Lazy cloud collector stops after enough survivors | Generator raises if filter-only pagination over-consumes |
| `latest` is temporal, not positional | Shared `select_version()` uses `max(as_of)` | Ascending and descending backend orders select the same version |
| One transfer has one selector and two stores | Early service validation plus normalized `base_uri` comparison | Combined selectors and aliased directories fail |
| Object-valued options remain objects | Shared JSON-object parser | Array, scalar, and null roots fail before any backend call |

### Practical proof

| Measurement | Before | After | Direction |
|---|---:|---:|---|
| Adversarial focused cases passing | 1 / 14 | 14 / 14 | Higher is better |
| Public archive/local CLI matrix | — | 43 / 43 | Higher is better |
| Manifest objects read for one selected version | Up to V | 1 | Lower is better |
| Filter-only cloud survivors consumed | Unbounded | At most `offset + limit` | Lower is better |
| Normal CLI import median, 20 warm samples | 273.8 ms | 273.9 ms | Neutral / flat |

The 43-case matrix used real local files, DuckDB, Parquet, strict SDK models, attachments, and both archive→local and local→archive transfers. It covered dataset/example IDs, exact/contains/glob/regex/metadata/split filters, sort, offset, limit, exclude, fields, count, JSONL/CSV/YAML output, get/versions/status, selected/all/repeated transfers, exact round-trip content, and expected rejection paths.

## Measured impact

All measurements used the real local filesystem, DuckDB, Pydantic SDK models, and repository/service paths—not mocked storage.

### Concurrency

| Scenario | Before hardening | Schema-v2 result | Lower is better |
|---|---:|---:|---|
| Divergent same-version mixed/corrupt outcomes | 38 / 40 | 0 / 30 | Yes |
| Lost independent versions | Reproduced | 0 / 30 | Yes |

### Representative 10,000-Example local replica

| Metric | Observed result |
|---|---:|
| Equivalent compact JSONL | 3.767 MiB |
| Complete replica objects | 0.041 MiB |
| Size reduction | 98.9% |
| Streamed write | 1.868 s |
| Read and reconstruct all 10,000 Examples | 0.186 s |

### Adversarial 50,000-Example memory fixture

Each Example carried a unique ~512-byte input. Peak RSS includes Python, Pydantic, DuckDB, and filesystem staging.

| Metric | Before red-team fix | After | Lower is better |
|---|---:|---:|---|
| Peak RSS | 489,824 KiB | 352,140 KiB | Yes (28.1% lower) |
| Python retention model | Full SDK list + full serialized list | Iterator + 1,000-row batch | — |
| DuckDB staging | In-memory table | Disk-backed, 256 MiB cap | — |

## Verification

- **1,463 passed** in the complete pytest suite in 118.72 seconds.
- **465 passed** in the broader Dataset/Example/filter/archive invariant suite.
- **43 / 43 passed** in the real public-CLI option and transfer matrix.
- Ruff, Ruff format, full Pyright, pre-commit, and `git diff --check` pass.
- `uv build` produced the 0.11.1 sdist and wheel; the wheel contains the Pydantic query and version-selection modules.
- Normal startup did not import either operation-only Pydantic module; median import time stayed flat at **273.8 ms → 273.9 ms** over 20 warm samples.
- Exact-head GitHub CI for commit `70973f5` is green: build, lint, Python 3.12, Python 3.13 on Ubuntu/macOS/Windows, Codecov patch, dependency review, and aggregate checks.

## Evidence caveats

- No live cloud pull was run because `LANGSMITH_API_KEY` is unavailable. Cloud boundaries use real installed SDK models and method signatures.
- No live S3 bucket was available. Local object storage is exercised end to end; S3 binary methods and conditional `IfNoneMatch`/`IfMatch` publication are covered by boto3-shaped contract tests.
- An explicit global `--sort-by` must materialize the complete cloud-eligible set because the installed SDK exposes no server-side ordering option. Filter-only pages stream and stop after enough survivors.

## Intentionally deferred

- Accumulating DuckDB-over-Parquet trace inventory.
- Optional linked-`source_run_id` trace materialization.
- Multi-source union, precedence, and deduplication.
- Writable local/archive Dataset forks or upload into a new cloud lineage.

These have separate identity and conflict invariants. This PR remains independently useful: exact Dataset versions can be retained, moved, and queried through one CLI without reimplementing LangSmith mutation semantics.