### PR TITLE
Fix nondeterministic language detection in CI

### DIFF
--- a/src/langsmith_cli/field_analysis.py
+++ b/src/langsmith_cli/field_analysis.py
@@ -260,10 +260,12 @@ def detect_language_safe(text: str) -> str | None:
 
     try:
         # Lazy import for performance
-        from langdetect import detect
+        from langdetect import DetectorFactory, detect
         from langdetect.lang_detect_exception import LangDetectException
 
         try:
+            # langdetect is nondeterministic unless its factory seed is fixed.
+            DetectorFactory.seed = 0
             return detect(sample)
         except LangDetectException:
             # Empty text after filtering, no detectable language, etc.

--- a/tests/test_field_analysis.py
+++ b/tests/test_field_analysis.py
@@ -147,6 +147,20 @@ class TestDetectLanguageSafe:
         # Should still work and detect English
         assert result == "en"
 
+    def test_detection_uses_a_fixed_seed(self, monkeypatch):
+        """Identical text must not produce different languages across calls."""
+        from langdetect import DetectorFactory
+
+        monkeypatch.setattr(DetectorFactory, "seed", None)
+
+        def assert_seeded(text: str) -> str:
+            assert DetectorFactory.seed == 0
+            return "en"
+
+        monkeypatch.setattr("langdetect.detect", assert_seeded)
+
+        assert detect_language_safe("This text is long enough for detection.") == "en"
+
     def test_detection_failure_returns_none(self, monkeypatch):
         """Language detection failures are treated as unknown language."""
         from langdetect.lang_detect_exception import LangDetectException


### PR DESCRIPTION
Today, identical text can produce different language codes because `langdetect` uses randomized detection by default, which intermittently fails the Python 3.12 CI suite. This PR fixes the detector seed before every call, so identical input is classified consistently and the ordinary CI suite no longer flakes on this assertion.

## What changed

- Set `DetectorFactory.seed = 0` immediately before language detection while preserving the lazy import path.
- Added a regression test enforcing the fixed-seed contract.

## Invariant

For the same input text and detector profiles, language detection returns the same language code across calls. The enforcement point is the fixed factory seed immediately before `detect(sample)`.

## Evidence

- Before: 100 identical detections produced `en: 99`, `nl: 1`.
- After: 500 identical detections produced `en: 500`.
- `uv run pytest --ignore=tests/test_e2e.py --ignore=tests/test_smoke.py -q` — 1,428 passed.
- `uv run ruff check .` — passed.
- `uv run ruff format --check .` — passed.
- `uv run pyright` — 0 errors.

Secret-backed E2E/smoke tests were excluded from the local verification; the PR CI workflow handles its configured lanes.