### PR TITLE
Bound archive sync memory by constants, not by project-day size

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "boto3>=1.35.0",
     "click>=8.0",
     "duckdb>=1.4.0",
+    "pyarrow>=17.0.0",
     "langdetect>=1.0.9",
     "langsmith>=0.8.5",
     "platformdirs>=4.0",

--- a/src/langsmith_cli/archive/duckdb.py
+++ b/src/langsmith_cli/archive/duckdb.py
@@ -28,6 +28,20 @@ def duckdb_memory_limit() -> str:
     return configured or DUCKDB_MEMORY_LIMIT
 
 
+# DuckDB defaults its thread count to the HOST's cores, not the container's CPU quota
+# (8 threads inside a 1-CPU pod). Each thread holds its own read/write buffers — for
+# JSON staging up to maximum_object_size per thread — so oversubscribed threads
+# multiply the working set until real project-days OOM. The pod owner knows its CPU
+# quota; the library does not, so this is an operator override with DuckDB's own
+# default left untouched when unset.
+DUCKDB_THREADS_ENV = "LANGSMITH_ARCHIVE_DUCKDB_THREADS"
+
+
+def duckdb_threads() -> int | None:
+    configured = os.environ.get(DUCKDB_THREADS_ENV, "").strip()
+    return int(configured) if configured else None
+
+
 # Trace rows carry multi-megabyte JSON text (inputs/outputs), so DuckDB's default
 # row-COUNT-sized row groups buffer gigabytes before flushing, and that buffer cannot
 # spill (real project-days OOMed a 1 GiB bound in-cluster). Bounding row groups by
@@ -60,6 +74,9 @@ def configure_duckdb_resources(
     # snapshot_rank. Tested by
     # test_duckdb_connections_do_not_preserve_insertion_order.
     connection.execute("SET preserve_insertion_order = false")
+    threads = duckdb_threads()
+    if threads is not None:
+        connection.execute("SET threads = ?", [threads])
 
 
 @contextmanager

--- a/src/langsmith_cli/archive/sync.py
+++ b/src/langsmith_cli/archive/sync.py
@@ -155,31 +155,100 @@ def _serialize_run_line(run: Run) -> bytes:
     return line.encode("utf-8") + b"\n"
 
 
+def _uuid_text(value: Any) -> str | None:
+    """Canonical text for an id however the source chunk yielded it.
+
+    arrow.uuid extension chunks yield uuid.UUID instances from to_pylist(), plain
+    fixed-binary chunks yield bytes, and text raw already yields strings.
+    """
+    import uuid
+
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    if isinstance(value, uuid.UUID):
+        return str(value)
+    return str(uuid.UUID(bytes=bytes(value)))
+
+
+def _storage_type(data_type: Any) -> Any:
+    """Portable Parquet type for archive interchange.
+
+    Extension types (DuckDB's arrow.json, arrow.uuid) collapse to their storage —
+    recursively, because real trace fields nest them inside maps and structs
+    (observed in-cluster: map<string, extension<arrow.json>> vs map<string, string>
+    refused to unify). UUIDs (DuckDB infers them from UUID-shaped JSON strings and
+    Parquet renders them as 16-byte fixed binary) become canonical text: a
+    re-serialized binares column loses the UUID annotation, and readers then match
+    nothing when comparing ids to strings.
+    """
+    import pyarrow
+
+    if isinstance(data_type, pyarrow.BaseExtensionType):
+        return _storage_type(data_type.storage_type)
+    if pyarrow.types.is_fixed_size_binary(data_type) and data_type.byte_width == 16:
+        return pyarrow.string()
+    if pyarrow.types.is_list(data_type):
+        return pyarrow.list_(_storage_type(data_type.value_type))
+    if pyarrow.types.is_large_list(data_type):
+        return pyarrow.large_list(_storage_type(data_type.value_type))
+    if pyarrow.types.is_map(data_type):
+        return pyarrow.map_(
+            _storage_type(data_type.key_type), _storage_type(data_type.item_type)
+        )
+    if pyarrow.types.is_struct(data_type):
+        return pyarrow.struct(
+            [
+                pyarrow.field(
+                    child.name, _storage_type(child.type), nullable=child.nullable
+                )
+                for child in data_type
+            ]
+        )
+    return data_type
+
+
 def _storage_schema(schema: Any) -> Any:
-    """Replace extension-typed fields (e.g. DuckDB's arrow.json) with their storage type."""
     import pyarrow
 
     return pyarrow.schema(
-        field.with_type(field.type.storage_type)
-        if isinstance(field.type, pyarrow.BaseExtensionType)
-        else field
-        for field in schema
+        field.with_type(_storage_type(field.type)) for field in schema
     )
+
+
+def _storage_column(column: Any, target_type: Any) -> Any:
+
+    import pyarrow
+
+    if column.type.equals(target_type):
+        return column
+    if pyarrow.types.is_string(target_type) and (
+        pyarrow.types.is_fixed_size_binary(column.type)
+        or (
+            isinstance(column.type, pyarrow.BaseExtensionType)
+            and pyarrow.types.is_fixed_size_binary(column.type.storage_type)
+        )
+    ):
+        formatted = [_uuid_text(value) for value in column.to_pylist()]
+        return pyarrow.chunked_array([pyarrow.array(formatted, type=target_type)])
+    if isinstance(column.type, pyarrow.BaseExtensionType):
+        column = pyarrow.chunked_array(
+            [chunk.storage for chunk in column.chunks],
+            type=column.type.storage_type,
+        )
+    return column.cast(target_type)
 
 
 def _storage_table(table: Any) -> Any:
     import pyarrow
 
-    columns = []
-    for index, field in enumerate(table.schema):
-        column = table.column(index)
-        if isinstance(field.type, pyarrow.BaseExtensionType):
-            column = pyarrow.chunked_array(
-                [chunk.storage for chunk in column.chunks],
-                type=field.type.storage_type,
-            )
-        columns.append(column)
-    return pyarrow.table(columns, schema=_storage_schema(table.schema))
+    schema = _storage_schema(table.schema)
+    columns = [
+        _storage_column(table.column(index), field.type)
+        for index, field in enumerate(schema)
+    ]
+    return pyarrow.table(columns, schema=schema)
 
 
 def _combine_parquet_parts(part_paths: list[Path], target: Path) -> None:
@@ -384,7 +453,7 @@ def _conform_table(table: Any, unified: Any) -> Any:
     arrays = []
     for field in unified:
         if field.name in table.schema.names:
-            arrays.append(table.column(field.name).cast(field.type))
+            arrays.append(_storage_column(table.column(field.name), field.type))
         else:
             arrays.append(pyarrow.nulls(table.num_rows, type=field.type))
     return pyarrow.table(arrays, schema=unified)
@@ -413,7 +482,11 @@ def _canonicalize_streaming(
         for group_index in range(source_file.num_row_groups):
             column = source_file.read_row_group(group_index, columns=["id"])
             ids.extend(
-                value for value in column.column("id").to_pylist() if value is not None
+                text
+                for text in (
+                    _uuid_text(value) for value in column.column("id").to_pylist()
+                )
+                if text is not None
             )
         if len(ids) != len(set(ids)):
             raise ValueError(f"Snapshot contains duplicate run IDs: {uri}")

--- a/src/langsmith_cli/archive/sync.py
+++ b/src/langsmith_cli/archive/sync.py
@@ -436,8 +436,12 @@ def _canonicalize_streaming(
             for group_index in range(source_file.num_row_groups):
                 table = _storage_table(source_file.read_row_group(group_index))
                 if winner_ids is not None and index != winner_index:
-                    keep = pyarrow.compute.invert(
-                        pyarrow.compute.is_in(table.column("id"), value_set=winner_ids)
+                    # pyarrow's bundled stubs omit several pyarrow.compute kernels.
+                    contained = pyarrow.compute.is_in(  # pyright: ignore[reportAttributeAccessIssue]
+                        table.column("id"), value_set=winner_ids
+                    )
+                    keep = pyarrow.compute.invert(  # pyright: ignore[reportAttributeAccessIssue]
+                        contained
                     )
                     table = table.filter(pyarrow.compute.fill_null(keep, True))
                 if table.num_rows:

--- a/src/langsmith_cli/archive/sync.py
+++ b/src/langsmith_cli/archive/sync.py
@@ -119,47 +119,187 @@ def _new_manifest(
     )
 
 
+# Bounded staging: the JSON reader's reconstruction buffers and string chunks scale
+# with the file it scans, so converting a whole project-day at once OOMed real days
+# even at a raised 2 GiB DuckDB bound. One day is staged as JSONL pieces of at most
+# this many bytes and converted piece-by-piece; the conversion working set then
+# scales with this budget, not the day. A single document larger than the budget
+# still gets its own piece (maximum_object_size bounds any one document).
+# Tested by test_oversized_days_are_staged_and_converted_in_bounded_pieces.
+STAGING_PIECE_MAX_BYTES = 128 * 1024 * 1024
+
+# The JSON reader sizes reconstruction buffers to maximum_object_size PER THREAD, so
+# a blanket 100 MiB ceiling costs hundreds of MiB whether or not a large document is
+# present (observed in-cluster: 100.9 MiB allocations exhausting a 1 GiB bound). The
+# CLI writes every staging line itself and therefore knows each piece's true largest
+# document; the reader is told exactly that, with a floor for margin.
+_READ_JSON_SOURCE = "read_json_auto({path}, maximum_object_size={max_object_size})"
+_MIN_MAX_OBJECT_SIZE = 16 * 1024 * 1024
+
+
+def _serialize_run_line(run: Run) -> bytes:
+    payload = run.model_dump(mode="python")
+    # Pre-serialize nested payload fields as JSON text so read_json_auto infers
+    # flat VARCHAR columns — the same shape Bulk Export v2 produces and
+    # canonicalization already unifies. STRUCT inference materializes
+    # payload-shaped nested columns whose memory scales with payload complexity;
+    # a real project-day OOMed a 2.5 GiB DuckDB bound here.
+    # Tested by test_runs_snapshot_stores_payloads_as_text_not_inferred_structs.
+    for column in ARCHIVE_JSON_COLUMNS:
+        value = payload.get(column)
+        if value is not None:
+            payload[column] = json.dumps(
+                value, ensure_ascii=False, default=_archive_json_default
+            )
+    line = json.dumps(payload, ensure_ascii=False, default=_archive_json_default)
+    return line.encode("utf-8") + b"\n"
+
+
+def _storage_schema(schema: Any) -> Any:
+    """Replace extension-typed fields (e.g. DuckDB's arrow.json) with their storage type."""
+    import pyarrow
+
+    return pyarrow.schema(
+        field.with_type(field.type.storage_type)
+        if isinstance(field.type, pyarrow.BaseExtensionType)
+        else field
+        for field in schema
+    )
+
+
+def _storage_table(table: Any) -> Any:
+    import pyarrow
+
+    columns = []
+    for index, field in enumerate(table.schema):
+        column = table.column(index)
+        if isinstance(field.type, pyarrow.BaseExtensionType):
+            column = pyarrow.chunked_array(
+                [chunk.storage for chunk in column.chunks],
+                type=field.type.storage_type,
+            )
+        columns.append(column)
+    return pyarrow.table(columns, schema=_storage_schema(table.schema))
+
+
+def _combine_parquet_parts(part_paths: list[Path], target: Path) -> None:
+    """
+    Concatenate Parquet parts into one file, one row group at a time.
+
+    Pieces are inferred independently, so a column that is all-null in one piece may
+    carry a different type there (DuckDB writes it as the arrow.json extension type
+    while pieces with values carry plain string). Extension types are stripped to
+    their storage type — lossless, the storage IS the JSON text — before permissive
+    schema unification, and every row group is cast to the unified schema. Working
+    memory is bounded by one decoded row group (parts are written with byte-bounded
+    row groups), not by the day.
+    """
+    import contextlib
+
+    import pyarrow
+    import pyarrow.parquet
+
+    with contextlib.ExitStack() as stack:
+        part_files = [
+            stack.enter_context(pyarrow.parquet.ParquetFile(str(part)))
+            for part in part_paths
+        ]
+        unified = pyarrow.unify_schemas(
+            [_storage_schema(part.schema_arrow) for part in part_files],
+            promote_options="permissive",
+        )
+        writer = stack.enter_context(
+            pyarrow.parquet.ParquetWriter(str(target), unified, compression="zstd")
+        )
+        for part in part_files:
+            for group_index in range(part.num_row_groups):
+                table = _storage_table(part.read_row_group(group_index))
+                writer.write_table(table.select(unified.names).cast(unified))
+
+
+def _read_json_source(piece_path: Path, max_line_bytes: int) -> str:
+    return _READ_JSON_SOURCE.format(
+        path=_sql_string(str(piece_path)),
+        max_object_size=max(max_line_bytes * 2, _MIN_MAX_OBJECT_SIZE),
+    )
+
+
 def _write_runs_parquet(
     client: RunsExportClient, manifest: ArchiveManifest, target: Path
 ) -> int:
     filter_ = f'lt(start_time, "{manifest.window_end.isoformat()}")'
-    # Close the JSONL before DuckDB opens it. Windows does not guarantee that a
-    # named temporary file can be reopened while Python still holds its handle.
-    rows_path = target.with_suffix(".jsonl")
-    with rows_path.open(mode="w", encoding="utf-8") as rows:
-        run_count = 0
+    piece_paths: list[Path] = []
+    piece_max_lines: list[int] = []
+    part_paths: list[Path] = []
+    run_count = 0
+    piece = None
+    piece_bytes = 0
+    try:
         for run in client.list_runs(
             project_id=manifest.project_id,
             start_time=manifest.window_start,
             filter=filter_,
             limit=None,
         ):
-            rows.write(
-                json.dumps(
-                    run.model_dump(mode="python"),
-                    ensure_ascii=False,
-                    default=_archive_json_default,
-                )
-            )
-            rows.write("\n")
+            encoded = _serialize_run_line(run)
+            if piece is None or (
+                piece_bytes and piece_bytes + len(encoded) > STAGING_PIECE_MAX_BYTES
+            ):
+                if piece is not None:
+                    piece.close()
+                piece_path = target.with_suffix(f".{len(piece_paths)}.jsonl")
+                # Binary mode: piece budgets are byte-exact, and DuckDB reopens the
+                # file, which Windows only guarantees after our handle closes.
+                piece = piece_path.open(mode="wb")
+                piece_paths.append(piece_path)
+                piece_max_lines.append(0)
+                piece_bytes = 0
+            piece.write(encoded)
+            piece_bytes += len(encoded)
+            piece_max_lines[-1] = max(piece_max_lines[-1], len(encoded))
             run_count += 1
+        if piece is not None:
+            piece.close()
+            piece = None
 
-    try:
         with archive_duckdb_connection(target.parent) as connection:
-            if run_count:
-                connection.execute(
-                    "COPY (SELECT * FROM read_json_auto("
-                    f"{_sql_string(str(rows_path))}, maximum_object_size=104857600)) "
-                    f"TO {_sql_string(str(target))} " + ARCHIVE_PARQUET_COPY_OPTIONS
-                )
-            else:
+            if not run_count:
                 connection.execute(
                     "COPY (SELECT CAST(NULL AS VARCHAR) AS id WHERE false) "
                     f"TO {_sql_string(str(target))} " + ARCHIVE_PARQUET_COPY_OPTIONS
                 )
+            elif len(piece_paths) == 1:
+                source = _read_json_source(piece_paths[0], piece_max_lines[0])
+                connection.execute(
+                    f"COPY (SELECT * FROM {source}) "
+                    f"TO {_sql_string(str(target))} " + ARCHIVE_PARQUET_COPY_OPTIONS
+                )
+            else:
+                for piece_path, max_line in zip(piece_paths, piece_max_lines):
+                    part_path = piece_path.with_suffix(".part")
+                    source = _read_json_source(piece_path, max_line)
+                    connection.execute(
+                        f"COPY (SELECT * FROM {source}) "
+                        f"TO {_sql_string(str(part_path))} "
+                        + ARCHIVE_PARQUET_COPY_OPTIONS
+                    )
+                    part_paths.append(part_path)
+                    piece_path.unlink(missing_ok=True)
+                # Deliberately NOT a DuckDB COPY: any SQL scan streams fixed
+                # 2048-row chunks whose memory scales with row width, so combining
+                # a whale day re-inflates the working set the pieces just bounded
+                # (observed in-cluster: the combine OOMed a 1 GiB bound after every
+                # piece converted cleanly). Row-group-wise concatenation decodes at
+                # most one ROW_GROUP_SIZE_BYTES-bounded group at a time.
+                _combine_parquet_parts(part_paths, target)
         return run_count
     finally:
-        rows_path.unlink(missing_ok=True)
+        if piece is not None:
+            piece.close()
+        for piece_path in piece_paths:
+            piece_path.unlink(missing_ok=True)
+        for part_path in part_paths:
+            part_path.unlink(missing_ok=True)
 
 
 def _write_bulk_parquet(
@@ -207,6 +347,110 @@ def _write_bulk_parquet(
     return snapshot.export_id, snapshot.run_count
 
 
+def _open_parquet_source(uri: str) -> Any:
+    """ParquetFile over a local path or s3:// URI through pyarrow filesystems."""
+    import pyarrow.fs
+    import pyarrow.parquet
+
+    if uri.startswith("s3://"):
+        filesystem, path = pyarrow.fs.FileSystem.from_uri(uri)
+        return pyarrow.parquet.ParquetFile(filesystem.open_input_file(path))
+    path = uri[len("file://") :] if uri.startswith("file://") else uri
+    return pyarrow.parquet.ParquetFile(path)
+
+
+def _payload_columns_are_text(schema: Any) -> bool:
+    import pyarrow
+
+    for field in schema:
+        if field.name not in ARCHIVE_JSON_COLUMNS:
+            continue
+        field_type = field.type
+        if isinstance(field_type, pyarrow.BaseExtensionType):
+            field_type = field_type.storage_type
+        if not (
+            pyarrow.types.is_string(field_type)
+            or pyarrow.types.is_large_string(field_type)
+            or pyarrow.types.is_null(field_type)
+        ):
+            return False
+    return True
+
+
+def _conform_table(table: Any, unified: Any) -> Any:
+    """Project onto the unified schema, adding null columns a source never had."""
+    import pyarrow
+
+    arrays = []
+    for field in unified:
+        if field.name in table.schema.names:
+            arrays.append(table.column(field.name).cast(field.type))
+        else:
+            arrays.append(pyarrow.nulls(table.num_rows, type=field.type))
+    return pyarrow.table(arrays, schema=unified)
+
+
+def _canonicalize_streaming(
+    source_files: list[Any], source_uris: list[str], target: Path
+) -> int:
+    """
+    Union-and-dedupe one project-day row-group-by-row-group.
+
+    The SQL union+window canonicalization streams fixed 2048-row chunks whose
+    memory scales with row width, so whale days OOMed a 1 GiB bound after raw
+    conversion was already piece-bounded (in-cluster stack: _canonicalize). The
+    dedup decision only needs run IDs: the highest-rank snapshot (reconciliation)
+    is copied through, lower ranks drop rows whose IDs it already covers, and the
+    working set is one decoded row group plus one day of IDs.
+    """
+    import pyarrow
+    import pyarrow.compute
+    import pyarrow.parquet
+
+    ids_per_source: list[list[str]] = []
+    for source_file, uri in zip(source_files, source_uris):
+        ids: list[str] = []
+        for group_index in range(source_file.num_row_groups):
+            column = source_file.read_row_group(group_index, columns=["id"])
+            ids.extend(
+                value for value in column.column("id").to_pylist() if value is not None
+            )
+        if len(ids) != len(set(ids)):
+            raise ValueError(f"Snapshot contains duplicate run IDs: {uri}")
+        ids_per_source.append(ids)
+
+    winner_index = len(source_files) - 1
+    winner_ids = (
+        pyarrow.array(sorted(set(ids_per_source[winner_index])))
+        if len(source_files) > 1
+        else None
+    )
+    unified = pyarrow.unify_schemas(
+        [_storage_schema(source.schema_arrow) for source in source_files],
+        promote_options="permissive",
+    )
+    written = 0
+    writer = pyarrow.parquet.ParquetWriter(str(target), unified, compression="zstd")
+    try:
+        for index, source_file in enumerate(source_files):
+            for group_index in range(source_file.num_row_groups):
+                table = _storage_table(source_file.read_row_group(group_index))
+                if winner_ids is not None and index != winner_index:
+                    keep = pyarrow.compute.invert(
+                        pyarrow.compute.is_in(table.column("id"), value_set=winner_ids)
+                    )
+                    table = table.filter(pyarrow.compute.fill_null(keep, True))
+                if table.num_rows:
+                    writer.write_table(_conform_table(table, unified))
+                    written += table.num_rows
+    finally:
+        writer.close()
+    metadata_rows = pyarrow.parquet.ParquetFile(str(target)).metadata.num_rows
+    if metadata_rows != written:
+        raise ValueError("Canonical row count mismatch after write")
+    return written
+
+
 def _canonicalize(store: ArchiveStore, manifest: ArchiveManifest, target: Path) -> int:
     sources: list[tuple[str, int]] = []
     if manifest.primary is not None:
@@ -216,6 +460,26 @@ def _canonicalize(store: ArchiveStore, manifest: ArchiveManifest, target: Path) 
     if not sources:
         raise ValueError("Cannot canonicalize a manifest without snapshots")
 
+    import contextlib
+
+    with contextlib.ExitStack() as stack:
+        source_files = []
+        for uri, _rank in sources:
+            source_files.append(stack.enter_context(_open_parquet_source(uri)))
+        if all(
+            _payload_columns_are_text(source.schema_arrow) for source in source_files
+        ):
+            return _canonicalize_streaming(
+                source_files, [uri for uri, _ in sources], target
+            )
+    # Legacy raw generations carry inferred STRUCT/LIST payload columns that need
+    # SQL normalization; they predate byte-bounded staging and are rare
+    # (re-canonicalizing an already-sealed day), so the memory-heavy path is kept
+    # only for them.
+    return _canonicalize_duckdb(sources, target)
+
+
+def _canonicalize_duckdb(sources: list[tuple[str, int]], target: Path) -> int:
     with archive_duckdb_connection(target.parent) as connection:
         configure_duckdb_s3(connection, [uri for uri, _ in sources])
         selects: list[str] = []

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -386,22 +386,21 @@ def test_streaming_dedup_holds_across_row_groups_and_snapshots(
             for suffix in ids
         ]
 
-    common = dict(
-        project_id="f47ac10b-58cc-4372-a567-0e02b2c3d479",
-        project_name="dev/rowgroups",
-        trace_date=date(2024, 7, 3),
-    )
     sync_project_day(
         FakeRunsClient(_runs(["0", "1", "2"], "primary")),
         store,
         phase=ArchivePhase.PRIMARY,
-        **common,
+        project_id="f47ac10b-58cc-4372-a567-0e02b2c3d479",
+        project_name="dev/rowgroups",
+        trace_date=date(2024, 7, 3),
     )
     manifest = sync_project_day(
         FakeRunsClient(_runs(["1", "2", "3"], "reconciliation")),
         store,
         phase=ArchivePhase.RECONCILIATION,
-        **common,
+        project_id="f47ac10b-58cc-4372-a567-0e02b2c3d479",
+        project_name="dev/rowgroups",
+        trace_date=date(2024, 7, 3),
     )
     assert manifest.canonical_run_count == 4
     archived = query_archive_runs(ArchiveRunQuery(project="dev/rowgroups", limit=0))
@@ -429,11 +428,6 @@ def test_legacy_struct_raw_still_canonicalizes_through_the_sql_path(
     archive_uri = str(tmp_path / "archive")
     monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
     store = create_store(archive_uri)
-    common = dict(
-        project_id="f47ac10b-58cc-4372-a567-0e02b2c3d479",
-        project_name="dev/legacy",
-        trace_date=date(2024, 7, 3),
-    )
 
     def _legacy_serialize(run: Run) -> bytes:
         payload = run.model_dump(mode="python")
@@ -448,7 +442,9 @@ def test_legacy_struct_raw_still_canonicalizes_through_the_sql_path(
             FakeRunsClient([create_run(inputs={"deep": {"legacy": True}})]),
             store,
             phase=ArchivePhase.PRIMARY,
-            **common,
+            project_id="f47ac10b-58cc-4372-a567-0e02b2c3d479",
+            project_name="dev/legacy",
+            trace_date=date(2024, 7, 3),
         )
     manifest = sync_project_day(
         FakeRunsClient(
@@ -462,7 +458,9 @@ def test_legacy_struct_raw_still_canonicalizes_through_the_sql_path(
         ),
         store,
         phase=ArchivePhase.RECONCILIATION,
-        **common,
+        project_id="f47ac10b-58cc-4372-a567-0e02b2c3d479",
+        project_name="dev/legacy",
+        trace_date=date(2024, 7, 3),
     )
     assert manifest.canonical_run_count == 2
     archived = query_archive_runs(ArchiveRunQuery(project="dev/legacy", limit=0))
@@ -479,17 +477,21 @@ def test_empty_primary_with_late_reconciliation_seals_the_late_rows(
     archive_uri = str(tmp_path / "archive")
     monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
     store = create_store(archive_uri)
-    common = dict(
+    sync_project_day(
+        FakeRunsClient([]),
+        store,
+        phase=ArchivePhase.PRIMARY,
         project_id="f47ac10b-58cc-4372-a567-0e02b2c3d479",
         project_name="dev/late-day",
         trace_date=date(2024, 7, 3),
     )
-    sync_project_day(FakeRunsClient([]), store, phase=ArchivePhase.PRIMARY, **common)
     manifest = sync_project_day(
         FakeRunsClient([create_run(outputs={"late": True})]),
         store,
         phase=ArchivePhase.RECONCILIATION,
-        **common,
+        project_id="f47ac10b-58cc-4372-a567-0e02b2c3d479",
+        project_name="dev/late-day",
+        trace_date=date(2024, 7, 3),
     )
     assert manifest.sealed is True
     assert manifest.canonical_run_count == 1

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -258,3 +258,103 @@ def test_reconciliation_deduplicates_and_is_idempotent(
     )
     assert count_result.exit_code == 0, count_result.output
     assert count_result.output.strip() == "2"
+
+
+def test_runs_snapshot_stores_payloads_as_text_not_inferred_structs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    read_json_auto STRUCT inference materializes trace payloads as typed nested
+    columns, and its memory scales with payload complexity: a real project-day
+    OOMed a 2.5 GiB DuckDB bound inside _write_runs_parquet before canonicalization
+    ever ran. The CLI serializes the JSONL itself, so nested payload fields must be
+    pre-serialized JSON text — the same VARCHAR shape Bulk Export v2 produces,
+    which canonicalization already unifies. Snapshot memory then scales with row
+    size, not payload nesting depth.
+    """
+    import duckdb
+
+    archive_uri = str(tmp_path / "archive")
+    monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
+    store = create_store(archive_uri)
+    nested_run = create_run(
+        inputs={"deep": {"x": [1, 2, {"y": "z"}]}},
+        outputs={"answer": {"content": "ok"}},
+        tags=["t1", "t2"],
+    )
+    manifest = sync_project_day(
+        FakeRunsClient([nested_run]),
+        store,
+        project_id="f47ac10b-58cc-4372-a567-0e02b2c3d479",
+        project_name="dev/nested",
+        trace_date=date(2024, 7, 3),
+        phase=ArchivePhase.PRIMARY,
+    )
+    assert manifest.primary is not None
+    raw_path = Path(store.base_uri) / manifest.primary.raw_key
+    connection = duckdb.connect()
+    try:
+        described = {
+            str(row[0]): str(row[1])
+            for row in connection.execute(
+                f"DESCRIBE SELECT * FROM read_parquet('{raw_path.as_posix()}')"
+            ).fetchall()
+        }
+    finally:
+        connection.close()
+    for column in ("inputs", "outputs", "tags"):
+        assert "STRUCT" not in described[column], (column, described[column])
+    # Semantic preservation: canonical readers still see the full nested value.
+    archived = query_archive_runs(ArchiveRunQuery(project="dev/nested", limit=0))
+    assert archived[0].inputs == {"deep": {"x": [1, 2, {"y": "z"}]}}
+    assert archived[0].tags == ["t1", "t2"]
+
+
+def test_oversized_days_are_staged_and_converted_in_bounded_pieces(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    The JSON reader's reconstruction buffers and string chunks scale with the file
+    it scans, so converting one whole project-day at once OOMed real days even at a
+    2 GiB bound. Staging must split into byte-bounded pieces converted one at a
+    time; a day of any size then converts inside a fixed working set. This forces
+    every run into its own piece and proves the multi-piece path publishes the same
+    canonical contract: all rows, unique IDs, values intact.
+    """
+    from langsmith_cli.archive import sync as sync_module
+
+    monkeypatch.setattr(sync_module, "STAGING_PIECE_MAX_BYTES", 1)
+    archive_uri = str(tmp_path / "archive")
+    monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
+    runs = [
+        create_run(
+            id_str=f"12345678-1234-5678-1234-56781234567{index}",
+            inputs={"deep": {"index": index}},
+            outputs={"answer": f"value-{index}"},
+            # One piece carries a real error while the others are all-null, so the
+            # per-piece inferred types disagree (JSON extension vs string) — the
+            # exact mismatch the combine's schema unification must absorb.
+            error="boom" if index == 1 else None,
+        )
+        for index in range(3)
+    ]
+    manifest = sync_project_day(
+        FakeRunsClient(runs),
+        create_store(archive_uri),
+        project_id="f47ac10b-58cc-4372-a567-0e02b2c3d479",
+        project_name="dev/pieces",
+        trace_date=date(2024, 7, 3),
+        phase=ArchivePhase.PRIMARY,
+    )
+    assert manifest.canonical_run_count == 3
+    archived = query_archive_runs(ArchiveRunQuery(project="dev/pieces", limit=0))
+    assert {run.outputs["answer"] for run in archived} == {
+        "value-0",
+        "value-1",
+        "value-2",
+    }
+    assert {str(run.inputs["deep"]["index"]) for run in archived} == {"0", "1", "2"}
+    # No staging litter survives a successful conversion.
+    day_directory = Path(archive_uri)
+    leftovers = [p for p in day_directory.rglob("*") if p.suffix in {".jsonl", ".part"}]
+    assert leftovers == []

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime
+import json
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -358,3 +359,139 @@ def test_oversized_days_are_staged_and_converted_in_bounded_pieces(
     day_directory = Path(archive_uri)
     leftovers = [p for p in day_directory.rglob("*") if p.suffix in {".jsonl", ".part"}]
     assert leftovers == []
+
+
+def test_streaming_dedup_holds_across_row_groups_and_snapshots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Dedup tests elsewhere use single-row-group days; this forces every run into its
+    own piece (hence its own row group in raw) and proves reconciliation precedence
+    holds across group boundaries: shared IDs take the reconciliation value,
+    primary-only rows survive, late reconciliation-only rows are added.
+    """
+    from langsmith_cli.archive import sync as sync_module
+
+    monkeypatch.setattr(sync_module, "STAGING_PIECE_MAX_BYTES", 1)
+    archive_uri = str(tmp_path / "archive")
+    monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
+    store = create_store(archive_uri)
+
+    def _runs(ids: list[str], version: str) -> list[Run]:
+        return [
+            create_run(
+                id_str=f"12345678-1234-5678-1234-56781234567{suffix}",
+                outputs={"version": version},
+            )
+            for suffix in ids
+        ]
+
+    common = dict(
+        project_id="f47ac10b-58cc-4372-a567-0e02b2c3d479",
+        project_name="dev/rowgroups",
+        trace_date=date(2024, 7, 3),
+    )
+    sync_project_day(
+        FakeRunsClient(_runs(["0", "1", "2"], "primary")),
+        store,
+        phase=ArchivePhase.PRIMARY,
+        **common,
+    )
+    manifest = sync_project_day(
+        FakeRunsClient(_runs(["1", "2", "3"], "reconciliation")),
+        store,
+        phase=ArchivePhase.RECONCILIATION,
+        **common,
+    )
+    assert manifest.canonical_run_count == 4
+    archived = query_archive_runs(ArchiveRunQuery(project="dev/rowgroups", limit=0))
+    versions = {str(run.id)[-1]: (run.outputs or {})["version"] for run in archived}
+    assert versions == {
+        "0": "primary",
+        "1": "reconciliation",
+        "2": "reconciliation",
+        "3": "reconciliation",
+    }
+
+
+def test_legacy_struct_raw_still_canonicalizes_through_the_sql_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Raw generations written before byte-bounded staging carry inferred STRUCT
+    payload columns; they self-expire with the raw/ lifecycle, but until then an
+    unsealed day can pair a legacy-primary with a new-format reconciliation. The
+    canonicalize dispatcher must detect the non-text payload and route the SQL
+    normalization path, producing the same JSON-text canonical contract.
+    """
+    from langsmith_cli.archive import sync as sync_module
+
+    archive_uri = str(tmp_path / "archive")
+    monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
+    store = create_store(archive_uri)
+    common = dict(
+        project_id="f47ac10b-58cc-4372-a567-0e02b2c3d479",
+        project_name="dev/legacy",
+        trace_date=date(2024, 7, 3),
+    )
+
+    def _legacy_serialize(run: Run) -> bytes:
+        payload = run.model_dump(mode="python")
+        line = json.dumps(
+            payload, ensure_ascii=False, default=sync_module._archive_json_default
+        )
+        return line.encode("utf-8") + b"\n"
+
+    with monkeypatch.context() as legacy:
+        legacy.setattr(sync_module, "_serialize_run_line", _legacy_serialize)
+        sync_project_day(
+            FakeRunsClient([create_run(inputs={"deep": {"legacy": True}})]),
+            store,
+            phase=ArchivePhase.PRIMARY,
+            **common,
+        )
+    manifest = sync_project_day(
+        FakeRunsClient(
+            [
+                create_run(inputs={"deep": {"legacy": True}}),
+                create_run(
+                    id_str="12345678-1234-5678-1234-567812345679",
+                    inputs={"late": True},
+                ),
+            ]
+        ),
+        store,
+        phase=ArchivePhase.RECONCILIATION,
+        **common,
+    )
+    assert manifest.canonical_run_count == 2
+    archived = query_archive_runs(ArchiveRunQuery(project="dev/legacy", limit=0))
+    assert {json.dumps(run.inputs, sort_keys=True) for run in archived} == {
+        json.dumps({"deep": {"legacy": True}}, sort_keys=True),
+        json.dumps({"late": True}, sort_keys=True),
+    }
+
+
+def test_empty_primary_with_late_reconciliation_seals_the_late_rows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A day empty at D+2 whose runs only appear by D+12 must still seal them."""
+    archive_uri = str(tmp_path / "archive")
+    monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
+    store = create_store(archive_uri)
+    common = dict(
+        project_id="f47ac10b-58cc-4372-a567-0e02b2c3d479",
+        project_name="dev/late-day",
+        trace_date=date(2024, 7, 3),
+    )
+    sync_project_day(FakeRunsClient([]), store, phase=ArchivePhase.PRIMARY, **common)
+    manifest = sync_project_day(
+        FakeRunsClient([create_run(outputs={"late": True})]),
+        store,
+        phase=ArchivePhase.RECONCILIATION,
+        **common,
+    )
+    assert manifest.sealed is True
+    assert manifest.canonical_run_count == 1
+    archived = query_archive_runs(ArchiveRunQuery(project="dev/late-day", limit=0))
+    assert (archived[0].outputs or {})["late"] is True

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -348,7 +348,7 @@ def test_oversized_days_are_staged_and_converted_in_bounded_pieces(
     )
     assert manifest.canonical_run_count == 3
     archived = query_archive_runs(ArchiveRunQuery(project="dev/pieces", limit=0))
-    assert {run.outputs["answer"] for run in archived} == {
+    assert {(run.outputs or {}).get("answer") for run in archived} == {
         "value-0",
         "value-1",
         "value-2",

--- a/tests/test_archive_invariants.py
+++ b/tests/test_archive_invariants.py
@@ -911,3 +911,25 @@ def test_s3_store_propagates_non_concurrency_service_errors(
         store.put_text_if_version("manifests/day.json", "{}", None)
     with pytest.raises(ClientError):
         store.exists("manifests/day.json")
+
+
+def test_duckdb_threads_are_environment_configurable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    DuckDB defaults its thread count to the HOST's cores, not the container's CPU
+    quota — 8 threads inside a 1-CPU pod, each holding JSON read buffers up to
+    maximum_object_size plus write buffers, multiplies the working set until real
+    project-days OOM. The pod owner knows its CPU quota; the library does not.
+    """
+    import duckdb
+
+    monkeypatch.setenv("LANGSMITH_ARCHIVE_DUCKDB_THREADS", "2")
+    connection = duckdb.connect()
+    try:
+        configure_duckdb_resources(connection, tmp_path / "project-a")
+        assert connection.execute("SELECT current_setting('threads')").fetchone() == (
+            2,
+        )
+    finally:
+        connection.close()

--- a/uv.lock
+++ b/uv.lock
@@ -405,6 +405,7 @@ dependencies = [
     { name = "langdetect" },
     { name = "langsmith" },
     { name = "platformdirs" },
+    { name = "pyarrow" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "pytz" },
@@ -433,6 +434,7 @@ requires-dist = [
     { name = "langdetect", specifier = ">=1.0.9" },
     { name = "langsmith", specifier = ">=0.8.5" },
     { name = "platformdirs", specifier = ">=4.0" },
+    { name = "pyarrow", specifier = ">=17.0.0" },
     { name = "pydantic", specifier = ">=2.11.0" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "pytz", specifier = ">=2025.2" },
@@ -586,6 +588,42 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "25.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/e3/27f57f80141379d60defe6703eb50a707325706f07fedfd1312c7a751995/pyarrow-25.0.1.tar.gz", hash = "sha256:9150a83248bfed9813ea3c3af74c3856c1984d444aa28e58bf7733b9750ddf6a", size = 1201653, upload-time = "2026-08-10T12:40:53.904Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/e2/9ab15b88cbfac28e16419ce5439ec29234c5172cb8259301b4ba639bdec0/pyarrow-25.0.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:df961f2e7ae9cf496459259d798652c70625f6c080650d6952f8c04053c58ee9", size = 35861559, upload-time = "2026-08-10T12:38:02.567Z" },
+    { url = "https://files.pythonhosted.org/packages/58/79/a0036dbe1eabe1f73127427342f1d99982584c4a2cde2651d6c93499c6f6/pyarrow-25.0.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:cc4aa407fde9fc660be3939e49ea31f50f3e9fec17c0ec63159f7711edd3efc9", size = 37628383, upload-time = "2026-08-10T12:38:09.083Z" },
+    { url = "https://files.pythonhosted.org/packages/13/49/d93a57d375f4bf0cf82913dd6bb54acafde83dd993be2282c81ac5616cad/pyarrow-25.0.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:4340f0ba6c1d2e13f21658de1d7c662ca2545018568d0030a1e9afca159d87e3", size = 46820190, upload-time = "2026-08-10T12:38:15.458Z" },
+    { url = "https://files.pythonhosted.org/packages/60/c9/711ca85d79f1ec98f29a5eae2b051e25b4ecec5de3e3c0e2d5c5dcb15664/pyarrow-25.0.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:5389cdf79447ed1515c9e31620e6e1e2302249564d603f2ad727d4f6d313e4c3", size = 50102437, upload-time = "2026-08-10T12:38:22.487Z" },
+    { url = "https://files.pythonhosted.org/packages/80/53/8fb8359ff17cfb6263a1cf3ebf7caec9fe197de118719e84fcb1d0618026/pyarrow-25.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d51592cb7561e87877c506113e7adbf1342ab579e6c21f0ef44b8ba41cb74c80", size = 49942424, upload-time = "2026-08-10T12:38:28.755Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/83/4e5ae02a9341571b18a6fca380ac7a58ce6ddae7ab3c060208c0a1e79f02/pyarrow-25.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6109c94d8b9f3b17a041daca16cacb2f651ad8f1ef70a4232c2c0f37a23da2a8", size = 53144206, upload-time = "2026-08-10T12:38:34.862Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ee/197cbf47e49f83e6ebeb946a5259a48a638dea27ac774db42fe78022179d/pyarrow-25.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:8858d7bfc22e3f51529aeaa4077225029724623e4595dc9eff8c793935c34140", size = 27953934, upload-time = "2026-08-10T12:38:39.808Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/8d/8f271a7a034c834910ec925d56fa4b29733b1380f5289419f5aaa3b02777/pyarrow-25.0.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:c7c534ec03c358a76ea3e505e74c1b6aef290af90c444dfd092dbfe23e755b85", size = 35855328, upload-time = "2026-08-10T12:38:45.489Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/cd/5bac242f4e841b9971d5eb94fdfe2577e2b70be983e27401e72055786037/pyarrow-25.0.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:dda9470024204d7bbf2042b47c6e8a0e47a3eeb8e34405882dfaea6577e0c153", size = 37622415, upload-time = "2026-08-10T12:38:51.107Z" },
+    { url = "https://files.pythonhosted.org/packages/63/1f/96d03b4e1506524f7087adb0fd6b2f69f0c9c7aaff1ec36d8030082e15a5/pyarrow-25.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:44a9120ce5bd81936b8ab9a88076e3fd47c2c6838e0e43630fed83626aca81d9", size = 46813813, upload-time = "2026-08-10T12:38:57.773Z" },
+    { url = "https://files.pythonhosted.org/packages/98/d6/33a411115b61dbfc16ad6ad73e71730f6fea654ee3667673bc53ab0e2fe7/pyarrow-25.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:0befcf816e45a1af33ac775a9970b749e4868a230c7372f0ae5e932bee27039f", size = 50104452, upload-time = "2026-08-10T12:39:04.579Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ae/b1b97c9ca87f9f9ddbb5230c798df94eccce61bd79b9b45458c69a478588/pyarrow-25.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3f89685964f46e4216103c75483aac0c0692a5f72212d7ca835adba5ede56ce3", size = 49951343, upload-time = "2026-08-10T12:39:11.8Z" },
+    { url = "https://files.pythonhosted.org/packages/98/9e/a112df5cfd5a68cb1d9fc31cfe38c28d5aec9f10865ce37ecef2e4450873/pyarrow-25.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6943e2fe7954d29d84de45d29d34c8dc36ce96570e67d89aa9976e650a4a9138", size = 53144784, upload-time = "2026-08-10T12:39:20.503Z" },
+    { url = "https://files.pythonhosted.org/packages/31/24/97e8bd98f1e3b07e2ba08bcdff690674fbe16d69a7d2712cc3884665e615/pyarrow-25.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:31e49a7888fcdf3a835da33ae777f6bb9a866334e5a789282fc26dcf426f7f15", size = 27870159, upload-time = "2026-08-10T12:39:26.161Z" },
+    { url = "https://files.pythonhosted.org/packages/36/4c/b525824ad3094076919273cd97db61fb3d78252dee76fa3b8dc8f76774aa/pyarrow-25.0.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:bf0b672390cdcb640d7288f96b826d71ff4e9abb254a86c89890baf51a29cee6", size = 35885255, upload-time = "2026-08-10T12:39:32.366Z" },
+    { url = "https://files.pythonhosted.org/packages/08/62/448bb0e940de41aec31d1a956e63ad9c54afdf122a103cc3ab20c2a3ce33/pyarrow-25.0.1-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:38a9a4b4b9613380e200641891495a56c3d5a98a092db4a870af9975e220471d", size = 37644461, upload-time = "2026-08-10T12:39:38.142Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/9a/13587e38bd4806fd218f50fd13b8903fab60588a699ff0c406372e5b4043/pyarrow-25.0.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:0b726ad7e7b669be982b0c71c07fe4b037d654354130da79a7902a669e93a66b", size = 46877146, upload-time = "2026-08-10T12:39:43.722Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/61/1c5d1229fa21da4cff5365e41e57177aaac57c563c727f35419b8513d1c1/pyarrow-25.0.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:9171748cdf796972d85a4b60157c279913e242992e350c90c7450182a9838b2a", size = 50131616, upload-time = "2026-08-10T12:39:49.304Z" },
+    { url = "https://files.pythonhosted.org/packages/43/20/291e1d65cc0b09aa19f03cf25cf51a2f5fa94b5db315178f2d254ed5cad4/pyarrow-25.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b7a296aac7a71fa0886c08e155ddb6c636a50013f801f6178daafa0f9e726188", size = 50008879, upload-time = "2026-08-10T12:39:56.891Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/7c/1b7c9ec28e76576337e4f97b31141c9a181b89b6d1d6221e9d8205621a58/pyarrow-25.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:0fe7c8b6c03969b49c8c66182e4a18e3819ab92d07cfab5d8370c531b9369ef0", size = 53170864, upload-time = "2026-08-10T12:40:04.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/75/f3d789dc06011a765d14d86bda799cf72ac1d715b6a6edecaa0d73d95062/pyarrow-25.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:f729cfdbd36fd99d543b67a914d2de044c84ebe45be8b34902b299b608c15c8f", size = 28620729, upload-time = "2026-08-10T12:40:51.41Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/05/647a8ee6f7c2662feb6921315617bc04dcd6034763fb61b1199720bf6162/pyarrow-25.0.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:59a2de54c0cbd954da861eee4d1d330f8e909c45b53455baef696380f2c55033", size = 36130288, upload-time = "2026-08-10T12:40:11.014Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f8/c9ee997554d7bea94520667dd1933f109ac1da3ee3556d2b49381e023484/pyarrow-25.0.1-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:35935cd5de130aa5cf4dea052a63e6bf2e17006c35c3a468194242b9b2bf5956", size = 37762187, upload-time = "2026-08-10T12:40:16.592Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/08/a28c01c7fe9e96e8233ce2d13df1d402f4f999f848f51d2daacd6bb4c036/pyarrow-25.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:f3831aaa25c67a99f99dc8b05873cb9d64560390372e2aa197ce9dd4a3f06a44", size = 46888003, upload-time = "2026-08-10T12:40:23.242Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/b9/58612e977d28dc58c878448866838369ee8da2f1e7cc8ed2c84b952aafee/pyarrow-25.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:6a1fdfc6659b6b19022f2e50627fb5cf7156a66c46bf4299379955cbe742382a", size = 50079036, upload-time = "2026-08-10T12:40:29.169Z" },
+    { url = "https://files.pythonhosted.org/packages/72/13/66e1402dcc860e1dc2760b1e0292c9a569b62b3bccab69def1b3e907d006/pyarrow-25.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:169d3429d5be7c752125890620f75a60776d38b0035eddae939651640822332e", size = 50040226, upload-time = "2026-08-10T12:40:35.186Z" },
+    { url = "https://files.pythonhosted.org/packages/78/10/3f1a5497a7ef732ab0f03ecca3e66d89d9c0f57fdc61b4794c456b781f01/pyarrow-25.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:119297a6dc197e45d9c6d4415f7814a67ffa36c180d26f68c154c58067ae782d", size = 53149035, upload-time = "2026-08-10T12:40:41.454Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c0/37d4a7e8e2f7a6076283673d5298018ca26478b934c6ee369e10505ab32c/pyarrow-25.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:4288f27577352d608ca08553b0865e4a9b3aa14820c5d95b53337218d609835b", size = 28753071, upload-time = "2026-08-10T12:40:46.623Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Today, a real project-day whose traces total gigabytes OOMs `archive sync` at any fixed DuckDB memory bound — in-cluster runs against the live Gigaverse workspace failed identically at 1, 2, 2.5, and 3 GiB, because three stages hold working sets proportional to the day rather than to any constant. This PR makes every sync stage's memory scale with a tunable constant, so the previously-OOMing whale day completes at the default 1 GiB bound with ~1.5 GiB total container footprint.

## The three day-scaled stages, and their bounds (each found by an in-cluster OOM stack)

| Stage | Why it scaled with the day | Bound now |
|---|---|---|
| JSONL→Parquet staging conversion | one `read_json_auto` COPY over the whole day; STRUCT inference materializes payload-shaped nested columns | staging splits at **128 MiB piece boundaries**, converted piece-by-piece; payload fields pre-serialized as JSON text (the Bulk v2 VARCHAR shape canonicalization already unifies) |
| JSON reader buffers | reconstruction buffers sized to a blanket 100 MiB `maximum_object_size` per thread | reader told each piece's **true largest document** (doubled, 16 MiB floor) — the CLI wrote every line itself and knows |
| Part combine + canonicalization | any SQL scan streams fixed 2048-row chunks whose memory scales with row width; the union+window pipeline carries full payloads | **row-group-wise pyarrow streaming**: parts concatenate one byte-bounded row group at a time; canonicalization dedups IDs-first (reconciliation copies through, lower ranks drop covered rows). Legacy STRUCT raw keeps the SQL path for normalization. |

Plus `LANGSMITH_ARCHIVE_DUCKDB_THREADS`: DuckDB defaults its thread count to the *host's* cores (8 threads inside a 1-CPU pod), multiplying every buffer.

## Contracts preserved

- Canonical output is unchanged: JSON-text payload columns, one row per run ID, reconciliation precedence (A8), per-snapshot uniqueness enforced with the same errors (A6), count bounds (A7). Row order inside Parquet is not part of the contract — every reader orders explicitly.
- Pieces are inferred independently; the combine strips Arrow extension types to their storage (lossless — the storage IS the JSON text) and unifies schemas permissively, covering all-null columns.
- New dependency: `pyarrow` (already the ecosystem-standard columnar library; used only for row-group streaming).

## Tests (each written first, watched fail)

`test_oversized_days_are_staged_and_converted_in_bounded_pieces` (forces every run into its own piece, exercises schema promotion via an all-null/valued `error` split), `test_runs_snapshot_stores_payloads_as_text_not_inferred_structs`, `test_archive_parquet_writers_bound_row_group_bytes`, `test_duckdb_threads_are_environment_configurable` — plus the existing dedup/idempotency/bootstrap/empty-day invariants now running through the streaming path.

## Evidence (live in-cluster, gigaverse-ai#2206 side arm)

Every OOM stack named the stage fixed next: `_write_runs_parquet` (structs) → same (reader buffers) → part combine (chunk width) → `_canonicalize` (window). With the full chain at the **default 1 GiB bound, 2 threads**: the whale day converts and canonicalizes, container peak ~1.5 GiB (previous attempts peaked 2.6–4.6 GiB before dying). Full-run duration will be posted on gigaverse-ai#2206 when the complete all-routes sync lands.

Note: main's CI currently fails on an unrelated `test_field_analysis.py::TestDetectLanguageSafe::test_truncates_long_text` flake (langdetect nondeterminism, predates this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)