### PR TITLE
Store queryable archive dimensions as typed Parquet columns

### DIFF
--- a/docs/TRACE_ARCHIVE_DESIGN.md
+++ b/docs/TRACE_ARCHIVE_DESIGN.md
@@ -176,11 +176,25 @@ Arbitrary SDK `bytes` values are preserved as tagged base64 objects with
 materialized at the JSON-to-Parquet boundary. This keeps non-UTF-8 media payloads
 without weakening UTF-8 validation for the surrounding trace document.
 
-Canonical nested fields (`inputs`, `outputs`, `extra`, `events`, `tags`,
-`feedback_stats`, and `parent_run_ids`) are JSON text. Runs API JSONL inference
-produces DuckDB `STRUCT`/`LIST` values while Bulk Export v2 supplies JSON `VARCHAR`;
-canonicalization converts both forms before union. This prevents provider changes or
-different object keys on adjacent days from producing incompatible Parquet schemas.
+Canonical schema v2 separates arbitrary payloads from shape-stable query dimensions:
+
+| Physical type | Run fields | Reason |
+| --- | --- | --- |
+| JSON text | `inputs`, `outputs`, `extra`, `events`, `feedback_stats` | Values are arbitrary provider/application documents; inferred children are unbounded. |
+| `list<string>` | `tags`, `parent_run_ids` | Both are documented homogeneous lists and useful filter/topology dimensions. |
+| `map<string, bigint>` | prompt/completion token details | Providers may add token categories without changing the Parquet schema. |
+| `map<string, decimal(38,18)>` | prompt/completion cost details | Cost categories remain open-ended while values retain decimal precision. |
+| `map<string, string>` | extracted `extra.metadata` | Metadata keys stay queryable without per-key columns; the authoritative heterogeneous object remains intact in `extra`. |
+
+Metadata map values use their stable textual representation (plain strings, decimal
+or boolean text, and compact JSON for nested values). Queries can cast a selected
+value when numeric comparison is required. Runs API JSONL and Bulk Export v2 are
+normalized to these types before canonical union.
+
+Manifest schema v1 remains readable. Readers normalize each published generation to
+v2 independently before cross-day `UNION ALL BY NAME`, so old JSON-text tags and
+parent IDs cannot dictate the type of new list columns. The next publication for an
+unsealed v1 day upgrades its manifest and canonical Parquet atomically to v2.
 
 The bucket owner may expire `raw/` after a repair/audit window. Canonical objects and
 manifests are retained according to the organization's policy.
@@ -276,7 +290,9 @@ routing, explicit-project failures, progress behavior, and status output.
 Bulk Export and the Runs API encode a few equivalent values differently. Bulk may
 pad inferred nested objects with null keys, add one JSON layer to LangChain's reserved
 `inputs.input`, omit the derived `child_run_ids`, and return unzoned UTC event times.
-The archive reader safely normalizes the latter three. It deliberately preserves
+It also emits tags/topology lists as JSON text and omits usage-detail maps. Canonical
+schema v2 normalizes those physical differences before publication; the archive
+reader safely normalizes the remaining SDK differences. It deliberately preserves
 nested nulls because the live CLI promises not to coerce or discard them. Parquet
 schema union cannot always distinguish an absent object member from an explicit null,
 so raw JSON is not universally byte-identical; semantic comparison must treat missing

--- a/docs/TRACE_ARCHIVE_DESIGN.md
+++ b/docs/TRACE_ARCHIVE_DESIGN.md
@@ -194,7 +194,11 @@ normalized to these types before canonical union.
 Manifest schema v1 remains readable. Readers normalize each published generation to
 v2 independently before cross-day `UNION ALL BY NAME`, so old JSON-text tags and
 parent IDs cannot dictate the type of new list columns. The next publication for an
-unsealed v1 day upgrades its manifest and canonical Parquet atomically to v2.
+unsealed v1 day upgrades its manifest and canonical Parquet atomically to v2. The
+upgrade re-canonicalizes v1 text-dimension raw on the same row-group-bounded
+streaming path as v2 raw (dimension values are parsed per byte-bounded row group),
+so migrating an unsealed whale day never re-enters the day-scaled SQL union.
+Id-only empty snapshots likewise never demote a day off the streaming path.
 
 The bucket owner may expire `raw/` after a repair/audit window. Canonical objects and
 manifests are retained according to the organization's policy.

--- a/docs/work-in-progress/tickets/codex-typed-queryable-dimensions-test-plan.md
+++ b/docs/work-in-progress/tickets/codex-typed-queryable-dimensions-test-plan.md
@@ -1,0 +1,19 @@
+# Typed queryable archive dimensions: test plan
+
+- [x] `test_canonical_schema_v2_uses_stable_queryable_types` — sync a real SDK
+  `Run` through the Runs API path and prove the published Parquet uses string lists
+  for tags/topology, typed maps for usage breakdowns, and an extracted metadata map
+  while arbitrary payloads remain JSON text.
+- [x] `test_mixed_v1_v2_archive_days_query_through_one_normalized_relation` — publish
+  adjacent legacy/current days, then exercise list, tag filtering, and strict SDK
+  validation across both canonical schemas without rewriting the legacy artifact.
+- [x] `test_reconciliation_upgrades_an_unsealed_v1_manifest_to_v2` — resume a legacy
+  project-day and prove the next canonical publication advertises the current schema.
+- [x] Extend the Runs API/Bulk Export reconciliation integration test so provider
+  boundaries preserve the same typed dimensions and metadata extraction.
+- [x] Keep corrupt/unknown manifest-version coverage: versions 1 and 2 are readable;
+  any other version fails at the typed storage boundary.
+
+External systems are represented by the existing strict `Run` models, fake Runs
+client, fake Bulk Export provider, local archive store, real DuckDB, and real PyArrow
+Parquet readers. No production function or schema model is mocked.

--- a/docs/work-in-progress/tickets/codex-typed-queryable-dimensions-test-plan.md
+++ b/docs/work-in-progress/tickets/codex-typed-queryable-dimensions-test-plan.md
@@ -14,6 +14,22 @@
 - [x] Keep corrupt/unknown manifest-version coverage: versions 1 and 2 are readable;
   any other version fails at the typed storage boundary.
 
+Post-rebase additions (after #170 landed and the taxonomy moved to
+`archive/parquet.py`, shared with the local trace backend):
+
+- [x] `test_empty_snapshot_does_not_route_the_day_through_the_sql_path` — an
+  id-only empty phase must not veto the bounded streaming path for the day's
+  real snapshot (SQL canonicalization is monkeypatched to fail the test).
+- [x] `test_unsealed_v1_text_raw_migrates_to_v2_on_the_bounded_streaming_path` —
+  feeds genuine v1-writer raw (text tags/topology, inferred detail columns,
+  string-encoded Decimal costs, no metadata column) through reconciliation and
+  proves a typed v2 canonical publication without the day-scaled SQL union.
+  Both tests were verified to fail against the pre-fix dispatch guard.
+- [x] Local fragments adopt the same typed schema through the shared
+  `write_runs_parquet` path; `LOCAL_TRACE_SCHEMA_VERSION` bumped to 2 and a
+  version-mismatched catalog reads as empty (local is a disposable replica),
+  covered by the updated local trace model test.
+
 External systems are represented by the existing strict `Run` models, fake Runs
 client, fake Bulk Export provider, local archive store, real DuckDB, and real PyArrow
 Parquet readers. No production function or schema model is mocked.

--- a/skills/langsmith/references/archive.md
+++ b/skills/langsmith/references/archive.md
@@ -240,6 +240,13 @@ schema with null members, while the Runs API may omit those members. Because the
 preserves explicit nested nulls, raw JSON is not universally byte-identical; compare
 missing and null object members as equivalent when validating provider parity.
 
+Canonical schema v2 stores `tags` and `parent_run_ids` as native string lists;
+prompt/completion token and cost breakdowns as typed maps; and a queryable
+`map<string,string>` projection of `extra.metadata`. Full `extra`, inputs, outputs,
+events, and feedback remain JSON text because their shapes are arbitrary. Existing
+v1 project-days remain queryable: readers normalize each generation before union,
+and the next write to an unsealed v1 day upgrades it to v2.
+
 See `docs/TRACE_ARCHIVE_DESIGN.md` for storage layout, reconciliation,
 deduplication, crash recovery, IAM boundaries, and efficiency decisions.
 

--- a/src/langsmith_cli/archive/duckdb.py
+++ b/src/langsmith_cli/archive/duckdb.py
@@ -59,6 +59,19 @@ class DuckConnection(Protocol):
     def fetchmany(self, size: int = 1) -> list[tuple[Any, ...]]: ...
 
 
+def sql_string(value: str) -> str:
+    """Quote one SQL string literal (paths/URIs interpolated into DDL/COPY)."""
+    return "'" + value.replace("'", "''") + "'"
+
+
+def source_column_names(connection: Any, source: str) -> set[str]:
+    """The column names one FROM-able source exposes, via DESCRIBE."""
+    return {
+        str(row[0])
+        for row in connection.execute(f"DESCRIBE SELECT * FROM {source}").fetchall()
+    }
+
+
 def configure_duckdb_resources(
     connection: DuckConnection,
     staging_directory: Path,

--- a/src/langsmith_cli/archive/models.py
+++ b/src/langsmith_cli/archive/models.py
@@ -10,6 +10,10 @@ from typing import NotRequired, TypedDict
 from uuid import UUID
 
 
+ARCHIVE_SCHEMA_VERSION = 2
+SUPPORTED_ARCHIVE_SCHEMA_VERSIONS = frozenset({1, ARCHIVE_SCHEMA_VERSION})
+
+
 class ArchivePhase(str, Enum):
     PRIMARY = "primary"
     RECONCILIATION = "reconciliation"
@@ -142,7 +146,7 @@ class ArchiveManifest:
 
     def __post_init__(self) -> None:
         """Enforce structural invariants for both working and published manifests."""
-        if self.schema_version != 1:
+        if self.schema_version not in SUPPORTED_ARCHIVE_SCHEMA_VERSIONS:
             raise ValueError(
                 f"Unsupported archive schema version: {self.schema_version}"
             )

--- a/src/langsmith_cli/archive/parquet.py
+++ b/src/langsmith_cli/archive/parquet.py
@@ -13,21 +13,30 @@ if TYPE_CHECKING:
     from langsmith.schemas import Run
 
 
-# Canonical Parquet stores nested provider fields as JSON text. Runs API JSONL is
-# inferred as STRUCT/LIST while Bulk Export v2 emits VARCHAR for the same fields;
-# this one contract keeps every fragment provider- and source-compatible.
+# Canonical Parquet keeps arbitrary payloads as JSON text and promotes only
+# shape-stable, queryable dimensions to native lists/maps. This explicit taxonomy
+# prevents provider keys from becoming inferred STRUCT children, and one contract
+# keeps every fragment provider- and source-compatible.
 ARCHIVE_JSON_OBJECT_COLUMNS = (
     "extra",
     "inputs",
     "outputs",
     "feedback_stats",
 )
-ARCHIVE_JSON_LIST_COLUMNS = (
-    "events",
-    "tags",
-    "parent_run_ids",
-)
+ARCHIVE_JSON_LIST_COLUMNS = ("events",)
 ARCHIVE_JSON_COLUMNS = ARCHIVE_JSON_OBJECT_COLUMNS + ARCHIVE_JSON_LIST_COLUMNS
+ARCHIVE_STRING_LIST_COLUMNS = ("tags", "parent_run_ids")
+BULK_EXPORT_JSON_COLUMNS = ARCHIVE_JSON_COLUMNS + ARCHIVE_STRING_LIST_COLUMNS
+ARCHIVE_INTEGER_MAP_COLUMNS = (
+    "prompt_token_details",
+    "completion_token_details",
+)
+ARCHIVE_DECIMAL_MAP_COLUMNS = (
+    "prompt_cost_details",
+    "completion_cost_details",
+)
+ARCHIVE_TYPED_MAP_COLUMNS = ARCHIVE_INTEGER_MAP_COLUMNS + ARCHIVE_DECIMAL_MAP_COLUMNS
+ARCHIVE_METADATA_COLUMN = "metadata"
 
 
 def normalize_event_time(value: object) -> object:
@@ -47,6 +56,13 @@ def normalize_event_time(value: object) -> object:
 
 def normalize_run_payload(payload: dict[str, Any]) -> dict[str, Any]:
     """Normalize provider-specific Parquet values to the LangSmith Run contract."""
+    # ``metadata`` is a physical query accelerator extracted from ``extra``; the
+    # strict SDK Run contract continues to receive the authoritative full object.
+    payload.pop(ARCHIVE_METADATA_COLUMN, None)
+    # Managed Bulk Export omits attachments. UNION BY NAME materializes that
+    # absence as NULL, while the SDK contract expects the field omitted/defaulted.
+    if "attachments" in payload and payload["attachments"] is None:
+        payload.pop("attachments")
     for field in (
         "id",
         "trace_id",
@@ -65,6 +81,7 @@ def normalize_run_payload(payload: dict[str, Any]) -> dict[str, Any]:
     expected_json_types = {
         **dict.fromkeys(ARCHIVE_JSON_OBJECT_COLUMNS, dict),
         **dict.fromkeys(ARCHIVE_JSON_LIST_COLUMNS, list),
+        **dict.fromkeys(ARCHIVE_STRING_LIST_COLUMNS, list),
     }
     for field, expected_type in expected_json_types.items():
         value = payload[field] if field in payload else None
@@ -147,7 +164,10 @@ def parquet_where_clause(query: RunQuery) -> tuple[str, list[object]]:
             "parent_run_id IS NULL" if query.is_root else "parent_run_id IS NOT NULL"
         )
     for tag in query.tags:
-        clauses.append("json_contains(CAST(tags AS JSON), to_json(?))")
+        # Every reader path materializes ``tags`` as a native VARCHAR[] (typed v2
+        # fragments directly; v1 archive generations through the normalized view),
+        # so list predicates push down into Parquet instead of re-parsing JSON.
+        clauses.append("list_contains(tags, ?)")
         parameters.append(tag)
     if query.text is not None:
         # Field identifiers come only from RunQuery's explicit allowlist. Every user

--- a/src/langsmith_cli/archive/parquet.py
+++ b/src/langsmith_cli/archive/parquet.py
@@ -37,6 +37,63 @@ ARCHIVE_DECIMAL_MAP_COLUMNS = (
 )
 ARCHIVE_TYPED_MAP_COLUMNS = ARCHIVE_INTEGER_MAP_COLUMNS + ARCHIVE_DECIMAL_MAP_COLUMNS
 ARCHIVE_METADATA_COLUMN = "metadata"
+ARCHIVE_DIMENSION_COLUMNS = (
+    *ARCHIVE_STRING_LIST_COLUMNS,
+    *ARCHIVE_TYPED_MAP_COLUMNS,
+    ARCHIVE_METADATA_COLUMN,
+)
+
+# The single SQL spelling of each promoted dimension's physical type. Every
+# writer and reader path that projects onto the canonical contract builds its
+# CAST/NULL expressions from this map — adding a dimension means adding it to
+# the column tuples above and here, nowhere else.
+ARCHIVE_DIMENSION_SQL_TYPES: dict[str, str] = {
+    **dict.fromkeys(ARCHIVE_STRING_LIST_COLUMNS, "VARCHAR[]"),
+    **dict.fromkeys(ARCHIVE_INTEGER_MAP_COLUMNS, "MAP(VARCHAR, BIGINT)"),
+    **dict.fromkeys(ARCHIVE_DECIMAL_MAP_COLUMNS, "MAP(VARCHAR, DECIMAL(38,18))"),
+    ARCHIVE_METADATA_COLUMN: "MAP(VARCHAR, VARCHAR)",
+}
+
+
+def json_dimension_projection(
+    columns: set[str], *, metadata_column_is_canonical: bool
+) -> tuple[list[str], list[str]]:
+    """SQL that projects JSON-text/absent dimension columns onto canonical types.
+
+    One projection serves every path that meets v1-era or provider JSON text:
+    Bulk Export snapshots, legacy SQL canonicalization, and the query-time
+    normalized view. Returns ``(excluded_columns, expressions)`` for a
+    ``SELECT * EXCLUDE (...), <expressions> FROM ...``.
+
+    ``metadata_column_is_canonical`` controls an existing ``metadata`` column:
+    the SQL canonicalizer may re-read its own typed output (pass ``True`` to
+    cast it through), while provider sources never carry a canonical
+    ``metadata`` column (pass ``False`` to re-derive from ``extra``, keeping
+    the accelerator consistent with its authoritative source).
+    """
+    excluded = [column for column in ARCHIVE_DIMENSION_COLUMNS if column in columns]
+    expressions = [
+        f"CAST(CAST({column} AS JSON) AS {ARCHIVE_DIMENSION_SQL_TYPES[column]}) "
+        f"AS {column}"
+        if column in columns
+        else f"NULL::{ARCHIVE_DIMENSION_SQL_TYPES[column]} AS {column}"
+        for column in (*ARCHIVE_STRING_LIST_COLUMNS, *ARCHIVE_TYPED_MAP_COLUMNS)
+    ]
+    metadata_type = ARCHIVE_DIMENSION_SQL_TYPES[ARCHIVE_METADATA_COLUMN]
+    if metadata_column_is_canonical and ARCHIVE_METADATA_COLUMN in columns:
+        expressions.append(
+            f"CAST({ARCHIVE_METADATA_COLUMN} AS {metadata_type}) "
+            f"AS {ARCHIVE_METADATA_COLUMN}"
+        )
+    elif "extra" in columns:
+        expressions.append(
+            "coalesce(CAST(json_extract(CAST(extra AS JSON), '$.metadata') "
+            f"AS {metadata_type}), map()::{metadata_type}) "
+            f"AS {ARCHIVE_METADATA_COLUMN}"
+        )
+    else:
+        expressions.append(f"map()::{metadata_type} AS {ARCHIVE_METADATA_COLUMN}")
+    return excluded, expressions
 
 
 def normalize_event_time(value: object) -> object:
@@ -103,12 +160,7 @@ def normalize_run_payload(payload: dict[str, Any]) -> dict[str, Any]:
             if not isinstance(event, dict) or "time" not in event:
                 continue
             event["time"] = normalize_event_time(event["time"])
-    for details_field in (
-        "prompt_token_details",
-        "completion_token_details",
-        "prompt_cost_details",
-        "completion_cost_details",
-    ):
+    for details_field in ARCHIVE_TYPED_MAP_COLUMNS:
         if details_field not in payload:
             continue
         details = payload[details_field]

--- a/src/langsmith_cli/archive/query.py
+++ b/src/langsmith_cli/archive/query.py
@@ -12,13 +12,12 @@ from langsmith_cli.archive.config import load_archive_config
 from langsmith_cli.archive.duckdb import (
     archive_duckdb_connection,
     configure_duckdb_s3,
+    source_column_names,
+    sql_string,
 )
 from langsmith_cli.archive.models import ARCHIVE_SCHEMA_VERSION
 from langsmith_cli.archive.parquet import (
-    ARCHIVE_DECIMAL_MAP_COLUMNS,
-    ARCHIVE_INTEGER_MAP_COLUMNS,
-    ARCHIVE_METADATA_COLUMN,
-    ARCHIVE_STRING_LIST_COLUMNS,
+    json_dimension_projection,
     normalize_run_payload,
     parquet_where_clause as _where_clause,
     validated_parquet_run as _validated_archive_run,
@@ -169,21 +168,11 @@ def _date_partition_overlaps(
     )
 
 
-def _sql_string(value: str) -> str:
-    return "'" + value.replace("'", "''") + "'"
-
-
 def _create_normalized_runs_view(
     connection: Any, sources: list[CanonicalArchiveSource]
 ) -> None:
     """Expose v1/v2 files through the current typed physical contract."""
     selects: list[str] = []
-    typed_columns = (
-        *ARCHIVE_STRING_LIST_COLUMNS,
-        *ARCHIVE_INTEGER_MAP_COLUMNS,
-        *ARCHIVE_DECIMAL_MAP_COLUMNS,
-        ARCHIVE_METADATA_COLUMN,
-    )
     current_uris = [
         source.uri
         for source in sources
@@ -196,43 +185,19 @@ def _create_normalized_runs_view(
     ]
     if current_uris:
         current = (
-            f"read_parquet([{', '.join(_sql_string(uri) for uri in current_uris)}], "
+            f"read_parquet([{', '.join(sql_string(uri) for uri in current_uris)}], "
             "union_by_name=true, hive_partitioning=false)"
         )
         # v2 is already the query contract. Keeping this projection as an identity
         # lets DuckDB push tag/list predicates and column projection into Parquet.
         selects.append(f"SELECT * FROM {current}")
     for uri in legacy_uris:
-        parquet = f"read_parquet({_sql_string(uri)}, hive_partitioning=false)"
-        columns = {
-            str(row[0])
-            for row in connection.execute(
-                f"DESCRIBE SELECT * FROM {parquet}"
-            ).fetchall()
-        }
-        excluded = [column for column in typed_columns if column in columns]
-        projection = [
-            f"CAST(CAST({column} AS JSON) AS VARCHAR[]) AS {column}"
-            if column in columns
-            else f"NULL::VARCHAR[] AS {column}"
-            for column in ARCHIVE_STRING_LIST_COLUMNS
-        ]
-        projection.extend(
-            f"CAST(CAST({column} AS JSON) AS MAP(VARCHAR, BIGINT)) AS {column}"
-            if column in columns
-            else f"NULL::MAP(VARCHAR, BIGINT) AS {column}"
-            for column in ARCHIVE_INTEGER_MAP_COLUMNS
-        )
-        projection.extend(
-            f"CAST(CAST({column} AS JSON) AS MAP(VARCHAR, DECIMAL(38,18))) AS {column}"
-            if column in columns
-            else f"NULL::MAP(VARCHAR, DECIMAL(38,18)) AS {column}"
-            for column in ARCHIVE_DECIMAL_MAP_COLUMNS
-        )
-        projection.append(
-            "coalesce(CAST(json_extract(CAST(extra AS JSON), '$.metadata') "
-            "AS MAP(VARCHAR, VARCHAR)), map()::MAP(VARCHAR, VARCHAR)) "
-            f"AS {ARCHIVE_METADATA_COLUMN}"
+        parquet = f"read_parquet({sql_string(uri)}, hive_partitioning=false)"
+        excluded, projection = json_dimension_projection(
+            source_column_names(connection, parquet),
+            # A v1 file never carries a canonical metadata column; any such
+            # column is provider noise, so re-derive from authoritative extra.
+            metadata_column_is_canonical=False,
         )
         exclude_sql = f" EXCLUDE ({', '.join(excluded)})" if excluded else ""
         selects.append(f"SELECT *{exclude_sql}, {', '.join(projection)} FROM {parquet}")
@@ -278,7 +243,11 @@ def query_archive_runs(
 def count_archive_runs(
     query: ArchiveRunQuery, *, config_path: str | None = None
 ) -> int:
-    """Count matching runs using Parquet metadata/predicate pushdown only."""
+    """Count matching runs without materializing them.
+
+    v2 sources stay on Parquet metadata/predicate pushdown; legacy v1 sources
+    pay a per-row JSON cast inside the normalized view before counting.
+    """
     sources = _canonical_sources(query, config_path)
     if not sources:
         return 0

--- a/src/langsmith_cli/archive/query.py
+++ b/src/langsmith_cli/archive/query.py
@@ -2,17 +2,23 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta, timezone
 from fnmatch import fnmatchcase
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from langsmith_cli.archive.config import load_archive_config
 from langsmith_cli.archive.duckdb import (
     archive_duckdb_connection,
     configure_duckdb_s3,
 )
+from langsmith_cli.archive.models import ARCHIVE_SCHEMA_VERSION
 from langsmith_cli.archive.parquet import (
+    ARCHIVE_DECIMAL_MAP_COLUMNS,
+    ARCHIVE_INTEGER_MAP_COLUMNS,
+    ARCHIVE_METADATA_COLUMN,
+    ARCHIVE_STRING_LIST_COLUMNS,
     normalize_run_payload,
     parquet_where_clause as _where_clause,
     validated_parquet_run as _validated_archive_run,
@@ -38,6 +44,12 @@ ArchiveRunQuery = RunQuery
 _normalize_run_payload = normalize_run_payload
 
 
+@dataclass(frozen=True)
+class CanonicalArchiveSource:
+    uri: str
+    schema_version: int
+
+
 def _project_matches(
     query: ArchiveRunQuery, project_id: str, project_name: str
 ) -> bool:
@@ -58,11 +70,13 @@ def _project_matches(
     return True
 
 
-def _canonical_uris(query: ArchiveRunQuery, config_path: str | None) -> list[str]:
+def _canonical_sources(
+    query: ArchiveRunQuery, config_path: str | None
+) -> list[CanonicalArchiveSource]:
     config = load_archive_config(config_path)
     since = ensure_aware_datetime(query.since)
     before = ensure_aware_datetime(query.before)
-    uris: list[str] = []
+    sources: list[CanonicalArchiveSource] = []
     exact = query.project or query.project_name or query.project_name_exact
     routes = (config.route_project(exact),) if exact is not None else config.routes
     for route in routes:
@@ -136,8 +150,13 @@ def _canonical_uris(query: ArchiveRunQuery, config_path: str | None) -> list[str
             # immediate, deterministic zero instead of referencing absent columns.
             if manifest.canonical_run_count == 0:
                 continue
-            uris.append(store.object_uri(manifest.canonical_key))
-    return sorted(set(uris))
+            sources.append(
+                CanonicalArchiveSource(
+                    uri=store.object_uri(manifest.canonical_key),
+                    schema_version=manifest.schema_version,
+                )
+            )
+    return sorted(set(sources), key=lambda source: source.uri)
 
 
 def _date_partition_overlaps(
@@ -150,26 +169,103 @@ def _date_partition_overlaps(
     )
 
 
+def _sql_string(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _create_normalized_runs_view(
+    connection: Any, sources: list[CanonicalArchiveSource]
+) -> None:
+    """Expose v1/v2 files through the current typed physical contract."""
+    selects: list[str] = []
+    typed_columns = (
+        *ARCHIVE_STRING_LIST_COLUMNS,
+        *ARCHIVE_INTEGER_MAP_COLUMNS,
+        *ARCHIVE_DECIMAL_MAP_COLUMNS,
+        ARCHIVE_METADATA_COLUMN,
+    )
+    current_uris = [
+        source.uri
+        for source in sources
+        if source.schema_version == ARCHIVE_SCHEMA_VERSION
+    ]
+    legacy_uris = [
+        source.uri
+        for source in sources
+        if source.schema_version != ARCHIVE_SCHEMA_VERSION
+    ]
+    if current_uris:
+        current = (
+            f"read_parquet([{', '.join(_sql_string(uri) for uri in current_uris)}], "
+            "union_by_name=true, hive_partitioning=false)"
+        )
+        # v2 is already the query contract. Keeping this projection as an identity
+        # lets DuckDB push tag/list predicates and column projection into Parquet.
+        selects.append(f"SELECT * FROM {current}")
+    for uri in legacy_uris:
+        parquet = f"read_parquet({_sql_string(uri)}, hive_partitioning=false)"
+        columns = {
+            str(row[0])
+            for row in connection.execute(
+                f"DESCRIBE SELECT * FROM {parquet}"
+            ).fetchall()
+        }
+        excluded = [column for column in typed_columns if column in columns]
+        projection = [
+            f"CAST(CAST({column} AS JSON) AS VARCHAR[]) AS {column}"
+            if column in columns
+            else f"NULL::VARCHAR[] AS {column}"
+            for column in ARCHIVE_STRING_LIST_COLUMNS
+        ]
+        projection.extend(
+            f"CAST(CAST({column} AS JSON) AS MAP(VARCHAR, BIGINT)) AS {column}"
+            if column in columns
+            else f"NULL::MAP(VARCHAR, BIGINT) AS {column}"
+            for column in ARCHIVE_INTEGER_MAP_COLUMNS
+        )
+        projection.extend(
+            f"CAST(CAST({column} AS JSON) AS MAP(VARCHAR, DECIMAL(38,18))) AS {column}"
+            if column in columns
+            else f"NULL::MAP(VARCHAR, DECIMAL(38,18)) AS {column}"
+            for column in ARCHIVE_DECIMAL_MAP_COLUMNS
+        )
+        projection.append(
+            "coalesce(CAST(json_extract(CAST(extra AS JSON), '$.metadata') "
+            "AS MAP(VARCHAR, VARCHAR)), map()::MAP(VARCHAR, VARCHAR)) "
+            f"AS {ARCHIVE_METADATA_COLUMN}"
+        )
+        exclude_sql = f" EXCLUDE ({', '.join(excluded)})" if excluded else ""
+        selects.append(f"SELECT *{exclude_sql}, {', '.join(projection)} FROM {parquet}")
+    # INVARIANT: all cross-day unions happen only after each generation has been
+    # normalized independently, so a v1 VARCHAR can never dictate a v2 list/map.
+    connection.execute(
+        "CREATE TEMP VIEW canonical_archive_runs AS "
+        + " UNION ALL BY NAME ".join(selects)
+    )
+
+
 def query_archive_runs(
     query: ArchiveRunQuery, *, config_path: str | None = None
 ) -> list[Run]:
     """Return LangSmith Run contracts populated from canonical Parquet."""
-    uris = _canonical_uris(query, config_path)
-    if not uris:
+    sources = _canonical_sources(query, config_path)
+    if not sources:
         return []
 
     where, where_parameters = _where_clause(query)
-    parameters: list[object] = [uris, *where_parameters]
+    parameters: list[object] = list(where_parameters)
     limit = "" if query.limit is None or query.limit == 0 else " LIMIT ?"
     if limit:
         parameters.append(query.limit)
     sql = (
-        "SELECT * FROM read_parquet(?, union_by_name=true)"
-        f"{where} ORDER BY start_time DESC, CAST(id AS VARCHAR) ASC{limit}"
+        f"SELECT * FROM canonical_archive_runs{where} "
+        f"ORDER BY start_time DESC, CAST(id AS VARCHAR) ASC{limit}"
     )
 
     with archive_duckdb_connection() as connection:
+        uris = [source.uri for source in sources]
         configure_duckdb_s3(connection, uris)
+        _create_normalized_runs_view(connection, sources)
         cursor = connection.execute(sql, parameters)
         columns = [description[0] for description in cursor.description]
         runs: list[Run] = []
@@ -183,15 +279,17 @@ def count_archive_runs(
     query: ArchiveRunQuery, *, config_path: str | None = None
 ) -> int:
     """Count matching runs using Parquet metadata/predicate pushdown only."""
-    uris = _canonical_uris(query, config_path)
-    if not uris:
+    sources = _canonical_sources(query, config_path)
+    if not sources:
         return 0
     where, parameters = _where_clause(query)
     with archive_duckdb_connection() as connection:
+        uris = [source.uri for source in sources]
         configure_duckdb_s3(connection, uris)
+        _create_normalized_runs_view(connection, sources)
         row = connection.execute(
-            f"SELECT count(*) FROM read_parquet(?, union_by_name=true){where}",
-            [uris, *parameters],
+            f"SELECT count(*) FROM canonical_archive_runs{where}",
+            parameters,
         ).fetchone()
         if row is None:
             raise ValueError("DuckDB did not return an archive count")
@@ -208,7 +306,7 @@ def read_archived_run(
     before: datetime | None = None,
     config_path: str | None = None,
 ) -> tuple[Run, list[Run]]:
-    uris = _canonical_uris(
+    sources = _canonical_sources(
         ArchiveRunQuery(
             project=project,
             project_id=project_id,
@@ -218,14 +316,16 @@ def read_archived_run(
         ),
         config_path,
     )
-    if not uris:
+    if not sources:
         raise LookupError(f"Archived run not found: {run_id}")
     with archive_duckdb_connection() as connection:
+        uris = [source.uri for source in sources]
         configure_duckdb_s3(connection, uris)
+        _create_normalized_runs_view(connection, sources)
         cursor = connection.execute(
-            "SELECT * FROM read_parquet(?, union_by_name=true) "
+            "SELECT * FROM canonical_archive_runs "
             "WHERE CAST(id AS VARCHAR) = ? LIMIT 1",
-            [uris, run_id],
+            [run_id],
         )
         row = cursor.fetchone()
         if row is None:
@@ -235,10 +335,10 @@ def read_archived_run(
         children: list[Run] = []
         if follow_children:
             child_cursor = connection.execute(
-                "SELECT * FROM read_parquet(?, union_by_name=true) "
+                "SELECT * FROM canonical_archive_runs "
                 "WHERE CAST(trace_id AS VARCHAR) = ? AND CAST(id AS VARCHAR) != ? "
                 "ORDER BY start_time",
-                [uris, str(run.trace_id or run.id), run_id],
+                [str(run.trace_id or run.id), run_id],
             )
             child_columns = [description[0] for description in child_cursor.description]
             children = [

--- a/src/langsmith_cli/archive/sync.py
+++ b/src/langsmith_cli/archive/sync.py
@@ -16,13 +16,24 @@ from uuid import uuid4
 from uuid import UUID
 
 from langsmith_cli.archive.models import (
+    ARCHIVE_SCHEMA_VERSION,
     ArchiveManifest,
     ArchivePhase,
     ArchiveProject,
     PhaseRecord,
     PhaseStatus,
 )
-from langsmith_cli.archive.parquet import ARCHIVE_JSON_COLUMNS
+from langsmith_cli.archive.parquet import (
+    ARCHIVE_DECIMAL_MAP_COLUMNS,
+    ARCHIVE_INTEGER_MAP_COLUMNS,
+    ARCHIVE_JSON_COLUMNS,
+    ARCHIVE_JSON_LIST_COLUMNS,
+    ARCHIVE_JSON_OBJECT_COLUMNS,
+    ARCHIVE_METADATA_COLUMN,
+    ARCHIVE_STRING_LIST_COLUMNS,
+    ARCHIVE_TYPED_MAP_COLUMNS,
+    BULK_EXPORT_JSON_COLUMNS,
+)
 from langsmith_cli.archive.duckdb import (
     ARCHIVE_PARQUET_COPY_OPTIONS,
     archive_duckdb_connection,
@@ -40,6 +51,29 @@ from langsmith_cli.archive.storage import ArchiveStore
 if TYPE_CHECKING:
     from langsmith.schemas import Run
     from langsmith_cli.archive.bulk import BulkWindowExporter
+
+
+# The queryable-dimension taxonomy lives in archive.parquet, shared with the
+# local trace backend. Staging-only column names stay private to this writer.
+_STAGING_METADATA_KEYS = "_archive_metadata_keys"
+_STAGING_METADATA_VALUES = "_archive_metadata_values"
+
+# Re-exported for tests and the public sync surface (the taxonomy predates the
+# shared parquet module and existing imports reference it from here).
+__all__ = [
+    "ARCHIVE_DECIMAL_MAP_COLUMNS",
+    "ARCHIVE_INTEGER_MAP_COLUMNS",
+    "ARCHIVE_JSON_COLUMNS",
+    "ARCHIVE_JSON_LIST_COLUMNS",
+    "ARCHIVE_JSON_OBJECT_COLUMNS",
+    "ARCHIVE_METADATA_COLUMN",
+    "ARCHIVE_STRING_LIST_COLUMNS",
+    "ARCHIVE_TYPED_MAP_COLUMNS",
+    "BULK_EXPORT_JSON_COLUMNS",
+    "due_trace_dates",
+    "sync_project_day",
+    "write_runs_parquet",
+]
 
 
 class RunsExportClient(Protocol):
@@ -88,7 +122,7 @@ def _new_manifest(
 ) -> ArchiveManifest:
     start = datetime.combine(trace_date, time.min, tzinfo=timezone.utc)
     return ArchiveManifest(
-        schema_version=1,
+        schema_version=ARCHIVE_SCHEMA_VERSION,
         project_id=project_id,
         project_name=project_name,
         trace_date=trace_date,
@@ -135,8 +169,112 @@ def _serialize_run_line(run: Run) -> bytes:
             payload[column] = json.dumps(
                 value, ensure_ascii=False, default=_archive_json_default
             )
+    for column in ARCHIVE_TYPED_MAP_COLUMNS:
+        value = payload[column]
+        if value is not None:
+            payload[column] = json.dumps(
+                value, ensure_ascii=False, default=_archive_json_default
+            )
+    extra = run.extra or {}
+    metadata_value = extra["metadata"] if "metadata" in extra else None
+    if metadata_value is not None and not isinstance(metadata_value, dict):
+        raise ValueError("Run extra.metadata must be an object")
+    metadata = metadata_value or {}
+    if any(not isinstance(key, str) for key in metadata):
+        raise ValueError("Run extra.metadata keys must be strings")
+    payload[_STAGING_METADATA_KEYS] = list(metadata)
+    payload[_STAGING_METADATA_VALUES] = [
+        _metadata_text(value) for value in metadata.values()
+    ]
     line = json.dumps(payload, ensure_ascii=False, default=_archive_json_default)
     return line.encode("utf-8") + b"\n"
+
+
+def _metadata_text(value: object) -> str | None:
+    """Stable textual map value; full-fidelity metadata remains in ``extra``."""
+    if value is None:
+        return None
+    if isinstance(value, Enum):
+        return _metadata_text(value.value)
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (UUID, Decimal)):
+        return str(value)
+    if isinstance(value, (datetime, date, time)):
+        return value.isoformat()
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        default=_archive_json_default,
+    )
+
+
+def _runs_api_snapshot_select(source: str) -> str:
+    excluded = ", ".join(
+        (
+            *ARCHIVE_STRING_LIST_COLUMNS,
+            *ARCHIVE_TYPED_MAP_COLUMNS,
+            _STAGING_METADATA_KEYS,
+            _STAGING_METADATA_VALUES,
+        )
+    )
+    expressions = [
+        *(
+            f"CAST({column} AS VARCHAR[]) AS {column}"
+            for column in ARCHIVE_STRING_LIST_COLUMNS
+        ),
+        *(
+            f"CASE WHEN {column} IS NULL THEN NULL::MAP(VARCHAR, BIGINT) "
+            f"ELSE CAST(CAST({column} AS JSON) AS MAP(VARCHAR, BIGINT)) END AS {column}"
+            for column in ARCHIVE_INTEGER_MAP_COLUMNS
+        ),
+        *(
+            f"CASE WHEN {column} IS NULL THEN NULL::MAP(VARCHAR, DECIMAL(38,18)) "
+            f"ELSE CAST(CAST({column} AS JSON) AS MAP(VARCHAR, DECIMAL(38,18))) END AS {column}"
+            for column in ARCHIVE_DECIMAL_MAP_COLUMNS
+        ),
+        f"map(CAST({_STAGING_METADATA_KEYS} AS VARCHAR[]), "
+        f"CAST({_STAGING_METADATA_VALUES} AS VARCHAR[])) AS {ARCHIVE_METADATA_COLUMN}",
+    ]
+    return f"(SELECT * EXCLUDE ({excluded}), {', '.join(expressions)} FROM {source})"
+
+
+def _bulk_snapshot_select(source: str, columns: set[str]) -> str:
+    typed_columns = (
+        *ARCHIVE_STRING_LIST_COLUMNS,
+        *ARCHIVE_TYPED_MAP_COLUMNS,
+        ARCHIVE_METADATA_COLUMN,
+    )
+    excluded = ", ".join(column for column in typed_columns if column in columns)
+    expressions = [
+        *(
+            f"CASE WHEN {column} IS NULL THEN NULL::VARCHAR[] "
+            f"ELSE CAST(CAST({column} AS JSON) AS VARCHAR[]) END AS {column}"
+            if column in columns
+            else f"NULL::VARCHAR[] AS {column}"
+            for column in ARCHIVE_STRING_LIST_COLUMNS
+        ),
+        *(
+            f"CAST(CAST({column} AS JSON) AS MAP(VARCHAR, BIGINT)) AS {column}"
+            if column in columns
+            else f"NULL::MAP(VARCHAR, BIGINT) AS {column}"
+            for column in ARCHIVE_INTEGER_MAP_COLUMNS
+        ),
+        *(
+            f"CAST(CAST({column} AS JSON) AS MAP(VARCHAR, DECIMAL(38,18))) AS {column}"
+            if column in columns
+            else f"NULL::MAP(VARCHAR, DECIMAL(38,18)) AS {column}"
+            for column in ARCHIVE_DECIMAL_MAP_COLUMNS
+        ),
+    ]
+    expressions.append(
+        "coalesce(CAST(json_extract(CAST(extra AS JSON), '$.metadata') "
+        "AS MAP(VARCHAR, VARCHAR)), map()::MAP(VARCHAR, VARCHAR)) "
+        f"AS {ARCHIVE_METADATA_COLUMN}"
+    )
+    exclude_sql = f" EXCLUDE ({excluded})" if excluded else ""
+    return f"(SELECT *{exclude_sql}, {', '.join(expressions)} FROM {source})"
 
 
 def _uuid_text(value: Any) -> str | None:
@@ -202,7 +340,6 @@ def _storage_schema(schema: Any) -> Any:
 
 
 def _storage_column(column: Any, target_type: Any) -> Any:
-
     import pyarrow
 
     if column.type.equals(target_type):
@@ -315,7 +452,9 @@ def write_runs_parquet(runs: Iterator[Run], target: Path) -> int:
                     f"TO {_sql_string(str(target))} " + ARCHIVE_PARQUET_COPY_OPTIONS
                 )
             elif len(piece_paths) == 1:
-                source = _read_json_source(piece_paths[0], piece_max_lines[0])
+                source = _runs_api_snapshot_select(
+                    _read_json_source(piece_paths[0], piece_max_lines[0])
+                )
                 connection.execute(
                     f"COPY (SELECT * FROM {source}) "
                     f"TO {_sql_string(str(target))} " + ARCHIVE_PARQUET_COPY_OPTIONS
@@ -323,7 +462,9 @@ def write_runs_parquet(runs: Iterator[Run], target: Path) -> int:
             else:
                 for piece_path, max_line in zip(piece_paths, piece_max_lines):
                     part_path = piece_path.with_suffix(".part")
-                    source = _read_json_source(piece_path, max_line)
+                    source = _runs_api_snapshot_select(
+                        _read_json_source(piece_path, max_line)
+                    )
                     connection.execute(
                         f"COPY (SELECT * FROM {source}) "
                         f"TO {_sql_string(str(part_path))} "
@@ -394,6 +535,13 @@ def _write_bulk_parquet(
                 raise ValueError("Bulk export row count does not match Parquet")
             if counts[0] != counts[1]:
                 raise ValueError("Bulk export contains duplicate run IDs")
+            columns = {
+                str(row[0])
+                for row in connection.execute(
+                    f"DESCRIBE SELECT * FROM {source}"
+                ).fetchall()
+            }
+            source = _bulk_snapshot_select(source, columns)
             connection.execute(
                 f"COPY (SELECT * FROM {source}) TO {_sql_string(str(target))} "
                 + ARCHIVE_PARQUET_COPY_OPTIONS
@@ -436,6 +584,236 @@ def _payload_columns_are_text(schema: Any) -> bool:
         ):
             return False
     return True
+
+
+def _query_dimensions_are_typed(schema: Any) -> bool:
+    """Return whether one raw generation already satisfies canonical v2 types."""
+    import pyarrow
+
+    fields = {field.name: field.type for field in schema}
+    for column in ARCHIVE_STRING_LIST_COLUMNS:
+        data_type = fields[column] if column in fields else None
+        if data_type is None or not pyarrow.types.is_list(data_type):
+            return False
+        if not pyarrow.types.is_string(data_type.value_type):
+            return False
+    expected_maps = {
+        **dict.fromkeys(ARCHIVE_INTEGER_MAP_COLUMNS, pyarrow.int64()),
+        **dict.fromkeys(ARCHIVE_DECIMAL_MAP_COLUMNS, pyarrow.decimal128(38, 18)),
+        ARCHIVE_METADATA_COLUMN: pyarrow.string(),
+    }
+    for column, value_type in expected_maps.items():
+        data_type = fields[column] if column in fields else None
+        if data_type is None or not pyarrow.types.is_map(data_type):
+            return False
+        if not pyarrow.types.is_string(data_type.key_type):
+            return False
+        if not data_type.item_type.equals(value_type):
+            return False
+    return True
+
+
+def _typed_dimension_types() -> dict[str, Any]:
+    """Canonical v2 Arrow type for every promoted queryable dimension."""
+    import pyarrow
+
+    return {
+        **dict.fromkeys(
+            ARCHIVE_STRING_LIST_COLUMNS, pyarrow.list_(pyarrow.string())
+        ),
+        **dict.fromkeys(
+            ARCHIVE_INTEGER_MAP_COLUMNS,
+            pyarrow.map_(pyarrow.string(), pyarrow.int64()),
+        ),
+        **dict.fromkeys(
+            ARCHIVE_DECIMAL_MAP_COLUMNS,
+            pyarrow.map_(pyarrow.string(), pyarrow.decimal128(38, 18)),
+        ),
+        ARCHIVE_METADATA_COLUMN: pyarrow.map_(pyarrow.string(), pyarrow.string()),
+    }
+
+
+def _dimensions_are_streamable(schema: Any) -> bool:
+    """Return whether dimension columns are v2-typed, v1 JSON text, or absent.
+
+    Any such generation upgrades row-group-wise on the bounded streaming path;
+    only inferred scalar shapes that neither parse nor cast (e.g. a dimension
+    inferred as a bare number) still need SQL normalization.
+    """
+    import pyarrow
+
+    fields = {field.name: field.type for field in schema}
+    for column in (
+        *ARCHIVE_STRING_LIST_COLUMNS,
+        *ARCHIVE_TYPED_MAP_COLUMNS,
+        ARCHIVE_METADATA_COLUMN,
+    ):
+        data_type = fields.get(column)
+        if data_type is None:
+            continue
+        if isinstance(data_type, pyarrow.BaseExtensionType):
+            data_type = data_type.storage_type
+        if (
+            pyarrow.types.is_null(data_type)
+            or pyarrow.types.is_string(data_type)
+            or pyarrow.types.is_large_string(data_type)
+        ):
+            continue
+        if column in ARCHIVE_STRING_LIST_COLUMNS:
+            if pyarrow.types.is_list(data_type) or pyarrow.types.is_large_list(
+                data_type
+            ):
+                continue
+            return False
+        if (
+            pyarrow.types.is_map(data_type)
+            or pyarrow.types.is_struct(data_type)
+        ):
+            continue
+        return False
+    return True
+
+
+def _integer_map_value(value: object) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError("Archived token detail value is not an integer")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    raise ValueError("Archived token detail value is not an integer")
+
+
+def _decimal_map_value(value: object) -> Decimal | None:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, int) and not isinstance(value, bool):
+        return Decimal(value)
+    if isinstance(value, float):
+        return Decimal(str(value))
+    raise ValueError("Archived cost detail value is not a number")
+
+
+def _parsed_dimension_values(
+    column: str, values: list[object]
+) -> list[object]:
+    """Parse one row group's v1 JSON-text dimension values into typed shapes."""
+    if column in ARCHIVE_STRING_LIST_COLUMNS:
+        parsed_lists: list[object] = []
+        for value in values:
+            decoded = json.loads(value) if isinstance(value, str) else value
+            if decoded is not None and not isinstance(decoded, list):
+                raise ValueError(f"Archived JSON field has an invalid type: {column}")
+            parsed_lists.append(decoded)
+        return parsed_lists
+    parsed_maps: list[object] = []
+    decimal_valued = column in ARCHIVE_DECIMAL_MAP_COLUMNS
+    for value in values:
+        decoded = (
+            json.loads(value, parse_float=Decimal)
+            if isinstance(value, str)
+            else value
+        )
+        if decoded is None:
+            parsed_maps.append(None)
+            continue
+        if not isinstance(decoded, dict):
+            raise ValueError(f"Archived JSON field has an invalid type: {column}")
+        converter = _decimal_map_value if decimal_valued else _integer_map_value
+        parsed_maps.append(
+            [(key, converter(item)) for key, item in decoded.items()]
+        )
+    return parsed_maps
+
+
+def _derived_metadata_values(table: Any) -> list[object]:
+    """Derive the metadata accelerator map from v1 JSON-text ``extra`` rows."""
+    if "extra" not in table.schema.names:
+        return [[] for _ in range(table.num_rows)]
+    derived: list[object] = []
+    for extra_text in table.column("extra").to_pylist():
+        extra = json.loads(extra_text) if isinstance(extra_text, str) else None
+        metadata = extra.get(ARCHIVE_METADATA_COLUMN) if isinstance(extra, dict) else None
+        if not isinstance(metadata, dict):
+            derived.append([])
+            continue
+        derived.append(
+            [(str(key), _metadata_text(item)) for key, item in metadata.items()]
+        )
+    return derived
+
+
+def _typed_dimensions_table(table: Any) -> Any:
+    """Materialize canonical v2 dimension columns on one decoded row group.
+
+    v2 raw already carries these exact types and passes through untouched. v1
+    raw carries the same dimensions as JSON text (or omits them entirely) and is
+    parsed value-by-value; ``metadata`` is derived from ``extra`` exactly as the
+    v2 writers do. The working set stays one byte-bounded row group, preserving
+    the constant-memory invariant during v1→v2 migration of unsealed days.
+    """
+    import pyarrow
+
+    for column, target_type in _typed_dimension_types().items():
+        if column in table.schema.names:
+            index = table.schema.get_field_index(column)
+            existing = table.column(index)
+            if existing.type.equals(target_type):
+                continue
+            if pyarrow.types.is_null(existing.type):
+                array: Any = pyarrow.nulls(table.num_rows, type=target_type)
+            elif pyarrow.types.is_string(existing.type) or pyarrow.types.is_large_string(
+                existing.type
+            ):
+                array = pyarrow.array(
+                    _parsed_dimension_values(column, existing.to_pylist()),
+                    type=target_type,
+                )
+            elif pyarrow.types.is_struct(existing.type):
+                array = pyarrow.array(
+                    _parsed_dimension_values(column, existing.to_pylist()),
+                    type=target_type,
+                )
+            else:
+                array = existing.cast(target_type)
+            table = table.set_column(
+                index, pyarrow.field(column, target_type), array
+            )
+        elif column == ARCHIVE_METADATA_COLUMN:
+            table = table.append_column(
+                pyarrow.field(column, target_type),
+                pyarrow.array(_derived_metadata_values(table), type=target_type),
+            )
+        else:
+            table = table.append_column(
+                pyarrow.field(column, target_type),
+                pyarrow.nulls(table.num_rows, type=target_type),
+            )
+    return table
+
+
+def _typed_schema(schema: Any) -> Any:
+    """The schema `_typed_dimensions_table` produces for one source schema."""
+    import pyarrow
+
+    targets = _typed_dimension_types()
+    fields = [
+        pyarrow.field(field.name, targets[field.name])
+        if field.name in targets
+        else field
+        for field in schema
+    ]
+    names = set(schema.names)
+    fields.extend(
+        pyarrow.field(column, target_type)
+        for column, target_type in targets.items()
+        if column not in names
+    )
+    return pyarrow.schema(fields)
 
 
 def _conform_table(table: Any, unified: Any) -> Any:
@@ -491,7 +869,10 @@ def _canonicalize_streaming(
         else None
     )
     unified = pyarrow.unify_schemas(
-        [_storage_schema(source.schema_arrow) for source in source_files],
+        [
+            _typed_schema(_storage_schema(source.schema_arrow))
+            for source in source_files
+        ],
         promote_options="permissive",
     )
     written = 0
@@ -499,7 +880,9 @@ def _canonicalize_streaming(
     try:
         for index, source_file in enumerate(source_files):
             for group_index in range(source_file.num_row_groups):
-                table = _storage_table(source_file.read_row_group(group_index))
+                table = _typed_dimensions_table(
+                    _storage_table(source_file.read_row_group(group_index))
+                )
                 if winner_ids is not None and index != winner_index:
                     # pyarrow's bundled stubs omit several pyarrow.compute kernels.
                     contained = pyarrow.compute.is_in(  # pyright: ignore[reportAttributeAccessIssue]
@@ -535,16 +918,25 @@ def _canonicalize(store: ArchiveStore, manifest: ArchiveManifest, target: Path) 
         source_files = []
         for uri, _rank in sources:
             source_files.append(stack.enter_context(_open_parquet_source(uri)))
+        # Empty snapshots are written id-only: they carry no payload or dimension
+        # columns and must never veto the bounded path for the day's real data —
+        # an empty phase paired with a whale phase is exactly the day that OOMs
+        # the SQL union.
+        occupied = [
+            source for source in source_files if source.metadata.num_rows
+        ]
         if all(
-            _payload_columns_are_text(source.schema_arrow) for source in source_files
+            _payload_columns_are_text(source.schema_arrow)
+            and _dimensions_are_streamable(source.schema_arrow)
+            for source in occupied
         ):
             return _canonicalize_streaming(
                 source_files, [uri for uri, _ in sources], target
             )
-    # Legacy raw generations carry inferred STRUCT/LIST payload columns that need
-    # SQL normalization; they predate byte-bounded staging and are rare
-    # (re-canonicalizing an already-sealed day), so the memory-heavy path is kept
-    # only for them.
+    # Raw generations that predate byte-bounded staging carry inferred payload
+    # STRUCTs that still need SQL normalization; they are rare (re-canonicalizing
+    # an already-sealed day), so the memory-heavy path is kept only for them.
+    # v1 text-dimension raw upgrades on the streaming path above, never here.
     return _canonicalize_duckdb(sources, target)
 
 
@@ -570,19 +962,64 @@ def _canonicalize_duckdb(sources: list[tuple[str, int]], target: Path) -> int:
             json_columns = tuple(
                 column for column in ARCHIVE_JSON_COLUMNS if column in columns
             )
-            if json_columns:
-                excluded = ", ".join(json_columns)
-                normalized = ", ".join(
+            typed_columns = tuple(
+                column
+                for column in (
+                    *ARCHIVE_STRING_LIST_COLUMNS,
+                    *ARCHIVE_TYPED_MAP_COLUMNS,
+                    ARCHIVE_METADATA_COLUMN,
+                )
+                if column in columns
+            )
+            excluded_columns = (*json_columns, *typed_columns)
+            expressions = [
+                *(
                     f"CASE WHEN typeof({column}) = 'VARCHAR' "
                     f"THEN CAST({column} AS VARCHAR) "
                     f"ELSE CAST(to_json({column}) AS VARCHAR) END AS {column}"
                     for column in json_columns
+                ),
+                *(
+                    f"CAST(CAST({column} AS JSON) AS VARCHAR[]) AS {column}"
+                    if column in columns
+                    else f"NULL::VARCHAR[] AS {column}"
+                    for column in ARCHIVE_STRING_LIST_COLUMNS
+                ),
+                *(
+                    f"CAST(CAST({column} AS JSON) AS MAP(VARCHAR, BIGINT)) AS {column}"
+                    if column in columns
+                    else f"NULL::MAP(VARCHAR, BIGINT) AS {column}"
+                    for column in ARCHIVE_INTEGER_MAP_COLUMNS
+                ),
+                *(
+                    f"CAST(CAST({column} AS JSON) "
+                    f"AS MAP(VARCHAR, DECIMAL(38,18))) AS {column}"
+                    if column in columns
+                    else f"NULL::MAP(VARCHAR, DECIMAL(38,18)) AS {column}"
+                    for column in ARCHIVE_DECIMAL_MAP_COLUMNS
+                ),
+            ]
+            if ARCHIVE_METADATA_COLUMN in columns:
+                expressions.append(
+                    f"CAST({ARCHIVE_METADATA_COLUMN} AS MAP(VARCHAR, VARCHAR)) "
+                    f"AS {ARCHIVE_METADATA_COLUMN}"
                 )
-                selects.append(
-                    f"SELECT * EXCLUDE ({excluded}), {normalized} FROM {view}"
+            elif "extra" in columns:
+                expressions.append(
+                    "coalesce(CAST(json_extract(CAST(extra AS JSON), '$.metadata') "
+                    "AS MAP(VARCHAR, VARCHAR)), map()::MAP(VARCHAR, VARCHAR)) "
+                    f"AS {ARCHIVE_METADATA_COLUMN}"
                 )
             else:
-                selects.append(f"SELECT * FROM {view}")
+                expressions.append(
+                    f"map()::MAP(VARCHAR, VARCHAR) AS {ARCHIVE_METADATA_COLUMN}"
+                )
+            exclude_sql = (
+                f" EXCLUDE ({', '.join(excluded_columns)})" if excluded_columns else ""
+            )
+            selects.append(
+                f"SELECT *{exclude_sql}, {', '.join(expressions)} FROM {view}"
+            )
 
         union_sql = " UNION ALL BY NAME ".join(selects)
         query = (
@@ -657,6 +1094,9 @@ def sync_project_day(
         return manifest
     if manifest.sealed:
         raise ValueError("A sealed archive day is immutable")
+    # INVARIANT: every new canonical publication uses the current physical schema;
+    # v1 remains readable, but resuming an unsealed day upgrades it atomically.
+    manifest = replace(manifest, schema_version=ARCHIVE_SCHEMA_VERSION)
     excluded_export_ids = frozenset(
         record.generation_id
         for record in (manifest.primary, manifest.reconciliation)

--- a/src/langsmith_cli/archive/sync.py
+++ b/src/langsmith_cli/archive/sync.py
@@ -618,9 +618,7 @@ def _typed_dimension_types() -> dict[str, Any]:
     import pyarrow
 
     return {
-        **dict.fromkeys(
-            ARCHIVE_STRING_LIST_COLUMNS, pyarrow.list_(pyarrow.string())
-        ),
+        **dict.fromkeys(ARCHIVE_STRING_LIST_COLUMNS, pyarrow.list_(pyarrow.string())),
         **dict.fromkeys(
             ARCHIVE_INTEGER_MAP_COLUMNS,
             pyarrow.map_(pyarrow.string(), pyarrow.int64()),
@@ -665,10 +663,7 @@ def _dimensions_are_streamable(schema: Any) -> bool:
             ):
                 continue
             return False
-        if (
-            pyarrow.types.is_map(data_type)
-            or pyarrow.types.is_struct(data_type)
-        ):
+        if pyarrow.types.is_map(data_type) or pyarrow.types.is_struct(data_type):
             continue
         return False
     return True
@@ -695,12 +690,16 @@ def _decimal_map_value(value: object) -> Decimal | None:
         return Decimal(value)
     if isinstance(value, float):
         return Decimal(str(value))
+    if isinstance(value, str):
+        # The v1 writer serialized SDK Decimal costs as JSON strings.
+        try:
+            return Decimal(value)
+        except ArithmeticError as error:
+            raise ValueError("Archived cost detail value is not a number") from error
     raise ValueError("Archived cost detail value is not a number")
 
 
-def _parsed_dimension_values(
-    column: str, values: list[object]
-) -> list[object]:
+def _parsed_dimension_values(column: str, values: list[object]) -> list[object]:
     """Parse one row group's v1 JSON-text dimension values into typed shapes."""
     if column in ARCHIVE_STRING_LIST_COLUMNS:
         parsed_lists: list[object] = []
@@ -714,9 +713,7 @@ def _parsed_dimension_values(
     decimal_valued = column in ARCHIVE_DECIMAL_MAP_COLUMNS
     for value in values:
         decoded = (
-            json.loads(value, parse_float=Decimal)
-            if isinstance(value, str)
-            else value
+            json.loads(value, parse_float=Decimal) if isinstance(value, str) else value
         )
         if decoded is None:
             parsed_maps.append(None)
@@ -724,9 +721,7 @@ def _parsed_dimension_values(
         if not isinstance(decoded, dict):
             raise ValueError(f"Archived JSON field has an invalid type: {column}")
         converter = _decimal_map_value if decimal_valued else _integer_map_value
-        parsed_maps.append(
-            [(key, converter(item)) for key, item in decoded.items()]
-        )
+        parsed_maps.append([(key, converter(item)) for key, item in decoded.items()])
     return parsed_maps
 
 
@@ -737,7 +732,9 @@ def _derived_metadata_values(table: Any) -> list[object]:
     derived: list[object] = []
     for extra_text in table.column("extra").to_pylist():
         extra = json.loads(extra_text) if isinstance(extra_text, str) else None
-        metadata = extra.get(ARCHIVE_METADATA_COLUMN) if isinstance(extra, dict) else None
+        metadata = (
+            extra.get(ARCHIVE_METADATA_COLUMN) if isinstance(extra, dict) else None
+        )
         if not isinstance(metadata, dict):
             derived.append([])
             continue
@@ -766,9 +763,9 @@ def _typed_dimensions_table(table: Any) -> Any:
                 continue
             if pyarrow.types.is_null(existing.type):
                 array: Any = pyarrow.nulls(table.num_rows, type=target_type)
-            elif pyarrow.types.is_string(existing.type) or pyarrow.types.is_large_string(
+            elif pyarrow.types.is_string(
                 existing.type
-            ):
+            ) or pyarrow.types.is_large_string(existing.type):
                 array = pyarrow.array(
                     _parsed_dimension_values(column, existing.to_pylist()),
                     type=target_type,
@@ -780,9 +777,7 @@ def _typed_dimensions_table(table: Any) -> Any:
                 )
             else:
                 array = existing.cast(target_type)
-            table = table.set_column(
-                index, pyarrow.field(column, target_type), array
-            )
+            table = table.set_column(index, pyarrow.field(column, target_type), array)
         elif column == ARCHIVE_METADATA_COLUMN:
             table = table.append_column(
                 pyarrow.field(column, target_type),
@@ -922,9 +917,7 @@ def _canonicalize(store: ArchiveStore, manifest: ArchiveManifest, target: Path) 
         # columns and must never veto the bounded path for the day's real data —
         # an empty phase paired with a whale phase is exactly the day that OOMs
         # the SQL union.
-        occupied = [
-            source for source in source_files if source.metadata.num_rows
-        ]
+        occupied = [source for source in source_files if source.metadata.num_rows]
         if all(
             _payload_columns_are_text(source.schema_arrow)
             and _dimensions_are_streamable(source.schema_arrow)

--- a/src/langsmith_cli/archive/sync.py
+++ b/src/langsmith_cli/archive/sync.py
@@ -25,6 +25,8 @@ from langsmith_cli.archive.models import (
 )
 from langsmith_cli.archive.parquet import (
     ARCHIVE_DECIMAL_MAP_COLUMNS,
+    ARCHIVE_DIMENSION_COLUMNS,
+    ARCHIVE_DIMENSION_SQL_TYPES,
     ARCHIVE_INTEGER_MAP_COLUMNS,
     ARCHIVE_JSON_COLUMNS,
     ARCHIVE_JSON_LIST_COLUMNS,
@@ -33,11 +35,14 @@ from langsmith_cli.archive.parquet import (
     ARCHIVE_STRING_LIST_COLUMNS,
     ARCHIVE_TYPED_MAP_COLUMNS,
     BULK_EXPORT_JSON_COLUMNS,
+    json_dimension_projection,
 )
 from langsmith_cli.archive.duckdb import (
     ARCHIVE_PARQUET_COPY_OPTIONS,
     archive_duckdb_connection,
     configure_duckdb_s3,
+    source_column_names,
+    sql_string,
 )
 from langsmith_cli.archive.repository import (
     ManifestSnapshot,
@@ -80,8 +85,9 @@ class RunsExportClient(Protocol):
     def list_runs(self, **kwargs: Any) -> Iterator[Run]: ...
 
 
-def _sql_string(value: str) -> str:
-    return "'" + value.replace("'", "''") + "'"
+# Bare alias: existing call sites throughout this module keep working while the
+# one implementation lives beside the connection helpers it belongs with.
+_sql_string = sql_string
 
 
 def _archive_json_default(value: object) -> object:
@@ -221,18 +227,15 @@ def _runs_api_snapshot_select(source: str) -> str:
     )
     expressions = [
         *(
-            f"CAST({column} AS VARCHAR[]) AS {column}"
+            # The v2 writer stages these as native JSON lists; a plain cast
+            # types them without a JSON round-trip.
+            f"CAST({column} AS {ARCHIVE_DIMENSION_SQL_TYPES[column]}) AS {column}"
             for column in ARCHIVE_STRING_LIST_COLUMNS
         ),
         *(
-            f"CASE WHEN {column} IS NULL THEN NULL::MAP(VARCHAR, BIGINT) "
-            f"ELSE CAST(CAST({column} AS JSON) AS MAP(VARCHAR, BIGINT)) END AS {column}"
-            for column in ARCHIVE_INTEGER_MAP_COLUMNS
-        ),
-        *(
-            f"CASE WHEN {column} IS NULL THEN NULL::MAP(VARCHAR, DECIMAL(38,18)) "
-            f"ELSE CAST(CAST({column} AS JSON) AS MAP(VARCHAR, DECIMAL(38,18))) END AS {column}"
-            for column in ARCHIVE_DECIMAL_MAP_COLUMNS
+            f"CAST(CAST({column} AS JSON) "
+            f"AS {ARCHIVE_DIMENSION_SQL_TYPES[column]}) AS {column}"
+            for column in ARCHIVE_TYPED_MAP_COLUMNS
         ),
         f"map(CAST({_STAGING_METADATA_KEYS} AS VARCHAR[]), "
         f"CAST({_STAGING_METADATA_VALUES} AS VARCHAR[])) AS {ARCHIVE_METADATA_COLUMN}",
@@ -241,39 +244,10 @@ def _runs_api_snapshot_select(source: str) -> str:
 
 
 def _bulk_snapshot_select(source: str, columns: set[str]) -> str:
-    typed_columns = (
-        *ARCHIVE_STRING_LIST_COLUMNS,
-        *ARCHIVE_TYPED_MAP_COLUMNS,
-        ARCHIVE_METADATA_COLUMN,
+    excluded, expressions = json_dimension_projection(
+        columns, metadata_column_is_canonical=False
     )
-    excluded = ", ".join(column for column in typed_columns if column in columns)
-    expressions = [
-        *(
-            f"CASE WHEN {column} IS NULL THEN NULL::VARCHAR[] "
-            f"ELSE CAST(CAST({column} AS JSON) AS VARCHAR[]) END AS {column}"
-            if column in columns
-            else f"NULL::VARCHAR[] AS {column}"
-            for column in ARCHIVE_STRING_LIST_COLUMNS
-        ),
-        *(
-            f"CAST(CAST({column} AS JSON) AS MAP(VARCHAR, BIGINT)) AS {column}"
-            if column in columns
-            else f"NULL::MAP(VARCHAR, BIGINT) AS {column}"
-            for column in ARCHIVE_INTEGER_MAP_COLUMNS
-        ),
-        *(
-            f"CAST(CAST({column} AS JSON) AS MAP(VARCHAR, DECIMAL(38,18))) AS {column}"
-            if column in columns
-            else f"NULL::MAP(VARCHAR, DECIMAL(38,18)) AS {column}"
-            for column in ARCHIVE_DECIMAL_MAP_COLUMNS
-        ),
-    ]
-    expressions.append(
-        "coalesce(CAST(json_extract(CAST(extra AS JSON), '$.metadata') "
-        "AS MAP(VARCHAR, VARCHAR)), map()::MAP(VARCHAR, VARCHAR)) "
-        f"AS {ARCHIVE_METADATA_COLUMN}"
-    )
-    exclude_sql = f" EXCLUDE ({excluded})" if excluded else ""
+    exclude_sql = f" EXCLUDE ({', '.join(excluded)})" if excluded else ""
     return f"(SELECT *{exclude_sql}, {', '.join(expressions)} FROM {source})"
 
 
@@ -535,13 +509,9 @@ def _write_bulk_parquet(
                 raise ValueError("Bulk export row count does not match Parquet")
             if counts[0] != counts[1]:
                 raise ValueError("Bulk export contains duplicate run IDs")
-            columns = {
-                str(row[0])
-                for row in connection.execute(
-                    f"DESCRIBE SELECT * FROM {source}"
-                ).fetchall()
-            }
-            source = _bulk_snapshot_select(source, columns)
+            source = _bulk_snapshot_select(
+                source, source_column_names(connection, source)
+            )
             connection.execute(
                 f"COPY (SELECT * FROM {source}) TO {_sql_string(str(target))} "
                 + ARCHIVE_PARQUET_COPY_OPTIONS
@@ -591,24 +561,21 @@ def _query_dimensions_are_typed(schema: Any) -> bool:
     import pyarrow
 
     fields = {field.name: field.type for field in schema}
-    for column in ARCHIVE_STRING_LIST_COLUMNS:
-        data_type = fields[column] if column in fields else None
-        if data_type is None or not pyarrow.types.is_list(data_type):
+    for column, target in _typed_dimension_types().items():
+        data_type = fields.get(column)
+        if data_type is None:
             return False
-        if not pyarrow.types.is_string(data_type.value_type):
-            return False
-    expected_maps = {
-        **dict.fromkeys(ARCHIVE_INTEGER_MAP_COLUMNS, pyarrow.int64()),
-        **dict.fromkeys(ARCHIVE_DECIMAL_MAP_COLUMNS, pyarrow.decimal128(38, 18)),
-        ARCHIVE_METADATA_COLUMN: pyarrow.string(),
-    }
-    for column, value_type in expected_maps.items():
-        data_type = fields[column] if column in fields else None
-        if data_type is None or not pyarrow.types.is_map(data_type):
+        if pyarrow.types.is_list(target):
+            if not pyarrow.types.is_list(data_type):
+                return False
+            if not pyarrow.types.is_string(data_type.value_type):
+                return False
+            continue
+        if not pyarrow.types.is_map(data_type):
             return False
         if not pyarrow.types.is_string(data_type.key_type):
             return False
-        if not data_type.item_type.equals(value_type):
+        if not data_type.item_type.equals(target.item_type):
             return False
     return True
 
@@ -641,11 +608,7 @@ def _dimensions_are_streamable(schema: Any) -> bool:
     import pyarrow
 
     fields = {field.name: field.type for field in schema}
-    for column in (
-        *ARCHIVE_STRING_LIST_COLUMNS,
-        *ARCHIVE_TYPED_MAP_COLUMNS,
-        ARCHIVE_METADATA_COLUMN,
-    ):
+    for column in ARCHIVE_DIMENSION_COLUMNS:
         data_type = fields.get(column)
         if data_type is None:
             continue
@@ -763,14 +726,13 @@ def _typed_dimensions_table(table: Any) -> Any:
                 continue
             if pyarrow.types.is_null(existing.type):
                 array: Any = pyarrow.nulls(table.num_rows, type=target_type)
-            elif pyarrow.types.is_string(
-                existing.type
-            ) or pyarrow.types.is_large_string(existing.type):
-                array = pyarrow.array(
-                    _parsed_dimension_values(column, existing.to_pylist()),
-                    type=target_type,
-                )
-            elif pyarrow.types.is_struct(existing.type):
+            elif (
+                # v1 JSON text and inferred STRUCTs both decode to Python values
+                # the same converters validate.
+                pyarrow.types.is_string(existing.type)
+                or pyarrow.types.is_large_string(existing.type)
+                or pyarrow.types.is_struct(existing.type)
+            ):
                 array = pyarrow.array(
                     _parsed_dimension_values(column, existing.to_pylist()),
                     type=target_type,
@@ -955,16 +917,12 @@ def _canonicalize_duckdb(sources: list[tuple[str, int]], target: Path) -> int:
             json_columns = tuple(
                 column for column in ARCHIVE_JSON_COLUMNS if column in columns
             )
-            typed_columns = tuple(
-                column
-                for column in (
-                    *ARCHIVE_STRING_LIST_COLUMNS,
-                    *ARCHIVE_TYPED_MAP_COLUMNS,
-                    ARCHIVE_METADATA_COLUMN,
-                )
-                if column in columns
+            # This canonicalizer may re-read its own typed output when a day is
+            # re-canonicalized, so an existing metadata column is canonical here.
+            dimension_excluded, dimension_expressions = json_dimension_projection(
+                columns, metadata_column_is_canonical=True
             )
-            excluded_columns = (*json_columns, *typed_columns)
+            excluded_columns = (*json_columns, *dimension_excluded)
             expressions = [
                 *(
                     f"CASE WHEN typeof({column}) = 'VARCHAR' "
@@ -972,41 +930,8 @@ def _canonicalize_duckdb(sources: list[tuple[str, int]], target: Path) -> int:
                     f"ELSE CAST(to_json({column}) AS VARCHAR) END AS {column}"
                     for column in json_columns
                 ),
-                *(
-                    f"CAST(CAST({column} AS JSON) AS VARCHAR[]) AS {column}"
-                    if column in columns
-                    else f"NULL::VARCHAR[] AS {column}"
-                    for column in ARCHIVE_STRING_LIST_COLUMNS
-                ),
-                *(
-                    f"CAST(CAST({column} AS JSON) AS MAP(VARCHAR, BIGINT)) AS {column}"
-                    if column in columns
-                    else f"NULL::MAP(VARCHAR, BIGINT) AS {column}"
-                    for column in ARCHIVE_INTEGER_MAP_COLUMNS
-                ),
-                *(
-                    f"CAST(CAST({column} AS JSON) "
-                    f"AS MAP(VARCHAR, DECIMAL(38,18))) AS {column}"
-                    if column in columns
-                    else f"NULL::MAP(VARCHAR, DECIMAL(38,18)) AS {column}"
-                    for column in ARCHIVE_DECIMAL_MAP_COLUMNS
-                ),
+                *dimension_expressions,
             ]
-            if ARCHIVE_METADATA_COLUMN in columns:
-                expressions.append(
-                    f"CAST({ARCHIVE_METADATA_COLUMN} AS MAP(VARCHAR, VARCHAR)) "
-                    f"AS {ARCHIVE_METADATA_COLUMN}"
-                )
-            elif "extra" in columns:
-                expressions.append(
-                    "coalesce(CAST(json_extract(CAST(extra AS JSON), '$.metadata') "
-                    "AS MAP(VARCHAR, VARCHAR)), map()::MAP(VARCHAR, VARCHAR)) "
-                    f"AS {ARCHIVE_METADATA_COLUMN}"
-                )
-            else:
-                expressions.append(
-                    f"map()::MAP(VARCHAR, VARCHAR) AS {ARCHIVE_METADATA_COLUMN}"
-                )
             exclude_sql = (
                 f" EXCLUDE ({', '.join(excluded_columns)})" if excluded_columns else ""
             )

--- a/src/langsmith_cli/local_traces/models.py
+++ b/src/langsmith_cli/local_traces/models.py
@@ -9,7 +9,11 @@ from pathlib import PurePosixPath
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 
-LOCAL_TRACE_SCHEMA_VERSION = 1
+# v2: fragments store queryable dimensions (tags, parent_run_ids, token/cost
+# details, extra.metadata) as typed Parquet lists/maps instead of JSON text.
+# v1 fragments cannot union with v2 under one DuckDB scan, and local is a
+# disposable replica: old catalogs are rejected and re-pulled, never migrated.
+LOCAL_TRACE_SCHEMA_VERSION = 2
 
 
 class TraceSource(str, Enum):

--- a/src/langsmith_cli/local_traces/repository.py
+++ b/src/langsmith_cli/local_traces/repository.py
@@ -20,6 +20,7 @@ from langsmith_cli.archive.storage import (
 )
 from langsmith_cli.archive.sync import write_runs_parquet
 from langsmith_cli.local_traces.models import (
+    LOCAL_TRACE_SCHEMA_VERSION,
     TraceCacheWriteResult,
     TraceCatalog,
     TraceFragment,
@@ -39,6 +40,24 @@ FRAGMENT_PREFIX = "traces/fragments"
 MAX_CATALOG_PUBLICATION_ATTEMPTS = 16
 
 
+def _validated_catalog(content: str) -> TraceCatalog:
+    """Parse a stored catalog, discarding other-version generations wholesale.
+
+    Local traces are a disposable replica of cloud/archive truth. Fragments
+    written under another physical schema cannot union with current ones in one
+    DuckDB scan, so a version-mismatched catalog reads as empty: queries see
+    nothing, the next pull republishes a current-version catalog, and the old
+    fragment objects become unreachable garbage instead of poisoning reads.
+    """
+    payload = json.loads(content)
+    if (
+        isinstance(payload, dict)
+        and payload.get("schema_version") != LOCAL_TRACE_SCHEMA_VERSION
+    ):
+        return TraceCatalog()
+    return TraceCatalog.model_validate_json(content)
+
+
 class LocalTraceRepository:
     """Expose one additive logical inventory over immutable Parquet observations."""
 
@@ -49,7 +68,7 @@ class LocalTraceRepository:
     def read_catalog(self) -> TraceCatalog:
         if not self._store.exists(CATALOG_KEY):
             return TraceCatalog()
-        return TraceCatalog.model_validate_json(self._store.get_text(CATALOG_KEY))
+        return _validated_catalog(self._store.get_text(CATALOG_KEY))
 
     def add_runs(
         self, request: TracePullRequest, runs: Iterable[Run]
@@ -370,7 +389,7 @@ class LocalTraceRepository:
         if not self._store.exists(CATALOG_KEY):
             return TraceCatalog(), None
         snapshot = self._store.get_text_with_version(CATALOG_KEY)
-        return TraceCatalog.model_validate_json(snapshot.content), snapshot.version
+        return _validated_catalog(snapshot.content), snapshot.version
 
     def _query_catalog(self, catalog: TraceCatalog, query: RunQuery) -> list[Run]:
         fragments = self._matching_fragments(catalog, query)

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -815,3 +815,176 @@ def test_empty_primary_with_late_reconciliation_seals_the_late_rows(
     assert manifest.canonical_run_count == 1
     archived = query_archive_runs(ArchiveRunQuery(project="dev/late-day", limit=0))
     assert (archived[0].outputs or {})["late"] is True
+
+
+def test_empty_snapshot_does_not_route_the_day_through_the_sql_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Empty phases write an id-only Parquet carrying none of the typed dimension
+    columns. That absence must never veto the bounded streaming path for the
+    day's real snapshot: an empty phase paired with a whale phase is exactly the
+    day-scaled SQL union that OOMed every fixed production memory bound.
+    """
+    from langsmith_cli.archive import sync as sync_module
+
+    def _sql_path_is_forbidden(*args: object, **kwargs: object) -> int:
+        raise AssertionError("empty snapshots must stay on the bounded streaming path")
+
+    monkeypatch.setattr(sync_module, "_canonicalize_duckdb", _sql_path_is_forbidden)
+    archive_uri = str(tmp_path / "archive")
+    monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
+    store = create_store(archive_uri)
+    project_id = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+    sync_project_day(
+        FakeRunsClient([]),
+        store,
+        project_id=project_id,
+        project_name="dev/empty-phase",
+        trace_date=date(2024, 7, 3),
+        phase=ArchivePhase.PRIMARY,
+    )
+    manifest = sync_project_day(
+        FakeRunsClient([create_run(tags=["kept"], metadata={"attempt": 1})]),
+        store,
+        project_id=project_id,
+        project_name="dev/empty-phase",
+        trace_date=date(2024, 7, 3),
+        phase=ArchivePhase.RECONCILIATION,
+    )
+    assert manifest.canonical_run_count == 1
+    archived = query_archive_runs(
+        ArchiveRunQuery(project="dev/empty-phase", tags=("kept",), limit=0)
+    )
+    assert [run.tags for run in archived] == [["kept"]]
+    # Control: a day where every snapshot is empty still publishes (zero rows).
+    all_empty = sync_project_day(
+        FakeRunsClient([]),
+        store,
+        project_id=project_id,
+        project_name="dev/empty-phase",
+        trace_date=date(2024, 7, 4),
+        phase=ArchivePhase.PRIMARY,
+    )
+    assert all_empty.canonical_run_count == 0
+
+
+def test_unsealed_v1_text_raw_migrates_to_v2_on_the_bounded_streaming_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Feed the genuine migration input: raw staged by the v1 writer, which stored
+    tags/parent_run_ids as JSON text, token/cost details as inferred columns
+    (Decimal costs as JSON strings), and no metadata column. Resuming the
+    unsealed day must publish typed v2 without ever touching the day-scaled SQL
+    union — unsealed v1 days at deploy time include the whale days that
+    motivated the memory bounds.
+    """
+    from langsmith_cli.archive import sync as sync_module
+    from langsmith_cli.archive.sync import BULK_EXPORT_JSON_COLUMNS
+
+    archive_uri = str(tmp_path / "archive")
+    monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
+    store = create_store(archive_uri)
+    project_id = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+
+    def _v1_serialize(run: Run) -> bytes:
+        payload = run.model_dump(mode="python")
+        # The v1 taxonomy pre-serialized payloads AND tags/parent_run_ids as
+        # JSON text; token/cost details were left for read_json_auto inference.
+        for column in BULK_EXPORT_JSON_COLUMNS:
+            value = payload.get(column)
+            if value is not None:
+                payload[column] = json.dumps(
+                    value,
+                    ensure_ascii=False,
+                    default=sync_module._archive_json_default,
+                )
+        line = json.dumps(
+            payload, ensure_ascii=False, default=sync_module._archive_json_default
+        )
+        return line.encode("utf-8") + b"\n"
+
+    v1_run = create_run(
+        tags=["shared", "v1"],
+        metadata={"environment": "legacy", "attempt": 1},
+    ).model_copy(
+        update={
+            "parent_run_ids": [UUID(TYPED_DIMENSIONS_PARENT_ID)],
+            "prompt_token_details": {"cache_read": 5},
+            "completion_token_details": {"reasoning": 8},
+            "prompt_cost_details": {"cache_read": Decimal("0.000001")},
+            "completion_cost_details": {"reasoning": Decimal("0.000004")},
+        }
+    )
+    with monkeypatch.context() as v1:
+        v1.setattr(sync_module, "_serialize_run_line", _v1_serialize)
+        v1.setattr(sync_module, "_runs_api_snapshot_select", lambda source: source)
+        sync_project_day(
+            FakeRunsClient([v1_run]),
+            store,
+            project_id=project_id,
+            project_name="dev/migrate-v1",
+            trace_date=date(2024, 7, 3),
+            phase=ArchivePhase.PRIMARY,
+        )
+    manifest_path = (
+        Path(store.base_uri)
+        / "manifests"
+        / f"project_id={project_id}"
+        / "date=2024-07-03.json"
+    )
+    manifest_payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest_payload["schema_version"] = 1
+    manifest_path.write_text(json.dumps(manifest_payload), encoding="utf-8")
+
+    def _sql_path_is_forbidden(*args: object, **kwargs: object) -> int:
+        raise AssertionError("v1 text raw must migrate on the bounded streaming path")
+
+    monkeypatch.setattr(sync_module, "_canonicalize_duckdb", _sql_path_is_forbidden)
+    late_run = create_run(
+        id_str="32345678-1234-5678-1234-567812345678",
+        tags=["shared", "late"],
+        metadata={"environment": "current"},
+    )
+    reconciled = sync_project_day(
+        FakeRunsClient([late_run]),
+        store,
+        project_id=project_id,
+        project_name="dev/migrate-v1",
+        trace_date=date(2024, 7, 3),
+        phase=ArchivePhase.RECONCILIATION,
+    )
+    assert reconciled.schema_version == 2
+    assert reconciled.sealed is True
+    assert reconciled.canonical_run_count == 2
+    assert reconciled.canonical_key is not None
+
+    import pyarrow.parquet
+
+    canonical_schema = pyarrow.parquet.ParquetFile(
+        str(Path(store.base_uri) / reconciled.canonical_key)
+    ).schema_arrow
+    from langsmith_cli.archive.sync import _query_dimensions_are_typed
+
+    assert _query_dimensions_are_typed(canonical_schema) is True
+
+    archived = query_archive_runs(
+        ArchiveRunQuery(project="dev/migrate-v1", tags=("shared",), limit=0)
+    )
+    assert {str(run.id) for run in archived} == {str(v1_run.id), str(late_run.id)}
+    migrated = next(run for run in archived if run.id == v1_run.id)
+    assert migrated.tags == ["shared", "v1"]
+    assert migrated.parent_run_ids == [UUID(TYPED_DIMENSIONS_PARENT_ID)]
+    assert migrated.prompt_token_details == {"cache_read": 5}
+    assert migrated.completion_token_details == {"reasoning": 8}
+    assert migrated.prompt_cost_details == {"cache_read": Decimal("0.000001")}
+    assert migrated.completion_cost_details == {"reasoning": Decimal("0.000004")}
+    assert (migrated.extra or {})["metadata"] == {
+        "environment": "legacy",
+        "attempt": 1,
+    }
+    only_v1 = query_archive_runs(
+        ArchiveRunQuery(project="dev/migrate-v1", tags=("v1",), limit=0)
+    )
+    assert [run.id for run in only_v1] == [v1_run.id]

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date, datetime, time, timezone
+from decimal import Decimal
 import json
 from pathlib import Path
 from typing import Any, Iterator
+from uuid import UUID
 
 import pytest
 from langsmith.schemas import Run
@@ -13,7 +15,11 @@ from langsmith.schemas import Run
 from conftest import create_run, parse_json_output
 from langsmith_cli.archive.config import load_archive_config
 from langsmith_cli.archive.models import ArchivePhase
-from langsmith_cli.archive.query import ArchiveRunQuery, query_archive_runs
+from langsmith_cli.archive.query import (
+    ArchiveRunQuery,
+    count_archive_runs,
+    query_archive_runs,
+)
 from langsmith_cli.archive.storage import create_store
 from langsmith_cli.archive.sync import due_trace_dates, sync_project_day
 from langsmith_cli.main import cli
@@ -27,6 +33,9 @@ class FakeRunsClient:
     def list_runs(self, **kwargs: Any) -> Iterator[Run]:
         self.calls += 1
         return iter(self.runs)
+
+
+TYPED_DIMENSIONS_PARENT_ID = "22345678-1234-5678-1234-567812345678"
 
 
 def test_route_config_selects_exactly_one_destination(tmp_path: Path) -> None:
@@ -311,6 +320,300 @@ def test_runs_snapshot_stores_payloads_as_text_not_inferred_structs(
     assert archived[0].tags == ["t1", "t2"]
 
 
+def test_canonical_schema_v2_uses_stable_queryable_types(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """INVARIANT: query dimensions have one shape-independent Parquet type."""
+    import duckdb
+
+    archive_uri = str(tmp_path / "archive")
+    monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
+    store = create_store(archive_uri)
+    run = create_run(
+        tags=["production", "billing"],
+        metadata={
+            "environment": "production",
+            "attempt": 3,
+            "temperature": 0.25,
+            "enabled": True,
+            "deployment": {"region": "us-east-1"},
+            "nothing": None,
+            "price": Decimal("1.25"),
+            "moment": datetime(2024, 7, 3, 9, 27, 16, tzinfo=timezone.utc),
+            "clock": time(9, 27, 16),
+            "correlation_id": UUID(TYPED_DIMENSIONS_PARENT_ID),
+            "phase": ArchivePhase.PRIMARY,
+        },
+        inputs={"arbitrary": {"shape": [1, {"two": 2}]}},
+        outputs={"answer": {"nested": True}},
+    ).model_copy(
+        update={
+            "parent_run_ids": [UUID(TYPED_DIMENSIONS_PARENT_ID)],
+            "prompt_token_details": {"cache_read": 7, "audio": 2},
+            "completion_token_details": {"reasoning": 11},
+            "prompt_cost_details": {"cache_read": Decimal("0.0000012")},
+            "completion_cost_details": {"reasoning": Decimal("0.0000045")},
+        }
+    )
+
+    manifest = sync_project_day(
+        FakeRunsClient([run]),
+        store,
+        project_id="f47ac10b-58cc-4372-a567-0e02b2c3d479",
+        project_name="dev/typed-dimensions",
+        trace_date=date(2024, 7, 3),
+        phase=ArchivePhase.PRIMARY,
+    )
+
+    assert manifest.schema_version == 2
+    assert manifest.canonical_key is not None
+    canonical_path = Path(store.base_uri) / manifest.canonical_key
+    connection = duckdb.connect()
+    try:
+        described = {
+            str(row[0]): str(row[1])
+            for row in connection.execute(
+                f"DESCRIBE SELECT * FROM read_parquet('{canonical_path.as_posix()}')"
+            ).fetchall()
+        }
+        dimensions = connection.execute(
+            "SELECT list_contains(tags, 'production'), "
+            "list_contains(parent_run_ids, ?), metadata['environment'], "
+            "metadata['attempt'], metadata['deployment'], "
+            "prompt_token_details['cache_read'], "
+            "completion_cost_details['reasoning'], metadata "
+            f"FROM read_parquet('{canonical_path.as_posix()}')",
+            [TYPED_DIMENSIONS_PARENT_ID],
+        ).fetchone()
+    finally:
+        connection.close()
+
+    assert described["tags"] == "VARCHAR[]"
+    assert described["parent_run_ids"] == "VARCHAR[]"
+    assert described["metadata"] == "MAP(VARCHAR, VARCHAR)"
+    assert described["prompt_token_details"] == "MAP(VARCHAR, BIGINT)"
+    assert described["completion_token_details"] == "MAP(VARCHAR, BIGINT)"
+    assert described["prompt_cost_details"] == "MAP(VARCHAR, DECIMAL(38,18))"
+    assert described["completion_cost_details"] == "MAP(VARCHAR, DECIMAL(38,18))"
+    for payload_column in ("inputs", "outputs", "extra", "feedback_stats", "events"):
+        assert described[payload_column] == "VARCHAR"
+    assert dimensions == (
+        True,
+        True,
+        "production",
+        "3",
+        '{"region":"us-east-1"}',
+        7,
+        Decimal("0.000004500000000000"),
+        {
+            "environment": "production",
+            "attempt": "3",
+            "temperature": "0.25",
+            "enabled": "true",
+            "deployment": '{"region":"us-east-1"}',
+            "nothing": None,
+            "price": "1.25",
+            "moment": "2024-07-03T09:27:16+00:00",
+            "clock": "09:27:16",
+            "correlation_id": TYPED_DIMENSIONS_PARENT_ID,
+            "phase": "primary",
+        },
+    )
+
+    archived = query_archive_runs(
+        ArchiveRunQuery(project="dev/typed-dimensions", tags=("production",), limit=0)
+    )
+    assert archived[0].tags == ["production", "billing"]
+    assert archived[0].parent_run_ids == [UUID(TYPED_DIMENSIONS_PARENT_ID)]
+    assert archived[0].prompt_token_details == {"cache_read": 7, "audio": 2}
+    assert archived[0].completion_cost_details == {
+        "reasoning": Decimal("0.000004500000000000")
+    }
+
+
+@pytest.mark.parametrize(
+    ("extra", "message"),
+    [
+        ({"metadata": "not-an-object"}, "must be an object"),
+        ({"metadata": {7: "not-a-string-key"}}, "keys must be strings"),
+    ],
+)
+def test_runs_api_snapshot_rejects_invalid_metadata_contracts(
+    tmp_path: Path,
+    extra: dict[object, object],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        sync_project_day(
+            FakeRunsClient([create_run(extra=extra)]),
+            create_store(str(tmp_path / "archive")),
+            project_id="f47ac10b-58cc-4372-a567-0e02b2c3d479",
+            project_name="dev/invalid-metadata",
+            trace_date=date(2024, 7, 3),
+            phase=ArchivePhase.PRIMARY,
+        )
+
+
+def test_streaming_schema_guard_rejects_noncanonical_dimension_types() -> None:
+    import pyarrow
+
+    from langsmith_cli.archive.sync import _query_dimensions_are_typed
+
+    canonical = {
+        "tags": pyarrow.list_(pyarrow.string()),
+        "parent_run_ids": pyarrow.list_(pyarrow.string()),
+        "prompt_token_details": pyarrow.map_(pyarrow.string(), pyarrow.int64()),
+        "completion_token_details": pyarrow.map_(pyarrow.string(), pyarrow.int64()),
+        "prompt_cost_details": pyarrow.map_(
+            pyarrow.string(), pyarrow.decimal128(38, 18)
+        ),
+        "completion_cost_details": pyarrow.map_(
+            pyarrow.string(), pyarrow.decimal128(38, 18)
+        ),
+        "metadata": pyarrow.map_(pyarrow.string(), pyarrow.string()),
+    }
+    invalid_types = (
+        ("tags", pyarrow.list_(pyarrow.int64())),
+        ("prompt_token_details", pyarrow.string()),
+        ("prompt_token_details", pyarrow.map_(pyarrow.int64(), pyarrow.int64())),
+        ("prompt_token_details", pyarrow.map_(pyarrow.string(), pyarrow.float64())),
+    )
+
+    for column, data_type in invalid_types:
+        invalid = {**canonical, column: data_type}
+        assert _query_dimensions_are_typed(pyarrow.schema(invalid)) is False
+
+
+def test_mixed_v1_v2_archive_days_query_through_one_normalized_relation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """INVARIANT: schema upgrades never strand already-published project-days."""
+    import duckdb
+
+    archive_uri = str(tmp_path / "archive")
+    monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
+    store = create_store(archive_uri)
+    project_id = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+    legacy_run = create_run(
+        tags=["shared", "legacy"],
+        metadata={"environment": "legacy", "attempt": 1},
+    ).model_copy(
+        update={
+            "parent_run_ids": [UUID(TYPED_DIMENSIONS_PARENT_ID)],
+            "prompt_token_details": {"cache_read": 5},
+            "completion_token_details": {"reasoning": 8},
+            "prompt_cost_details": {"cache_read": Decimal("0.000001")},
+            "completion_cost_details": {"reasoning": Decimal("0.000004")},
+        }
+    )
+    legacy_manifest = sync_project_day(
+        FakeRunsClient([legacy_run]),
+        store,
+        project_id=project_id,
+        project_name="dev/mixed-schema",
+        trace_date=date(2024, 7, 3),
+        phase=ArchivePhase.PRIMARY,
+    )
+    assert legacy_manifest.canonical_key is not None
+    current_path = Path(store.base_uri) / legacy_manifest.canonical_key
+    legacy_path = current_path.with_suffix(".legacy.parquet")
+    connection = duckdb.connect()
+    try:
+        connection.execute(
+            "COPY (SELECT * EXCLUDE (tags, parent_run_ids, metadata, "
+            "prompt_token_details, completion_token_details, "
+            "prompt_cost_details, completion_cost_details), "
+            "CAST(to_json(tags) AS VARCHAR) AS tags, "
+            "CAST(to_json(parent_run_ids) AS VARCHAR) AS parent_run_ids, "
+            "CAST(to_json(prompt_token_details) AS VARCHAR) "
+            "AS prompt_token_details, "
+            "CAST(to_json(completion_token_details) AS VARCHAR) "
+            "AS completion_token_details, "
+            "CAST(to_json(prompt_cost_details) AS VARCHAR) "
+            "AS prompt_cost_details, "
+            "CAST(to_json(completion_cost_details) AS VARCHAR) "
+            "AS completion_cost_details "
+            f"FROM read_parquet('{current_path.as_posix()}')) "
+            f"TO '{legacy_path.as_posix()}' (FORMAT PARQUET)"
+        )
+    finally:
+        connection.close()
+    legacy_path.replace(current_path)
+    manifest_key = (
+        Path(store.base_uri)
+        / "manifests"
+        / f"project_id={project_id}"
+        / "date=2024-07-03.json"
+    )
+    manifest_payload = json.loads(manifest_key.read_text(encoding="utf-8"))
+    manifest_payload["schema_version"] = 1
+    manifest_key.write_text(json.dumps(manifest_payload), encoding="utf-8")
+
+    current_run = create_run(
+        id_str="32345678-1234-5678-1234-567812345678",
+        tags=["shared", "current"],
+        metadata={"environment": "current", "attempt": 2},
+    )
+    sync_project_day(
+        FakeRunsClient([current_run]),
+        store,
+        project_id=project_id,
+        project_name="dev/mixed-schema",
+        trace_date=date(2024, 7, 4),
+        phase=ArchivePhase.PRIMARY,
+    )
+
+    query = ArchiveRunQuery(project="dev/mixed-schema", tags=("shared",), limit=0)
+    archived = query_archive_runs(query)
+    assert {str(run.id) for run in archived} == {
+        str(legacy_run.id),
+        str(current_run.id),
+    }
+    assert count_archive_runs(query) == 2
+    legacy = next(run for run in archived if run.id == legacy_run.id)
+    assert legacy.tags == ["shared", "legacy"]
+    assert legacy.parent_run_ids == [UUID(TYPED_DIMENSIONS_PARENT_ID)]
+    assert legacy.prompt_token_details == {"cache_read": 5}
+
+
+def test_reconciliation_upgrades_an_unsealed_v1_manifest_to_v2(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive_uri = str(tmp_path / "archive")
+    monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
+    store = create_store(archive_uri)
+    project_id = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+    primary = sync_project_day(
+        FakeRunsClient([create_run()]),
+        store,
+        project_id=project_id,
+        project_name="dev/upgrade-schema",
+        trace_date=date(2024, 7, 3),
+        phase=ArchivePhase.PRIMARY,
+    )
+    manifest_path = (
+        Path(store.base_uri)
+        / "manifests"
+        / f"project_id={project_id}"
+        / "date=2024-07-03.json"
+    )
+    payload = primary.to_dict()
+    payload["schema_version"] = 1
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    reconciled = sync_project_day(
+        FakeRunsClient([create_run()]),
+        store,
+        project_id=project_id,
+        project_name="dev/upgrade-schema",
+        trace_date=date(2024, 7, 3),
+        phase=ArchivePhase.RECONCILIATION,
+    )
+
+    assert reconciled.schema_version == 2
+    assert reconciled.sealed is True
+
+
 def test_oversized_days_are_staged_and_converted_in_bounded_pieces(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -373,6 +676,13 @@ def test_streaming_dedup_holds_across_row_groups_and_snapshots(
     from langsmith_cli.archive import sync as sync_module
 
     monkeypatch.setattr(sync_module, "STAGING_PIECE_MAX_BYTES", 1)
+
+    def _legacy_sql_path_is_forbidden(*args: object, **kwargs: object) -> int:
+        raise AssertionError("canonical v2 raw must stay on the bounded streaming path")
+
+    monkeypatch.setattr(
+        sync_module, "_canonicalize_duckdb", _legacy_sql_path_is_forbidden
+    )
     archive_uri = str(tmp_path / "archive")
     monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
     store = create_store(archive_uri)
@@ -429,6 +739,13 @@ def test_legacy_struct_raw_still_canonicalizes_through_the_sql_path(
     monkeypatch.setenv("LANGSMITH_ARCHIVE_URI", archive_uri)
     store = create_store(archive_uri)
 
+    def _v2_streaming_path_is_forbidden(*args: object, **kwargs: object) -> int:
+        raise AssertionError("legacy inferred payloads require SQL normalization")
+
+    monkeypatch.setattr(
+        sync_module, "_canonicalize_streaming", _v2_streaming_path_is_forbidden
+    )
+
     def _legacy_serialize(run: Run) -> bytes:
         payload = run.model_dump(mode="python")
         line = json.dumps(
@@ -438,6 +755,7 @@ def test_legacy_struct_raw_still_canonicalizes_through_the_sql_path(
 
     with monkeypatch.context() as legacy:
         legacy.setattr(sync_module, "_serialize_run_line", _legacy_serialize)
+        legacy.setattr(sync_module, "_runs_api_snapshot_select", lambda source: source)
         sync_project_day(
             FakeRunsClient([create_run(inputs={"deep": {"legacy": True}})]),
             store,

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -988,3 +988,142 @@ def test_unsealed_v1_text_raw_migrates_to_v2_on_the_bounded_streaming_path(
         ArchiveRunQuery(project="dev/migrate-v1", tags=("v1",), limit=0)
     )
     assert [run.id for run in only_v1] == [v1_run.id]
+
+
+def test_v1_dimension_converters_cover_every_stored_value_shape() -> None:
+    """
+    The streaming migration parses v1 values Python-side, so each converter must
+    accept every shape the v1 writer could store (JSON numbers, integral floats,
+    string-encoded Decimals, nulls) and reject shapes that would silently
+    corrupt a typed column instead of failing the sync.
+    """
+    from langsmith_cli.archive import sync as sync_module
+
+    assert sync_module._integer_map_value(None) is None
+    assert sync_module._integer_map_value(7) == 7
+    assert sync_module._integer_map_value(3.0) == 3
+    with pytest.raises(ValueError, match="not an integer"):
+        sync_module._integer_map_value(3.5)
+    with pytest.raises(ValueError, match="not an integer"):
+        sync_module._integer_map_value(True)
+
+    assert sync_module._decimal_map_value(None) is None
+    assert sync_module._decimal_map_value(Decimal("0.5")) == Decimal("0.5")
+    assert sync_module._decimal_map_value(2) == Decimal(2)
+    assert sync_module._decimal_map_value(0.25) == Decimal("0.25")
+    assert sync_module._decimal_map_value("0.125") == Decimal("0.125")
+    with pytest.raises(ValueError, match="not a number"):
+        sync_module._decimal_map_value("not-a-number")
+    with pytest.raises(ValueError, match="not a number"):
+        sync_module._decimal_map_value([1])
+
+    assert sync_module._parsed_dimension_values(
+        "tags", [None, "null", '["a", "b"]']
+    ) == [None, None, ["a", "b"]]
+    with pytest.raises(ValueError, match="invalid type"):
+        sync_module._parsed_dimension_values("tags", ["{}"])
+    parsed = sync_module._parsed_dimension_values(
+        "prompt_cost_details", [None, "null", '{"a": 0.5, "b": null}']
+    )
+    assert parsed[:2] == [None, None]
+    assert parsed[2] == [("a", Decimal("0.5")), ("b", None)]
+    with pytest.raises(ValueError, match="invalid type"):
+        sync_module._parsed_dimension_values("prompt_token_details", ["[1]"])
+
+
+def test_typed_dimensions_table_repairs_absent_null_and_castable_columns() -> None:
+    """
+    Row groups reach the migration transform with every shape unify tolerates:
+    dimension columns can be all-null, absent entirely, castable list variants,
+    or (for metadata) derivable only from a text/absent/scalar ``extra``.
+    """
+    import pyarrow
+
+    from langsmith_cli.archive import sync as sync_module
+
+    table = pyarrow.table(
+        {
+            "id": pyarrow.array(["a", "b", "c"], type=pyarrow.string()),
+            "extra": pyarrow.array(
+                ['{"metadata": {"k": "v"}}', "5", None], type=pyarrow.string()
+            ),
+            "tags": pyarrow.nulls(3, type=pyarrow.null()),
+            "parent_run_ids": pyarrow.array(
+                [["p"], None, None],
+                type=pyarrow.large_list(pyarrow.large_string()),
+            ),
+        }
+    )
+    typed = sync_module._typed_dimensions_table(table)
+    assert sync_module._query_dimensions_are_typed(typed.schema) is True
+    assert typed.column("tags").to_pylist() == [None, None, None]
+    assert typed.column("parent_run_ids").to_pylist() == [["p"], None, None]
+    # Absent map columns materialize as typed nulls, metadata derives from extra
+    # (empty map for scalar or null extra, matching the SQL writers' coalesce).
+    assert typed.column("prompt_token_details").to_pylist() == [None, None, None]
+    assert typed.column("metadata").to_pylist() == [[("k", "v")], [], []]
+
+    # Guard parity: absent columns stream (they are repairable), while typed
+    # dimensions inferred as scalars that neither parse nor cast do not.
+    assert sync_module._query_dimensions_are_typed(table.schema) is False
+    assert sync_module._query_dimensions_are_typed(pyarrow.schema([])) is False
+    assert sync_module._dimensions_are_streamable(table.schema) is True
+    assert (
+        sync_module._dimensions_are_streamable(
+            pyarrow.schema({"tags": pyarrow.int64()})
+        )
+        is False
+    )
+    assert (
+        sync_module._dimensions_are_streamable(
+            pyarrow.schema({"prompt_token_details": pyarrow.int64()})
+        )
+        is False
+    )
+
+
+def test_dimension_edges_without_extra_or_with_extension_types(
+    tmp_path: Path,
+) -> None:
+    """
+    Remaining migration edges: a row group with no ``extra`` column still gets
+    an empty metadata map; extension-typed dimension columns strip to their
+    storage type before the streamable check; and the SQL fallback synthesizes
+    an empty metadata map for sources carrying neither metadata nor extra.
+    """
+    import pyarrow
+    import pyarrow.parquet
+
+    from langsmith_cli.archive import sync as sync_module
+
+    bare = pyarrow.table({"id": pyarrow.array(["a"], type=pyarrow.string())})
+    assert sync_module._derived_metadata_values(bare) == [[]]
+
+    extension = getattr(pyarrow, "uuid", None)
+    if extension is not None:
+        # A uuid-extension tags column strips to fixed binary: not a list, so
+        # the source must fall off the streaming path instead of miscasting.
+        assert (
+            sync_module._dimensions_are_streamable(
+                pyarrow.schema({"tags": extension()})
+            )
+            is False
+        )
+
+    source_path = tmp_path / "no-extra.parquet"
+    pyarrow.parquet.write_table(
+        pyarrow.table(
+            {
+                "id": pyarrow.array(["a"], type=pyarrow.string()),
+                "inputs": pyarrow.array(
+                    [{"deep": 1}],
+                    type=pyarrow.struct([("deep", pyarrow.int64())]),
+                ),
+            }
+        ),
+        str(source_path),
+    )
+    target = tmp_path / "canonical.parquet"
+    assert sync_module._canonicalize_duckdb([(str(source_path), 1)], target) == 1
+    canonical = pyarrow.parquet.read_table(str(target))
+    assert canonical.column("metadata").to_pylist() == [[]]

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1082,14 +1082,29 @@ def test_typed_dimensions_table_repairs_absent_null_and_castable_columns() -> No
     )
 
 
-def test_dimension_edges_without_extra_or_with_extension_types(
+def test_extension_typed_dimension_falls_off_the_streaming_path() -> None:
+    import pyarrow
+
+    from langsmith_cli.archive import sync as sync_module
+
+    extension = getattr(pyarrow, "uuid", None)
+    if extension is None:
+        pytest.skip("this pyarrow build has no uuid extension type")
+    # A uuid-extension tags column strips to fixed binary: not a list, so the
+    # source must fall off the streaming path instead of miscasting.
+    assert (
+        sync_module._dimensions_are_streamable(pyarrow.schema({"tags": extension()}))
+        is False
+    )
+
+
+def test_dimension_edges_without_extra_column(
     tmp_path: Path,
 ) -> None:
     """
     Remaining migration edges: a row group with no ``extra`` column still gets
-    an empty metadata map; extension-typed dimension columns strip to their
-    storage type before the streamable check; and the SQL fallback synthesizes
-    an empty metadata map for sources carrying neither metadata nor extra.
+    an empty metadata map, and the SQL fallback synthesizes an empty metadata
+    map for sources carrying neither metadata nor extra.
     """
     import pyarrow
     import pyarrow.parquet
@@ -1098,17 +1113,6 @@ def test_dimension_edges_without_extra_or_with_extension_types(
 
     bare = pyarrow.table({"id": pyarrow.array(["a"], type=pyarrow.string())})
     assert sync_module._derived_metadata_values(bare) == [[]]
-
-    extension = getattr(pyarrow, "uuid", None)
-    if extension is not None:
-        # A uuid-extension tags column strips to fixed binary: not a list, so
-        # the source must fall off the streaming path instead of miscasting.
-        assert (
-            sync_module._dimensions_are_streamable(
-                pyarrow.schema({"tags": extension()})
-            )
-            is False
-        )
 
     source_path = tmp_path / "no-extra.parquet"
     pyarrow.parquet.write_table(

--- a/tests/test_bulk_export.py
+++ b/tests/test_bulk_export.py
@@ -34,7 +34,12 @@ from langsmith_cli.archive.query import (
 )
 from langsmith_cli.archive.query import _normalize_run_payload
 from langsmith_cli.archive.storage import create_store
-from langsmith_cli.archive.sync import ARCHIVE_JSON_COLUMNS, sync_project_day
+from langsmith_cli.archive.sync import (
+    ARCHIVE_JSON_COLUMNS,
+    ARCHIVE_STRING_LIST_COLUMNS,
+    BULK_EXPORT_JSON_COLUMNS,
+    sync_project_day,
+)
 from langsmith_cli.main import cli
 
 
@@ -54,15 +59,15 @@ def test_archive_json_columns_are_one_explicit_provider_schema_contract() -> Non
         "outputs",
         "feedback_stats",
         "events",
-        "tags",
-        "parent_run_ids",
     )
+    assert ARCHIVE_STRING_LIST_COLUMNS == ("tags", "parent_run_ids")
 
 
 def _bulk_v2_payload(run: Run) -> dict[str, object]:
     """Encode a Run like Bulk Export v2's JSON-valued Parquet columns."""
-    payload = cast(dict[str, object], run.model_dump(mode="json"))
-    for field in ARCHIVE_JSON_COLUMNS:
+    dumped = cast(dict[str, object], run.model_dump(mode="json"))
+    payload = {field: dumped[field] for field in BULK_EXPORT_FIELDS if field in dumped}
+    for field in BULK_EXPORT_JSON_COLUMNS:
         if field in payload and payload[field] is not None:
             payload[field] = json.dumps(payload[field])
     return payload
@@ -1023,9 +1028,17 @@ def test_bulk_reconciliation_unifies_runs_api_and_v2_json_column_types(
     tmp_path: Path, monkeypatch, runner
 ) -> None:
     """A Bulk v2 reconciliation must replace native Runs API rows by run ID."""
-    primary_run = create_run(outputs={"version": "runs-api"}, tags=["primary"])
+    primary_run = create_run(
+        outputs={"version": "runs-api"},
+        tags=["primary"],
+        metadata={"provider": "runs-api", "attempt": 1},
+    )
     reconciled_run = primary_run.model_copy(
-        update={"outputs": {"version": "bulk-v2"}, "tags": ["reconciled"]}
+        update={
+            "outputs": {"version": "bulk-v2"},
+            "tags": ["reconciled"],
+            "extra": {"metadata": {"provider": "bulk-v2", "attempt": 2}},
+        }
     )
     late_child = create_run(
         id_str="62345678-1234-5678-1234-567812345678",
@@ -1034,7 +1047,8 @@ def test_bulk_reconciliation_unifies_runs_api_and_v2_json_column_types(
         outputs={"late": True},
     ).model_copy(
         update={
-            "events": [{"name": "start", "time": "2026-08-19T21:59:53.948395+00:00"}]
+            "events": [{"name": "start", "time": "2026-08-19T21:59:53.948395+00:00"}],
+            "parent_run_ids": [primary_run.id],
         }
     )
     json_rows = tmp_path / "bulk-mixed.json"
@@ -1073,6 +1087,22 @@ def test_bulk_reconciliation_unifies_runs_api_and_v2_json_column_types(
     )
 
     assert manifest.canonical_run_count == 2
+    assert manifest.schema_version == 2
+    assert manifest.canonical_key is not None
+    import duckdb
+
+    canonical_path = Path(store.base_uri) / manifest.canonical_key
+    connection = duckdb.connect()
+    try:
+        extracted_provider = connection.execute(
+            "SELECT metadata['provider'] "
+            f"FROM read_parquet('{canonical_path.as_posix()}') "
+            "WHERE CAST(id AS VARCHAR) = ?",
+            [str(primary_run.id)],
+        ).fetchone()
+    finally:
+        connection.close()
+    assert extracted_provider == ("bulk-v2",)
     archived = query_archive_runs(ArchiveRunQuery(project="dev/agent", limit=0))
     assert {str(run.id) for run in archived} == {
         str(primary_run.id),
@@ -1081,6 +1111,7 @@ def test_bulk_reconciliation_unifies_runs_api_and_v2_json_column_types(
     root = next(run for run in archived if run.id == primary_run.id)
     assert root.outputs == {"version": "bulk-v2"}
     assert root.tags == ["reconciled"]
+    assert root.extra == {"metadata": {"provider": "bulk-v2", "attempt": 2}}
     archived_root, archived_children = read_archived_run(
         str(primary_run.id),
         follow_children=True,
@@ -1088,6 +1119,7 @@ def test_bulk_reconciliation_unifies_runs_api_and_v2_json_column_types(
     )
     assert [child.id for child in archived_children] == [late_child.id]
     assert archived_root.child_run_ids == [late_child.id]
+    assert archived_children[0].parent_run_ids == [primary_run.id]
     assert archived_children[0].model_dump(mode="json")["events"] == [
         {"name": "start", "time": "2026-08-19T21:59:53.948395+00:00"}
     ]

--- a/tests/test_local_traces.py
+++ b/tests/test_local_traces.py
@@ -17,7 +17,11 @@ from conftest import create_run, parse_json_output, strip_ansi
 from langsmith_cli.archive.storage import LocalArchiveStore
 from langsmith_cli.archive.models import ArchivePhase
 from langsmith_cli.archive.sync import sync_project_day
-from langsmith_cli.local_traces.models import TracePullRequest, TraceSource
+from langsmith_cli.local_traces.models import (
+    LOCAL_TRACE_SCHEMA_VERSION,
+    TracePullRequest,
+    TraceSource,
+)
 from langsmith_cli.local_traces.repository import LocalTraceRepository
 from langsmith_cli.main import cli
 from langsmith_cli.trace_query import RunQuery
@@ -112,7 +116,7 @@ def test_local_trace_models_reject_invalid_identity_time_and_catalog_state() -> 
         TraceFragment.model_validate(valid_fragment | {"observed_at": naive})
     fragment = TraceFragment.model_validate(valid_fragment)
     with pytest.raises(ValidationError, match="Unsupported local trace catalog"):
-        TraceCatalog(schema_version=2)
+        TraceCatalog(schema_version=LOCAL_TRACE_SCHEMA_VERSION + 1)
     with pytest.raises(ValidationError, match="duplicate fragments"):
         TraceCatalog(fragments=(fragment, fragment))
 
@@ -766,3 +770,33 @@ def test_archive_and_local_share_supported_query_semantics(
     local_ids = [str(run.id) for run in repository.query(query)]
 
     assert archived_ids == local_ids == [FIRST_RUN_ID]
+
+
+def test_other_version_local_catalog_reads_empty_and_is_replaced_by_next_pull(
+    tmp_path: Path,
+) -> None:
+    """
+    Local traces are a disposable replica: a catalog written under another
+    physical schema version must read as empty (its fragments cannot union with
+    current ones in one DuckDB scan) and the next pull must atomically publish a
+    current-version catalog instead of crashing every command.
+    """
+    repository = LocalTraceRepository(tmp_path)
+    first = repository.add_runs(_pull_request(), [_run(FIRST_RUN_ID, "first")])
+    assert first.added_run_count == 1
+
+    catalog_path = tmp_path / "traces" / "catalog.json"
+    stale = json.loads(catalog_path.read_text(encoding="utf-8"))
+    stale["schema_version"] = LOCAL_TRACE_SCHEMA_VERSION - 1
+    catalog_path.write_text(json.dumps(stale), encoding="utf-8")
+
+    assert repository.read_catalog().fragments == ()
+    assert repository.query(RunQuery(limit=None)) == []
+
+    recovered = repository.add_runs(_pull_request(), [_run(SECOND_RUN_ID, "second")])
+    assert recovered.added_run_count == 1
+    catalog = repository.read_catalog()
+    assert catalog.schema_version == LOCAL_TRACE_SCHEMA_VERSION
+    assert [str(run.id) for run in repository.query(RunQuery(limit=None))] == [
+        SECOND_RUN_ID
+    ]


### PR DESCRIPTION
Today, queryable run dimensions such as tags and topology IDs are stored as JSON text, while open-ended usage-breakdown keys can become inferred Parquet struct fields. This PR establishes canonical archive schema v2 with stable list/map dimensions, so DuckDB can query those fields natively (`list_contains`, `map['key']`, predicate pushdown) without reintroducing shape-dependent schema growth.

## BEFORE / AFTER: the physical contract

| Run field | v1 (before) | v2 (after) | Why |
| --- | --- | --- | --- |
| `inputs`, `outputs`, `extra`, `events`, `feedback_stats` | JSON text | JSON text (unchanged) | Arbitrary provider documents; inferred children are unbounded |
| `tags`, `parent_run_ids` | JSON text | `list<string>` | Documented homogeneous lists; filter/topology dimensions |
| prompt/completion token details | inferred (per-key struct growth) | `map<string, bigint>` | Providers add token categories without schema growth |
| prompt/completion cost details | inferred (per-key struct growth) | `map<string, decimal(38,18)>` | Same, with decimal precision retained |
| `extra.metadata` | buried in `extra` JSON | extracted `map<string, string>` accelerator | Queryable keys without per-key columns; authoritative object stays in `extra` |

Query BEFORE/AFTER: `json_contains(CAST(tags AS JSON), to_json(?))` (re-parses JSON per row) → `list_contains(tags, ?)` (pushes into Parquet). The field choices follow the official [run data format](https://docs.langchain.com/langsmith/run-data-format), [Bulk Export contract](https://docs.langchain.com/langsmith/data-export), and documented open-ended [token/cost detail maps](https://docs.langchain.com/langsmith/cost-tracking).

## Invariants

| # | Invariant | Enforcement point | Test |
| --- | --- | --- | --- |
| I1 | Every promoted dimension has exactly one physical type, spelled once | `ARCHIVE_DIMENSION_SQL_TYPES` + `json_dimension_projection` in `archive/parquet.py`; every writer/reader path builds its SQL from them | `test_canonical_schema_v2_uses_stable_queryable_types` |
| I2 | No archive-sync stage holds memory proportional to project-day size — including v1→v2 migration (existing invariant from #168, strengthened) | dispatch guard in `_canonicalize` filters zero-row generations and routes v1 text raw to the streaming path; `_typed_dimensions_table` parses per byte-bounded row group | `test_empty_snapshot_does_not_route_the_day_through_the_sql_path`, `test_unsealed_v1_text_raw_migrates_to_v2_on_the_bounded_streaming_path` (both verified to fail on the pre-fix guard) |
| I3 | v1 VARCHAR can never dictate a v2 list/map: every generation normalizes independently before any cross-day union | `_create_normalized_runs_view` (per-source projection before `UNION ALL BY NAME`) | `test_mixed_v1_v2_archive_days_query_through_one_normalized_relation` |
| I4 | New canonical publications always use the current schema; unsealed v1 days upgrade atomically, sealed days are immutable | `sync_project_day` (`replace(manifest, schema_version=...)` after the sealed check) | `test_reconciliation_upgrades_an_unsealed_v1_manifest_to_v2` |
| I5 | A local catalog written under another physical schema reads as empty and the next pull recovers atomically (local is a disposable replica) | `_validated_catalog` in `local_traces/repository.py`; `LOCAL_TRACE_SCHEMA_VERSION = 2` | `test_other_version_local_catalog_reads_empty_and_is_replaced_by_next_pull` |

I2 is a strengthened existing invariant (bug fix — the original commit's dispatch guard violated it two ways); I1/I3/I4/I5 are established by this PR.

## Rebase onto #170

The typed taxonomy lives in `archive/parquet.py` — the contract layer shared with the local trace backend — and local fragments adopt v2 through the shared `write_runs_parquet` path. Post-review consolidation: the dimension projection had grown six spellings (four hand-written SQL cast ladders plus two Arrow respellings); it is now one SQL type map + one projection builder, net −37 lines, with a latent query-view crash on legacy files lacking `extra` fixed by the shared builder.

## Meeting reality: in-cluster E2E on the live Gigaverse workspace

Run via the real gigaverse-ai Prefect flow (`langsmith-archive-sync-flow`, gigaverse-app/gigaverse-ai#2219 pinning this branch) on dev-cluster, all-routes mode, 4000Mi pod limit, `LANGSMITH_ARCHIVE_DUCKDB_THREADS=2`. Full evidence in [this comment](https://github.com/gigaverse-app/langsmith-cli/pull/171#issuecomment-5400544307).

Evidence caveat: the E2E ran at head `9245dae`; the review-consolidation commit after it (`4b83743`) is behavior-preserving refactoring — same 1,380 tests pass, and the projection SQL it centralizes is asserted byte-level-typed by the schema tests — but was not itself re-run in-cluster.

| Check (lower is better for memory; limit 4,000 MiB) | Result |
| --- | --- |
| Scheduled all-routes flow run | COMPLETED, 39.6 min, exit 0; 3 routes advanced to D+2, 0 invalid manifests |
| Flow-run pod memory peak | **1,784 MiB** (~45% of limit) |
| v1→v2 migration, dev route (60 projects) | 56,751 runs re-canonicalized + sealed, exit 0 |
| v1→v2 migration, production route (46 projects, incl. whale `prd/namedrop_service` 31,458 runs) | sealed, exit 0, memory peak **1,753 MiB** |
| v1→v2 migration, staging route (39 projects, 0 runs — live empty-snapshot path) | sealed, exit 0 |
| Mixed v1+v2 union read | 500 runs across both schema versions in one query |
| Typed tag filter (`--tag`) across versions | 400/400 correct |
| Migrated production trace queryback | intact (payloads, tags, token counts) |

Manifests were confirmed flipped v1→v2 with `sealed: true` after migration, and the day the flow published fresh carried `schema_version: 2`.

## Local evidence (this branch head)

| Check | Result |
| --- | --- |
| Full test suite (WSL) | 1,380 passed, 0 failed |
| Falsifiability of the two memory tests | Both fail on the pre-fix dispatch guard |
| Ruff lint + format, Pyright | clean |
| GitHub CI (full matrix incl. Windows) | green; codecov/patch green |

## Scope

No production latency claim is made for queries (the tag-filter pushdown is a correctness-preserving mechanism change; measuring query latency at scale is follow-up once v2 days accumulate). One pre-existing Windows-only CI flake was observed and filed separately (dataset-replica rename race, #167 code, untouched here).
