### PR TITLE
Release v0.12.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "LangSmith CLI plugin marketplace",
-    "version": "0.11.1"
+    "version": "0.12.0"
   },
   "plugins": [
     {
       "name": "langsmith-cli",
       "source": "./",
       "description": "A context-efficient interface for LangSmith observability and evaluations.",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "author": {
         "name": "Gigaverse",
         "email": "aviadr1@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith-cli",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "A context-efficient interface for LangSmith observability and evaluations.",
   "author": {
     "name": "Aviad Rozenhek",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "langsmith-cli"
 # IMPORTANT: When bumping this version, also update .claude-plugin/plugin.json
-version = "0.11.1"
+version = "0.12.0"
 description = "Context-efficient CLI for LangSmith. Built for humans and agents."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -396,7 +396,7 @@ wheels = [
 
 [[package]]
 name = "langsmith-cli"
-version = "0.11.1"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

Bump the Python package and Claude plugin manifests from `0.11.1` to `0.12.0`. This minor release packages the archive, dataset-replica, local-trace, and typed-dimension work merged since `v0.11.1`.

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `TMPDIR=/tmp TEMP=/tmp TMP=/tmp uv run pytest -q` — 1,380 passed
- `uv build --out-dir /tmp/langsmith-cli-0.12.0-dist`
- built `langsmith_cli-0.12.0.tar.gz` and `langsmith_cli-0.12.0-py3-none-any.whl`

After merge, tagging the merge commit as `v0.12.0` will trigger the repository publish workflow for PyPI and GitHub Releases.